### PR TITLE
Allow moving and resizing plugin panels

### DIFF
--- a/src/GeositeFramework/GeositeFramework.csproj
+++ b/src/GeositeFramework/GeositeFramework.csproj
@@ -186,6 +186,7 @@
     <Content Include="plugins\full_extent\icon.png" />
     <Content Include="plugins\full_extent\main.js" />
     <Content Include="plugins\full_extent\full_extent.css" />
+    <Content Include="plugins\layer_selector\stripJsonComments.js" />
     <Content Include="plugins\layer_selector\icon.png" />
     <Content Include="plugins\layer_selector\icon_active.png" />
     <Content Include="plugins\layer_selector\images\gear.png" />

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -178,14 +178,17 @@
     </script>
 
     <script type="text/template" id="template-plugin-container">
-        <div class="plugin-container">
-            <div class="plugin-container-header">
-                <h6><%- title %></h6>
-                <a class="plugin-off" href="javascript:;">&#10006;</a>
-                <a class="plugin-close" href="javascript:;">&#95;</a>
+        <div class="plugin-container-outer" id="<%= id %>" style="position: absolute;"> <!-- Extra outer div to minimize mis-alignment of dojo resize "ghost".
+                                                                                             Position:absolute to eliminate jump in dojo drag. -->
+            <div class="plugin-container">
+                <div class="plugin-container-header">
+                    <h6><%- title %></h6>
+                    <a class="plugin-off" href="javascript:;">&#10006;</a>
+                    <a class="plugin-close" href="javascript:;">&#95;</a>
                 
+                </div>
+                <div class="plugin-container-inner"></div>
             </div>
-            <div class="plugin-container-inner"></div>
         </div>
     </script>
 

--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -197,23 +197,30 @@ input.code-like, textarea.code-like {
 			color: transparent;
 		}
 
