### PR TITLE
Show plugin UI before activating plugin

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -52,17 +52,17 @@
 
             onSelectedChanged: function () {
                 if (this.selected) {
-                    this.get('pluginObject').activate();
                     this.set('active', true);
+                    this.get('pluginObject').activate();
                 } else {
                     this.get('pluginObject').deactivate();
                 }
             },
 
             turnOff: function () {
-                this.get('pluginObject').hibernate();
-                this.set('active', false);
                 this.deselect();
+                this.set('active', false);
+                this.get('pluginObject').hibernate();
             },
 
             identify: function (point, processResults) {
@@ -107,6 +107,9 @@
             view.render();
             model.on('selected deselected', function () {
                 model.onSelectedChanged();
+                view.render();
+            });
+            model.on('change:active', function () {
                 view.render();
             });
         }


### PR DESCRIPTION
Things need to happen in this order:
- set plugin model 'active'
- render plugin view (displays UI because model is 'active')
- activate() plugin (layer_selector's ExtJS rendering fails if the container isn't visible, so it only renders if the container is visible)
