### PR TITLE
Fix comparer bug on split screen

### DIFF
--- a/src/GeositeFramework/plugins/feature_compare/Comparer.js
+++ b/src/GeositeFramework/plugins/feature_compare/Comparer.js
@@ -5,11 +5,10 @@
         highlightGraphic: null,
         currentLayer: null,
         currentFieldInfos: null,
-        selectedFeatures: new Backbone.Collection(),
-        selectionGraphics: [],
-        selectionLayer: new esri.layers.GraphicsLayer(
-            { id: 'compare-feature-selection' }),
-        layerEventHandlers: [],
+        selectedFeatures: null,
+        selectionGraphics: null,
+        selectionLayer: null ,
+        layerEventHandlers: null,
         
         defaults: {
             maxSelectableFeatures: 3
@@ -18,6 +17,12 @@
         initialize: function(attrs, options) {
             this.options = options;
             this.highlightStyle = this._makeHighlightSymbol();
+            this.selectedFeatures = new Backbone.Collection();
+            this.selectionLayer = new esri.layers.GraphicsLayer(
+                { id: 'compare-feature-selection' });
+            this.selectionGraphics = [];
+            this.layerEventHandlers = [];
+
             this.options.map.addLayer(this.selectionLayer);
             this.activate();
         },


### PR DESCRIPTION
Split Screen mode would share and otherwise disrupt the "selected"
graphics from one map to another.  The containers and layer were
initialized when the class was loaded instead of when an instance
was created, so they were actually shared between map panes.  They
are now initialized in the constructor to be unique.
