### PR TITLE
Permalink to use URL shortener service

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -4,6 +4,7 @@
     "type": "object",
     "properties": {
         "googleAnalyticsPropertyId": {"type": "string", "required": false},
+        "googleUrlShortenerApiKey": {"type": "string", "required": false},
         "titleMain": {
             "type": "object",
             "properties": {

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -220,14 +220,14 @@
     <!-- Adding any white space between the textarea and the iframe
         will result in whitespace within the rendered textarea, which looks strange. -->
     <script type="text/template" id="embed-iframe">
-       <textarea class="code-like"><iframe width="<%= width %>" height="<%= height %>" src="<%= url %>"></iframe>        
+       <textarea class="code-like"><iframe width="<%= width %>" height="<%= height %>" src="<%= shortUrl %>"></iframe>        
        </textarea>
     </script>
 
     <script type="text/template" id="permalink-share-window">
         <div id="permalink-dialog">
           <h3>Save & Share</h3>
-          <label>Permalink:<input class="permalink-textbox" type="text" value="<%= url %>"/></label>
+          <label>Permalink:<input class="code-like permalink-textbox" type="text" value="<%= shortUrl %>"/></label>
           <p>Share your map with friends or family, or just bookmark the link for later.</p>
           <label>Embed this map in your website:</label>
           <div id="iframe-embed"></div>
@@ -283,7 +283,8 @@
     <div id="right-pane" class="content"></div>
     
     <script src="js/polyfill.js"></script>
-
+    
+    <script src="//apis.google.com/js/client.js"></script>
     <script src="//serverapi.arcgisonline.com/jsapi/arcgis/?v=3.5compact"></script>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
     <script src="Scripts/json2.min.js"></script>

--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -24,7 +24,7 @@ h1, h2, h3, h4, h5, h6 {
 	font-family: 'Archivo Narrow', 'Arial Narrow', Arial, Helvetica, sans-serif;
 }
 
-.code-like {
+input.code-like, textarea.code-like {
     font-family: "Courier New", Courier, monospace;
 }
 

--- a/src/GeositeFramework/js/App.js
+++ b/src/GeositeFramework/js/App.js
@@ -1,5 +1,5 @@
 ﻿/*jslint nomen:true, devel:true */
-/*global Geosite, $, _*/
+/*global Geosite, $, _, gapi*/
 
 (function (N) {
     "use strict";
@@ -15,6 +15,12 @@
             N.app.version = version;
             N.app.data.region = regionData;
             N.plugins = pluginClasses;
+
+            // Set up the google url shortener service
+            gapi.client.load('urlshortener', 'v1');
+            if (regionData.googleUrlShortenerApiKey) {
+                gapi.client.setApiKey(regionData.googleUrlShortenerApiKey);
+            }
 
             N.app.models.screen = new N.models.Screen();
 
@@ -47,8 +53,6 @@
                 popup = new N.views.Permalink({
                     model: permalink
                 });
-
-            popup.render();
         },
 
         setupHashMonitorCallback: function (handleHashChangedFn) {


### PR DESCRIPTION
The google URL shortener service is free and stable.  When generating
a permalink for app state, it is run through the service.  If it
fails, it will still present the traditional long URL.  The
administrator may optionally provide a googleUrlShortenerApiKey value
in region.json (generated from google API console) which allows
additional requests per day.  No key is required though, and any
usage errors will be logged and the long URL will be used.
