### PR TITLE
Set currentState on deactivate

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector/main.js
+++ b/src/GeositeFramework/plugins/layer_selector/main.js
@@ -81,6 +81,7 @@ define([
 
             deactivate: function () {
                 this._ui.hideAll();
+                this._currentState = this._layerManager.getServiceState();
             },
 
             hibernate: function () {


### PR DESCRIPTION
Fixes Github Issue #119

The problem was that when activate is called, the state is loaded from
the currentState cache, but it can be out of sync with the actual
state of the plugin because it wasn't updated at deactivation time.