-    .content .plugin-container {
+    .content .plugin-container-outer {
         position: absolute;
         border: 5px #444 solid;
         border-radius: 5px;
         width: 300px;
         height: 400px;
-        overflow: visible;
         background: #FFFFFF;
         z-index: 999;
         box-shadow: 0 0 15px #333;
 		box-shadow: 0 0 15px rgba(0,0,0,.5);
+        }
+
+    .content .plugin-container {
+        width: 100%;
+        height: 100%;
+        padding-bottom: 28px; /* reduces inner container's 100% height by header's height */
+        overflow: visible;
         }
         .content .plugin-container-header {
             height: 28px;
             padding: 5px 8px;
 			background: #444;
 			overflow: hidden;
+            cursor: move;
             }
             .content .plugin-container-header h6 {
             	float: left;
@@ -235,15 +242,15 @@ input.code-like, textarea.code-like {
             	.content .plugin-container-header a.plugin-off {
             		border-left: 1px solid #666;
             	}
-            	.content .plugin-container-header a.plugin-close {}
             	.content .plugin-container-header a:hover {
             		background: black;
             		color: white;
             	}
 
         .content .plugin-container-inner {
-            height: 362px; 
+            height: 100%; 
             padding-top: 2px;
+            overflow: auto;
         }
 
         .content .plugin-infographic {

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -194,7 +194,11 @@
         view.model.get('plugins').each(function (plugin) {
             var toolbarType = plugin.get('pluginObject').toolbarType;
             if (toolbarType === 'sidebar') {
-                new N.views.SidebarPlugin({ model: plugin, $parent: $sidebar });
+                new N.views.SidebarPlugin({
+                    model: plugin,
+                    $parent: $sidebar,
+                    paneNumber: view.model.get('paneNumber')
+                });
             } else if (toolbarType === 'map') {
                 var pluginView = new N.views.TopbarPlugin({ model: plugin });
                 $topbar.append(pluginView.$el);

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -215,12 +215,15 @@
         });
     }());
 
+    dojo.require("dojox.layout.ResizeHandle");
+    dojo.require('dojo.dnd.Moveable');
+
     (function sidebarPlugin() {
 
-        function initialize(view, $parent) {
+        function initialize(view, $parent, paneNumber) {
             render(view);
             view.$el.appendTo($parent);
-            createUiContainer(view);
+            createUiContainer(view, paneNumber);
             createLegendContainer(view);
             N.views.BasePlugin.prototype.initialize.call(view);
         }
@@ -258,8 +261,12 @@
             return view;
         }
 
-        function createUiContainer(view) {
-            var bindings = { title: view.model.get("pluginObject").toolbarName },
+        function createUiContainer(view, paneNumber) {
+            var containerId = view.model.name() + '-' + paneNumber,
+                bindings = {
+                    title: view.model.get("pluginObject").toolbarName,
+                    id: containerId
+                },
                 $uiContainer = $($.trim(N.app.templates['template-plugin-container'](bindings))),
 
                 calculatePosition = function ($el) {
@@ -294,6 +301,13 @@
             // Attach to top pane element
             view.$el.parents('.content').append($uiContainer.hide());
 
+            // Make the container resizable and moveable
+            new dojox.layout.ResizeHandle({
+                targetId: containerId
+            }).placeAt(containerId);
+
+            new dojo.dnd.Moveable($uiContainer[0]);
+
             // Tell the model about $uiContainer so it can pass it to the plugin object
             view.model.set('$uiContainer', $uiContainer);
             view.$uiContainer = $uiContainer;
@@ -316,7 +330,7 @@
             $uiContainer: null,
             $legendContainer: null,
 
-            initialize: function () { initialize(this, this.options.$parent); },
+            initialize: function () { initialize(this, this.options.$parent, this.options.paneNumber); },
 
             render: function renderSidbarPlugin() { return render(this); }
         });

--- a/src/GeositeFramework/plugins/draw_report/draw_report.css
+++ b/src/GeositeFramework/plugins/draw_report/draw_report.css
@@ -1,4 +1,10 @@
-﻿dl.tabs dd { 
+﻿.report-plugin-outer {
+    height: 100%;
+    padding-bottom: 40px; /* reduces inner container's 100% height by height of tab controls*/
+    overflow: visible;
+}
+
+dl.tabs dd { 
 	cursor: pointer;
 }
 
@@ -6,8 +12,7 @@ ul.tabs-content.report-plugin-list {
 	margin: 0 0 0;
 	padding: 0;
 	overflow: auto;
-	height: 320px;
-	position: relative;
+	height: 100%;
 	}
 	ul.tabs-content.report-plugin-list > li {
 		padding: 0 12px;

--- a/src/GeositeFramework/plugins/draw_report/templates.html
+++ b/src/GeositeFramework/plugins/draw_report/templates.html
@@ -1,6 +1,6 @@
 ﻿
 <script type="text/template" id="template-report-pluginbody">
-    <div>
+    <div class="report-plugin-outer">
         
         <dl class="tabs report-plugin-tabs">
           <dd class="active"><a data-content="report-plugin-tab-select">Report Selection</a></dd>

--- a/src/GeositeFramework/plugins/layer_selector/main.css
+++ b/src/GeositeFramework/plugins/layer_selector/main.css
@@ -5,35 +5,42 @@
     background: url(images/spinner.gif) no-repeat center center;
 }
 
-.pluginLayerSelector-search {
-    height: 32px;
-    position: relative;
+.pluginLayerSelector-outer {
+    height: 100%;
     width: 100%;
-    }
-    .pluginLayerSelector-search input[type="text"] {
-        margin: 2px auto 0;
-        width: 95%;
+    padding-bottom: 58px;  /* reduces inner container's 100% height by search area's height */
+    overflow: visible;
     }
 
-.pluginLayerSelector-rest {
-    height: 301px;
-    margin-top: 5px;
-    border-top: 1px solid #EEE;
-    }
-    .pluginLayerSelector-clear {
-        padding: 4px 4px 2px;
-        display: block;
-    }
-    .pluginLayerSelector-tree-container {
+    .pluginLayerSelector-search {
+        height: 58px;
+        position: relative;
+        width: 100%;
+        padding: 2px 4px 0 4px;
+        }
+        .pluginLayerSelector-search input[type="text"] {
+            margin: 0;
+            width: 100%;
+        }
+        .pluginLayerSelector-clear {
+            padding: 5px 0 0 1px;
+            display: block;
+        }
+
+    .pluginLayerSelector-rest {
         height: 100%;
-        overflow: auto;
+        border-top: 1px solid #EEE;
         }
-        .pluginLayerSelector-tree-container table {
-            border-width: 0; /* Otherwise there's a light gray border from Foundation*/
-        }
-        .pluginLayerSelector-rest .x-grid-header-hidden .x-grid-body {
-            border: none;
-        }
+        .pluginLayerSelector-tree-container {
+            height: 100%;
+            overflow: auto;
+            }
+            .pluginLayerSelector-tree-container table {
+                border-width: 0; /* Otherwise there's a light gray border from Foundation*/
+            }
+            .pluginLayerSelector-rest .x-grid-header-hidden .x-grid-body {
+                border: none;
+            }
 
 /* 
  * Icons for different levels of the "Map Layers" tree 

--- a/src/GeositeFramework/plugins/layer_selector/templates.html
+++ b/src/GeositeFramework/plugins/layer_selector/templates.html
@@ -1,12 +1,13 @@
 ﻿
 <script type="text/template" id="template-layer-selector">
-    <div class="pluginLayerSelector-search">
-        <!-- should this have a "search" button? -->
-        <input type="text" placeholder="Filter Map Layers"/>
-    </div>
-    <div class="pluginLayerSelector-rest">
-        <a class="pluginLayerSelector-clear" href="javascript:;">Clear All</a>
-        <div class="pluginLayerSelector-tree-container"></div>
+    <div class="pluginLayerSelector-outer">
+        <div class="pluginLayerSelector-search">
+            <input type="text" placeholder="Filter Map Layers"/>
+            <a class="pluginLayerSelector-clear" href="javascript:;">Clear All</a>
+        </div>
+        <div class="pluginLayerSelector-rest">
+            <div class="pluginLayerSelector-tree-container"></div>
+        </div>
     </div>
 </script>
 

--- a/src/GeositeFramework/plugins/layer_selector/ui.js
+++ b/src/GeositeFramework/plugins/layer_selector/ui.js
@@ -194,7 +194,6 @@ define(["jquery", "use!underscore", "use!extjs", "./treeFilter"],
                 var tree = Ext.create('FilteredTreePanel', {
                     store: store,
                     rootVisible: false,
-                    width: 400,
                     animate: false,
                     scroll: false,
                     border: false,


### PR DESCRIPTION
Use dojo Moveable and ResizeHandle
- Pass paneNumber down to plugin so it can make a unique ID

Adjust CSS so plugin panels respond gracefully to resize
- Main area of all plugin panels must have "height: 100%"
- When there's a header above the main area, use trick of setting parent div's "padding-bottom" to height of header, so the 100% height won't include it.
- This technique is used in 3 places -- the generic plugin container (titlebar/body), the layer selector plugin (searchbox/body), and the draw/report plugin (tabs/body).

Note:
- CSS for TNC's other plugins will need to be modified as well.
- Also I expect that the UCSC "infographic" feature (for which we currently have no tests) will need to be modified

Also:
- The dojo resizing "ghost box" gets drawn in the wrong place if the target div has padding/margins, so add an extra plugin-container-outer div that has none.
- The panel jumps on dojo move unless the outer div has style="position: absolute"
