### PR TITLE
Add pluginFolders option in region.json configuration.

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -67,6 +67,10 @@
                 "additionalProperties": false
             }
         },
+        "pluginFolders": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
         "pluginOrder": {
             "type": "array",
             "items": {"type": "string"},

--- a/src/GeositeFramework/GeositeFramework.csproj
+++ b/src/GeositeFramework/GeositeFramework.csproj
@@ -122,11 +122,13 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\PluginLoader.cs" />
     <Compile Include="Helpers\JsonDataPlugin.cs" />
     <Compile Include="Helpers\JsonData.cs" />
     <Compile Include="Helpers\JsonDataRegion.cs" />
     <Compile Include="Models\Geosite.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tests\PluginLoaderTests.cs" />
     <Compile Include="Tests\GeositeTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GeositeFramework/Global.asax.cs
+++ b/src/GeositeFramework/Global.asax.cs
@@ -47,16 +47,12 @@ namespace GeositeFramework
         private Geosite LoadGeositeData()
         {
             // Load geosite data from "region.json" file
+            string basePath = HostingEnvironment.MapPath("~/");
             string configFilePath = HostingEnvironment.MapPath("~/region.json");
-            string pluginsFolderPath = HostingEnvironment.MapPath("~/plugins");
             string appDataFolderPath = HostingEnvironment.MapPath("~/App_Data");
             if (!File.Exists(configFilePath))
             {
                 throw new FileNotFoundException("Site configuration file not found: " + configFilePath);
-            }
-            if (!Directory.Exists(pluginsFolderPath))
-            {
-                throw new FileNotFoundException("Plugins folder not found: " + pluginsFolderPath);
             }
             if (!Directory.Exists(appDataFolderPath))
             {
@@ -64,7 +60,7 @@ namespace GeositeFramework
             }
             try
             {
-                var geositeData = Geosite.LoadSiteData(configFilePath, pluginsFolderPath, appDataFolderPath);
+                var geositeData = Geosite.LoadSiteData(configFilePath, basePath, appDataFolderPath);
                 geositeData.GeositeFrameworkVersion = _geositeFrameworkVersion;
                 return geositeData;
             }

--- a/src/GeositeFramework/Helpers/PluginLoader.cs
+++ b/src/GeositeFramework/Helpers/PluginLoader.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace GeositeFramework.Helpers
+{
+    public class PluginLoader
+    {
+        /// <summary>
+        /// Return pluginPath relative to basePath.
+        /// For example, if basePath is "~/www" and pluginPath is "~/www/plugins/xyz"
+        /// then return "plugins/xyz".
+        /// </summary>
+        public static string GetPluginFolderPath(string basePath, string pluginPath)
+        {
+            return pluginPath.Replace(basePath, "").Replace("\\", "/");
+        }
+
+        /// <summary>
+        /// Convert pluginPath to relative module path.
+        /// For example, if basePath is "~/www" and pluginPath is "~/www/plugins/xyz"
+        /// then return "tnc/plugins/xyz/main". Assuming "tnc" prefix is a package
+        /// configured to point to your basePath.
+        /// </summary>
+        public static string GetPluginModuleName(string basePath, string pluginPath)
+        {
+            return string.Format("tnc/{0}/main", pluginPath.Replace(basePath, "").Replace("\\", "/"));
+        }
+
+        /// <summary>
+        /// Given a module name like "tnc/plugins/layer_selector/main" return "layer_selector".
+        /// </summary>
+        public static string StripPluginModule(string pluginModule)
+        {
+            string result = pluginModule.Replace("tnc/", "");
+            result = result.Replace("/main", "");
+            result = result.Split('/').Last();
+            return result;
+        }
+
+        /// <summary>
+        /// Sort pluginNames by specified keyFunc.
+        /// Items for which keyFunc returns -1 (not found) will be sorted
+        /// towards the end of the list in no particular order.
+        /// </summary>
+        public static void SortPluginNames(List<string> pluginNames, Func<string, int> keyFunc)
+        {
+            pluginNames.Sort((a, b) =>
+            {
+                int ai = keyFunc(a);
+                int bi = keyFunc(b);
+                if (ai == -1) return 1;
+                if (bi == -1) return -1;
+                return ai.CompareTo(bi);
+            });
+        }
+
+        /// <summary>
+        /// Return pluginFolders array from region.json.
+        /// Default value is ["plugins"]
+        /// </summary>
+        public static IEnumerable<string> GetPluginDirectories(JsonData jsonDataRegion, string basePath)
+        {
+            JObject regionData = jsonDataRegion.Validate();
+            JToken token;
+            if (regionData.TryGetValue("pluginFolders", out token))
+            {
+                return (token as JArray).Select(folderPath => Path.Combine(basePath, folderPath.ToString()));
+            }
+            return new string[] { Path.Combine(basePath, "plugins") };
+        }
+
+        /// <summary>
+        /// Throw exception if folder does not exist.
+        /// </summary>
+        public static void VerifyDirectoriesExist(IEnumerable<string> dirs)
+        {
+            foreach (string path in dirs)
+            {
+                if (!Directory.Exists(path))
+                {
+                    throw new FileNotFoundException("Plugin folder not found: " + path);
+                }
+            }
+        }
+    }
+}

--- a/src/GeositeFramework/Tests/GeositeTests.cs
+++ b/src/GeositeFramework/Tests/GeositeTests.cs
@@ -27,12 +27,12 @@ namespace GeositeFramework.Tests
 
         private Geosite CreateGeosite(string regionJson)
         {
-            return new Geosite(LoadRegionData(regionJson), new List<string>(), null);
+            return new Geosite(LoadRegionData(regionJson), new List<string>(), new List<string>(), null);
         }
 
-        private Geosite CreateGeosite(string regionJson, List<string> pluginFolderNames)
+        private Geosite CreateGeosite(string regionJson, List<string> pluginFolderNames, List<string> pluginModuleNames)
         {
-            return new Geosite(LoadRegionData(regionJson), pluginFolderNames, null);
+            return new Geosite(LoadRegionData(regionJson), pluginFolderNames, pluginModuleNames, null);
         }
 
         private JsonData LoadRegionData(string regionJson)
@@ -60,16 +60,17 @@ namespace GeositeFramework.Tests
                     ],
                     'pluginOrder': [ 'layer_selector', 'measure' ]
                 }";
