### PR TITLE
Improve plugin resizing

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -287,7 +287,7 @@
                 $uiContainer = $($.trim(N.app.templates['template-plugin-container'](bindings)));
 
             $uiContainer
-                // Position the dialog next to the sidebar button which shows it.
+                // Position the dialog
                 .css(calculatePosition(view.$el))
             
                 // Listen for events to turn the plugin completely off
@@ -305,16 +305,26 @@
 
             // Make the container resizable and moveable
             new dojox.layout.ResizeHandle({
-                targetId: containerId
-            }).placeAt(containerId);
+                targetId: containerId,
+                activeResize: true,
+                animateSizing: false
+            })
+                .placeAt(containerId)
+                .on('resize', function (e) { onContainerResize(view, this, e); });
 
             new dojo.dnd.Moveable($uiContainer[0], {
-                 handle: $uiContainer.find('.plugin-container-header')[0]
+                handle: $uiContainer.find('.plugin-container-header')[0]
             });
 
             // Tell the model about $uiContainer so it can pass it to the plugin object
             view.model.set('$uiContainer', $uiContainer);
             view.$uiContainer = $uiContainer;
+        }
+
+        function onContainerResize(view, resizeHandle, event) {
+            var dx = event.x - resizeHandle.startPoint.x,
+                dy = event.y - resizeHandle.startPoint.y;
+            view.model.get("pluginObject").resize(dx, dy);
         }
 
         function createLegendContainer(view) {

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -47,8 +47,10 @@ define(["dojo/_base/declare",
             activate: function () {},
             deactivate: function () {},
             hibernate: function () {},
+            resize: function () {},
             getState: function () {},
-            
+            setState: function () {},
+
             showInfographic: CheckandShowInfographic,
 
             identify: identify,

--- a/src/GeositeFramework/plugins/layer_selector/main.js
+++ b/src/GeositeFramework/plugins/layer_selector/main.js
@@ -91,6 +91,10 @@ define([
                 this._layerManager.hideAllLayers(this.map);
             },
 
+            resize: function (dx, dy) {
+                this._ui.onContainerSizeChanged(dx, dy);
+            },
+
             getState: function () {
                 return this._layerManager.getServiceState();
             },


### PR DESCRIPTION
- Make plugin resizing immediate and continuous (rather than using the default dojo animation)
- Call new plugin method resize() when a plugin container is resized, so plugins have a chance to update themselves
- Layer selector plugin implements resize(), revealing more width as container is resized wider
- Clarify existing layer selector resizing by renaming previous resize() function to onContentSizeChanged() (and add some doc)
