### PR TITLE
Permalink changes

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -175,7 +175,7 @@
 
     <script type="text/template" id="permalink-share-window">
       <h3>Save & Share</h3>
-      <label>Permalink:<input type="text" value="<%= url %>"></input></label>
+      <label>Permalink:<input class="permalink-textbox" type="text" value="<%= url %>"></input></label>
       <p>Share your map with friends or family, or just bookmark the link for later.</p>
     </script>
 

--- a/src/GeositeFramework/js/App.js
+++ b/src/GeositeFramework/js/App.js
@@ -19,7 +19,9 @@
             N.app.models.screen = new N.models.Screen();
 
             this.hashModels = Backbone.HashModels.init({
-                updateOnChange: false
+                updateOnChange: false,
+                hashUpdateCallback: this.showHashUrlPopup,
+                setupHashMonitorCallback: this.setupHashMonitorCallback
             });
             this.hashModels.addModel(N.app.models.screen, {
                 id: 'screen',
@@ -38,6 +40,34 @@
             N.app.syncedMapManager = new N.SyncedMapManager(N.app.models.screen);
 
             registerPopupHandlers();
+        },
+
+        showHashUrlPopup: function (hash) {
+            var windowTemplate = N.app.templates['permalink-share-window'],
+            currentHref = document.location.href;
+
+            // sometimes location.href will havea  trailing #, sometimes it
+            // won't. This makes sure to always append when missing.
+            if (currentHref.slice(-1) !== "#") { currentHref += "#"; }
+
+            TINY.box.show({
+                html: windowTemplate({ url: currentHref + hash }),
+                width: 500,
+                height: 200,
+                fixed: true,
+                openjs: function () {
+                    $('.permalink-textbox').select();
+                }
+            });
+        },
+
+        setupHashMonitorCallback: function (handleHashChangedFn) {
+            // Process the hash once using the handleHashChanged
+            // function, then clear it. This is done instead of the
+            // typical behavior of HashModels which is to continue
+            // listening for changes in the location.hash
+            handleHashChangedFn(location.hash);
+            location.hash = "";
         },
 
         createPane: function createPane(paneIndex) {

--- a/src/GeositeFramework/js/Screen.js
+++ b/src/GeositeFramework/js/Screen.js
@@ -126,21 +126,13 @@
         },
 
         makePermalink: function makePermalink() {
-            var windowTemplate = N.app.templates['permalink-share-window'];
-
             _.each(paneViews, function (paneView) {
                 if (paneView !== null) {
                     paneView.mapView.saveState();
                 }
             });
-            Backbone.HashModels.update();
 
-            TINY.box.show({
-                html: windowTemplate({ url: window.location.href }),
-                width: 500,
-                height: 200,
-                fixed: true
-            });
+            Backbone.HashModels.update();
         },
 
         printMap: function printMap() {


### PR DESCRIPTION
Stop showing permalink in location bar of browser. Passed callbacks
into HashModels in order to override default behavior.

Moved permalink pop-up to App.js to resolve a circular dependency
with storing it in the screen view: the screen view requires hashmodels
to have been initialized, but we want to send the permalink pop-up
callback that was living in the screen view to the init method on
hashmodels.

Highlight permalink text in pop-up box so that users can easily
press their keyboard shortcut for copying.
