### PR TITLE
Add support for blacklisting identify attributes

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -87,6 +87,10 @@
             },
             "required": false,
             "additionalProperties": false
+        },
+        "identifyBlacklist": {
+            "type": "array",
+            "items": { "type": "string" }
         }
     },
     "additionalProperties": false

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -27,5 +27,6 @@
     "colors": {
         "primary": "#26648E",
         "secondary": "#26648E"
-    }
+    },
+    "identifyBlacklist": ["OBJECTID", "OBJECTID_1"]
 }


### PR DESCRIPTION
Certain attributes do not provide meaningful data, so this feature allows those attributes to be blacklisted so they can be removed from the output.

As of this commit, you CANNOT blacklist display values, which are very similar to attributes, so it may create the appearance of attributes that cannot be blacklisted.
