### PR TITLE
Fix single instance of plugin bug

### DIFF
--- a/src/GeositeFramework/plugins/full_extent/main.js
+++ b/src/GeositeFramework/plugins/full_extent/main.js
@@ -23,8 +23,7 @@ require({
 define(
     ["dojo/_base/declare", "framework/PluginBase"],
     function (declare, PluginBase) {
-        var $launcher = $('<div class="full-extent"></div>'),
-            _extent;
+        var _extent;
         
         function fullExtent (regionConfig)
         {
@@ -48,7 +47,7 @@ define(
             },
             
             renderLauncher: function renderLauncher() {
-                return $launcher;
+                return $('<div class="full-extent"></div>');
             },
 
             activate: function () {


### PR DESCRIPTION
The 'launcher' for the extent plugin was defined outside of the declare
body, meaning the reference was shared with all instances of the plugin, meaning there
was only 1 launcher at a time.  By locally scoping the element, it's works in
infinity maps.

Fixes #98 