-            var pluginFolderNames = new List<string> { "nearshore_waves", "measure", "layer_selector", "explode"};
+            var pluginFolderNames = new List<string> { "nearshore_waves", "measure", "layer_selector", "explode" };
+            var pluginModuleNames = new List<string> { "nearshore_waves/main", "measure/main", "layer_selector/main", "explode/main" };
             var pluginJsonData = new List<JsonData> { LoadPluginData(@"{ css: ['main.css'], use: { underscore: { attach: '_' } } }") };
-            var geosite = new Geosite(LoadRegionData(regionJson), pluginFolderNames, pluginJsonData);
+            var geosite = new Geosite(LoadRegionData(regionJson), pluginFolderNames, pluginModuleNames, pluginJsonData);
 
             Expect(geosite.TitleMain.Text, EqualTo("Geosite Framework Sample"));
             Expect(geosite.TitleDetail.Text, EqualTo("Sample Region"));
             Expect(geosite.HeaderLinks.Count, EqualTo(2));
             Expect(geosite.HeaderLinks[0].Url, EqualTo("http://www.azavea.com/"));
             Expect(geosite.HeaderLinks[1].Text, EqualTo("GIS"));
-            Expect(geosite.PluginModuleIdentifiers, EqualTo("'plugins/layer_selector/main', 'plugins/measure/main', 'plugins/nearshore_waves/main', 'plugins/explode/main'"));
+            Expect(geosite.PluginModuleIdentifiers, EqualTo("'layer_selector/main', 'measure/main', 'nearshore_waves/main', 'explode/main'"));
             Expect(geosite.PluginVariableNames, EqualTo("p0, p1, p2, p3"));
             Expect(geosite.PluginCssUrls, Contains("main.css"));
             Expect(geosite.ConfigurationForUseJs, Contains("underscore"));
@@ -156,23 +157,6 @@ namespace GeositeFramework.Tests
             Expect((ex as JsonValidationException).ParseMessages[0], Contains("3 is less than minimum count of 4"));
         }
 
-        /// <exclude/>
-        [Test]
-        [ExpectedException(typeof(ApplicationException), ExpectedMessage = "XYZ", MatchType = MessageMatch.Contains)]
-        public void TestMissingPlugin()
-        {
-            var regionJson = @"
-                {
-                    'titleMain': {'text':''},
-                    'titleDetail': {'text':''},
-                    'initialExtent': [0,0,0,0],
-                    'basemaps': [{'name':'', 'url':''}],
-                    'pluginOrder': [ 'layer_selector', 'XYZ' ]
-                }";
-            var pluginFolderNames = new List<string> { "nearshore_waves", "measure", "layer_selector", "explode" };
-            CreateGeosite(regionJson, pluginFolderNames);
-        }
-
         // ------------------------------------------------------------------------
         // Tests for plugin.json configuration
 
