### PR TITLE
Fix layer selector saveServiceState methods

### DIFF
--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -234,7 +234,7 @@
             plugins.each(function (plugin) {
                 var state = plugin.getState();
 
-                if (state) {
+                if (state && Object.keys(state).length > 0) {
                     stateOfPlugins[plugin.name()] = state;
                 }
             });

--- a/src/GeositeFramework/plugins/layer_selector/WmsLoader.js
+++ b/src/GeositeFramework/plugins/layer_selector/WmsLoader.js
@@ -81,7 +81,7 @@ define(["use!underscore"],
             }
 
             function saveServiceState (folderNode, stateObject) {
-                if (folderNode.visibleLayerIds && folderNode.visibleLayerIds !== []) {
+                if (folderNode.visibleLayerIds && folderNode.visibleLayerIds.length > 0) {
                     stateObject[folderNode.serviceName] = folderNode.visibleLayerIds;
                 }
             }

--- a/src/GeositeFramework/plugins/layer_selector/agsLoader.js
+++ b/src/GeositeFramework/plugins/layer_selector/agsLoader.js
@@ -195,7 +195,7 @@ define(["jquery", "use!underscore"],
 
             function saveServiceState (serviceNode, stateObject) {
                 if (serviceNode.esriService &&
-                    serviceNode.esriService.visibleLayers !== [-1]) {
+                    !(_.isEqual(serviceNode.esriService.visibleLayers,[-1]))) {
                     stateObject[serviceNode.serviceName] = {
                         visibleLayerIds: getLayerIds(serviceNode.esriService),
                         opacity: serviceNode.opacity


### PR DESCRIPTION
Fixes github issue #119

These methods were using faulty javascript comparisons that were
evaluating to undesired boolean conditions.
