### PR TITLE
Add PluginTool model and view.

### DIFF
--- a/GeositeFramework/Views/Home/Index.cshtml
+++ b/GeositeFramework/Views/Home/Index.cshtml
@@ -67,10 +67,8 @@
     </script>
 
     <script type="text/template" id="template-sidebar-plugin">
-        <div class="plugin">
-            <img src="/plugins/<%- toolbarName %>/icon.png">
-            <div><%- toolbarName %></div>
-        </div>
+        <img src="/plugins/<%- toolbarName %>/icon.png">
+        <div><%- toolbarName %></div>
     </script>
 
     <script type="text/template" id="template-sidebar-link">
@@ -85,6 +83,7 @@
     <script src="js/lib/underscore-1.4.3.min.js"></script>
     <script src="js/lib/backbone-0.9.10.min.js"></script>
     <script src="js/Geosite.js"></script>
+    <script src="js/PluginTool.js"></script>
     <script src="js/Pane.js"></script>
     <script src="js/MapWrapper.js"></script>
     <script src="js/TemplateLoader.js"></script>

--- a/GeositeFramework/js/App.js
+++ b/GeositeFramework/js/App.js
@@ -26,10 +26,12 @@
             paneNumber: i,
             regionData: regionData
         });
+        N.app.models[i] = pane;
         var paneView = new N.views.Pane({
             model: pane,
             el: $('#pane' + i)
         });
+        N.app.views[i] = paneView;
 
         // Render the pane, then create the map (which needs a DOM element to live in)
         paneView.render();

--- a/GeositeFramework/js/Pane.js
+++ b/GeositeFramework/js/Pane.js
@@ -11,11 +11,26 @@
     }
 
     function createPlugins(model) {
-        model.set('plugins', []);
+        // Iterate over plugin objects in top-level namespace
+        // and add them to an array in the pane model.
+        // also instantiate a backbone model and view to wrap
+        // around these plugin objects and add them to
+        // arrays in the pane model as well.
+
+        model.set({
+            plugins: [],
+            pluginTools: [],
+            pluginToolViews: []
+        });
 
         _.each(N.plugins, function (pluginClass) {
             var plugin = new pluginClass();
+            var pluginTool = new N.models.PluginTool({ pluginObject: plugin });
+            var pluginToolView = new N.views.PluginTool({ model: pluginTool });
+
             model.get('plugins').push(plugin);
+            model.get('pluginTools').push(pluginTool);
+            model.get('pluginToolViews').push(pluginToolView);
         });
     }
 
@@ -33,6 +48,11 @@
 
     N.models = N.models || {};
     N.models.Pane = Backbone.Model.extend({
+        defaults: {
+            plugins: null,
+            pluginTools: null,
+            pluginToolViews: null
+        },
         initialize: function () { initializePane(this); },
         initPlugins: function (wrappedMap) { initPlugins(this, wrappedMap); }
     });
@@ -56,14 +76,14 @@
     }
 
     function renderPlugins(view) {
-        var regionData = view.model.get('regionData'),
-            plugins = view.model.get('plugins'),
-            toolTemplate = N.app.templates['template-sidebar-plugin'],
-            $tools = view.$('.plugins');
-        _.each(plugins, function (plugin) {
-            var html = toolTemplate({ toolbarName: plugin.toolbarName });
-            $tools.append(html);
-        });
+        // for each model that wraps a plugin object:
+        // render its view and add them to the sidebar
+        // section for plugin icons
+        var $tools = view.$('.plugins');
+        _.each(view.model.get('pluginToolViews'),
+            function (pluginToolView) {
+                $tools.append(pluginToolView.render().$el);
+            });
     }
 
     function renderSidebarLinks(view) {

--- a/GeositeFramework/js/PluginTool.js
+++ b/GeositeFramework/js/PluginTool.js
@@ -1,0 +1,68 @@
+﻿/*jslint nomen:true, devel:true */
+/*global Backbone, _, $, Geosite*/
+
+// A plugin tool wraps around a plugin object and manages it in backbone
+
+(function (N) {
+    "use strict";
+    (function () {
+
+        // this functionality might get swallowed up
+        // by the Pane model. not yet sure which will
+        // be responsible for tracking who is currently
+        // active.
+        function toggleActive(model) {
+            if (model.get('currentlyActive')) {
+                model.set({ currentlyActive: false });
+                model.set({ showingUI: false });
+            } else {
+                model.set({ currentlyActive: true });
+            }
+        }
+
+        // not currently used, not likely to still be
+        // in this class when we implement the feature
+        // TODO: remove
+        function toggleUI(model) {
+            if (model.showingUI) {
+                model.set({ showingUI: false });
+            } else {
+                model.set({ showingUI: true });
+            }
+        }
+
+        N.models = N.models || {};
+        N.models.PluginTool = Backbone.Model.extend({
+            defaults: {
+                pluginObject: null,
+                currentlyActive: false,
+                showingUI: false
+            },
+            toggleActive: function () { toggleActive(this) },
+            toggleUI: function () { toggleUI(this) }
+
+        });
+
+    }());
+
+    (function () {
+
+        function renderSelf(view) {
+            var pluginToolTemplate = N.app.templates['template-sidebar-plugin'];
+            var html = pluginToolTemplate({ toolbarName: view.model.get('pluginObject').toolbarName });
+            view.$el.append(html);
+            return view;
+        }
+
+        N.views = N.views || {};
+        N.views.PluginTool = Backbone.View.extend({
+            className: 'plugin',
+            events: {
+                // currently just a proof of concept
+                'click' : function () { alert("clicked!") }
+            },
+            render: function () { return renderSelf(this); }
+        });
+    }());
+
+}(Geosite));


### PR DESCRIPTION
Plugins are now managed by their own view and model
instead of the pane. As of now, a click event can
be triggered from their dom elements as a proof of
concept.