@@ -185,7 +169,7 @@ namespace GeositeFramework.Tests
                     'initialExtent': [0,0,0,0],
                     'basemaps': [{'name':'', 'url':''}]
                 }";
-            return new Geosite(LoadRegionData(regionJson), new List<string>(), pluginConfigJsonData);
+            return new Geosite(LoadRegionData(regionJson), new List<string>(), new List<string>(), pluginConfigJsonData);
         }
 
         private JObject ParsePluginData(string pluginJson)
@@ -277,6 +261,5 @@ namespace GeositeFramework.Tests
             };
             CreateGeosite(jsonData);
         }
-
     }
 }

--- a/src/GeositeFramework/Tests/PluginLoaderTests.cs
+++ b/src/GeositeFramework/Tests/PluginLoaderTests.cs
@@ -1,0 +1,42 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using GeositeFramework.Models;
+using Newtonsoft.Json.Linq;
+using System.IO;
+using GeositeFramework.Helpers;
+
+namespace GeositeFramework.Tests
+{
+    [TestFixture]
+    public class PluginLoaderTests : AssertionHelper
+    {
+        [Test]
+        public void TestSortPluginNames()
+        {
+            List<string> orderBy = new List<string> { "A", "B", "C" };
+            List<string> pluginNames = new List<string> { "C", "X", "B", "A" };
+            Func<string, int> keyFunc = x => orderBy.IndexOf(x);
+            PluginLoader.SortPluginNames(pluginNames, keyFunc);
+            Assert.AreEqual("A", pluginNames[0]);
+            Assert.AreEqual("B", pluginNames[1]);
+            Assert.AreEqual("C", pluginNames[2]);
+            Assert.AreEqual("X", pluginNames[3]);
+        }
+
+        [Test]
+        public void TestSortPluginNamesWithStripPluginModule()
+        {
+            List<string> orderBy = new List<string> { "A", "B", "C" };
+            List<string> pluginNames = new List<string> { "plugin/C", "plugin/X", "sample_plugin/B", "plugin/A" };
+            Func<string, int> keyFunc = x => orderBy.IndexOf(PluginLoader.StripPluginModule(x));
+            PluginLoader.SortPluginNames(pluginNames, keyFunc);
+            Assert.AreEqual("plugin/A", pluginNames[0]);
+            Assert.AreEqual("sample_plugin/B", pluginNames[1]);
+            Assert.AreEqual("plugin/C", pluginNames[2]);
+            Assert.AreEqual("plugin/X", pluginNames[3]);
+        }
+    }
+}

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -151,7 +151,7 @@
 
     <script type="text/template" id="template-sidebar-plugin">
             <a class="plugin-launcher" title="<%=fullName%>" href="javascript:;">
-                <img src="plugins/<%- pluginSrcFolder %>/icon<%= selected ? '_active' : ''%>.png">
+                <img src="<%- pluginSrcFolder %>/icon<%= selected ? '_active' : ''%>.png">
                 <div><%- pluginObject.toolbarName %></div>
             </a>
     </script>
@@ -377,6 +377,10 @@
                 {
                     name: "plugins",
                     location: location.pathname.replace(/\/[^/]+$/, "") + "plugins"  // e.g. "/virtualFolderName/plugins"
+                },
+                {
+                    name: "tnc",
+                    location: location.protocol + "//" + location.host + location.pathname.replace(/\/+$/, "")
                 },
                 {
                     name: "framework",

--- a/src/GeositeFramework/plugins/layer_selector/main.js
+++ b/src/GeositeFramework/plugins/layer_selector/main.js
@@ -42,8 +42,8 @@ define([
         "framework/PluginBase",
         "./LayerManager",
         "./Ui",
-        "dojo/text!plugins/layer_selector/layers.json",
-        "dojo/text!plugins/layer_selector/templates.html",
+        "dojo/text!./layers.json",
+        "dojo/text!./templates.html",
         "jquery"
     ],
     function (declare, PluginBase, LayerManager, Ui, layerSourcesJson, templates, $) {


### PR DESCRIPTION
This gives us the ability to organize plugins into separate folders. We can
use this to add sample plugins to the core framework without running
into conflicts when deploying to existing client implementations.
