### PR TITLE
Make identify plugin show info for all layers

### DIFF
--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -186,6 +186,7 @@ define(["dojo/_base/declare",
 
                             identifyParams.tolerance = tolerance;
                             identifyParams.layerIds = service.visibleLayers;
+                            identifyParams.layerOption = IdentifyParameters.LAYER_OPTION_VISIBLE;
                             identifyParams.width = map.width;
                             identifyParams.height = map.height;
                             identifyParams.geometry = mapPoint;


### PR DESCRIPTION
fixes #190 on github

By the IdentifyTask uses IdentifyParameters which default to LAYER_OPTION_TOP, identifying ONLY the top layer. This setting changes it to the desired behavior, identifying all visible layers.
