### PR TITLE
Allow customizing top-bar colors

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -76,6 +76,15 @@
         "helpUrl": {
             "type": "string",
             "required": false
+        },
+        "colors": {
+            "type": "object",
+            "properties": {
+                "primary": {"type": "string", "required": true},
+                "secondary": {"type": "string", "required": true}
+            },
+            "required": false,
+            "additionalProperties": false
         }
     },
     "additionalProperties": false

--- a/src/GeositeFramework/Tests/GeositeTests.cs
+++ b/src/GeositeFramework/Tests/GeositeTests.cs
@@ -14,6 +14,13 @@ namespace GeositeFramework.Tests
     public class GeositeTests : AssertionHelper
     {
         private static readonly string _appDataFolderPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"..\App_Data");
+        private string baseValidRegionJson = @"
+                {
+                    'titleMain': {'text':''},
+                    'titleDetail': {'text':''},
+                    'initialExtent': [0,0,0,0],
+                    'basemaps': [{'name':'', 'url':''}]
+                ";
 
         // ------------------------------------------------------------------------
         // Tests for region.json configuration
@@ -98,6 +105,36 @@ namespace GeositeFramework.Tests
             Expect(messages[0], Contains("'a'")); // extra property
             Expect(messages[1], Contains("'b'")); // extra property
             Expect(messages[2], Contains(": titleMain, titleDetail, initialExtent, basemaps.")); // missing required properties
+        }
+
+        /// <exclude/>
+        [Test]
+        public void TestGoodColorsJson()
+        {
+            const string primary = "#C0C0C0", secondary = "#FF11AA";
+            var regionJson = baseValidRegionJson + 
+                    ",'colors': { 'primary': '" + primary + "',  'secondary': '" + secondary + "'}}";
+            var geo = CreateGeosite(regionJson);
+            Assert.AreEqual(geo.PrimaryColor, primary);
+            Assert.AreEqual(geo.SecondaryColor, secondary);
+        }
+
+        /// <exclude/>
+        [Test]
+        [ExpectedException(typeof(Exception), Handler = "HandleBadJsonColors")]
+        public void TestBadColorsJson()
+        {
+            var regionJson = baseValidRegionJson + 
+                    @",'colors': {
+                        'primary': 'hot pink',
+                        'secondary': 'cool cucumber'
+                    }
+                }";
+            CreateGeosite(regionJson);
+        }
+        private void HandleBadJsonColors(Exception ex)
+        {
+            Expect(ex.Message, Contains("Bad color config"));
         }
 
         /// <exclude/>

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -38,6 +38,17 @@
 
     <script src="js/lib/foundation/modernizr.foundation.js"></script>
     
+    <!-- Simple implementation style overrides from config -->
+    <style type="text/css">
+        .top-bar {
+            background: @Model.PrimaryColor;
+        } 
+
+        .top-bar ul > li.name h1 a {
+            color: @Model.SecondaryColor;
+        }
+    </style>
+
     @if (Model.GoogleAnalyticsPropertyId != null)
     {
         <script type="text/javascript">

--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -38,7 +38,6 @@ h1, h2, h3, h4, h5, h6 {
 
 .top-bar {
 	margin-bottom: 0;
-	background: #26648E;
 	}
 	.top-bar ul > li.divider {
 		background: white;
@@ -61,7 +60,6 @@ h1, h2, h3, h4, h5, h6 {
 			border-bottom: 45px solid transparent;
 		}
 		.top-bar ul > li.name h1 a {
-			color: #26648E;
 			text-transform: uppercase;
 			font-size: 16px !important;
 		}

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -22,5 +22,9 @@
         { "name": "Terrain"            , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer" }
     ],
     "pluginOrder": [ "layer_selector", "zoom_to", "measure" ],
-    "printServerUrl": "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task"
+    "printServerUrl": "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+    "colors": {
+        "primary": "#26648E",
+        "secondary": "#26648E"
+    }
 }


### PR DESCRIPTION
Provides a way to allow implementers to specify custom
colors for the top bar branding area of a site by changing
the region.json config file.  Simpler than adding a pre-compile
LESS/SASS step and cleaner and more accessible than attaching
`!important` overrides to implementation-specific css files.
