### PR TITLE
Use TNC AGS for printing

### DIFF
--- a/src/GeositeFramework/proxy.config
+++ b/src/GeositeFramework/proxy.config
@@ -14,7 +14,7 @@
     <serverUrl matchAll="true" url="http://sampleserver6.arcgisonline.com/"></serverUrl>
     <serverUrl matchAll="true" url="http://tasks.arcgisonline.com/"></serverUrl>
     <serverUrl matchAll="true" url="http://devags.coastalresilience.org:6080"></serverUrl>
-    
+    <serverUrl matchAll="true" url="http://50.18.215.52/"></serverUrl>  
   </serverUrls>
   
 </ProxyConfig>

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -23,7 +23,7 @@
         { "name": "Terrain"            , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer" }
     ],
     "pluginOrder": [ "layer_selector", "zoom_to", "measure" ],
-    "printServerUrl": "http://sampleserver6.arcgisonline.com/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
+    "printServerUrl": "http://50.18.215.52/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
     "colors": {
         "primary": "#26648E",
         "secondary": "#26648E"


### PR DESCRIPTION
The sampleserver6.arcgisonline.com Print Task was very unstable and is not meant to be used consistently.
