### PR TITLE
Provide handle for moving panels

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -182,8 +182,9 @@
         }).placeAt(view.legendContainerId);
 
         var mover = new dojo.dnd.Moveable(
-            document.getElementById(view.legendContainerId)
-        );
+            document.getElementById(view.legendContainerId), {
+                handle: $('#' + view.legendContainerId).find('.legend-header')[0]
+            } );
 
         // Update the legend whenever the map changes
         dojo.connect(esriMap, 'onUpdateEnd', _.debounce(updateLegend, 100));

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -306,7 +306,9 @@
                 targetId: containerId
             }).placeAt(containerId);
 
-            new dojo.dnd.Moveable($uiContainer[0]);
+            new dojo.dnd.Moveable($uiContainer[0], {
+                 handle: $uiContainer.find('.plugin-container-header')[0]
+            });
 
             // Tell the model about $uiContainer so it can pass it to the plugin object
             view.model.set('$uiContainer', $uiContainer);


### PR DESCRIPTION
Use the header for legend and plugin panels to do the moving.
This is both a little more intuitive and happens to resolve
an issue with the body of the element being dragged consuming
events meant for child form elements in the container.
