### PR TITLE
Allow tooltip on feature for selection

### DIFF
--- a/src/GeositeFramework/plugins/feature_compare/compare_config.json
+++ b/src/GeositeFramework/plugins/feature_compare/compare_config.json
@@ -6,6 +6,7 @@
         {
             "name": "HUC 8",
             "url": "http://50.18.215.52/arcgis/rest/services/Louisiana_Freshwater/Watershed_and_Political_Boundaries/MapServer/0",
+            "mapDisplayAttribute": "SUBREGION",
             "attrs": [
                 {"name": "SUBREGION", "format": "text", "maxLength": 25},
                 {"name": "canal_idx", "format": "number", "digits": 3, "unit": " mi", "nonZeroCutoff": 0.001},
@@ -20,6 +21,7 @@
         {
             "name": "HUC 12",
             "url": "http://50.18.215.52/arcgis/rest/services/Louisiana_Freshwater/Watershed_and_Political_Boundaries/MapServer/1",
+            "mapDisplayAttribute": "STATES",
             "attrs": [
                 {"name": "STATES", "format": "text", "maxLength": 25},
                 {"name": "canal_idx", "format": "number", "digits": 3, "unit": " mi", "nonZeroCutoff": 0.001},

--- a/src/GeositeFramework/plugins/feature_compare/comparerSchema.json
+++ b/src/GeositeFramework/plugins/feature_compare/comparerSchema.json
@@ -14,6 +14,7 @@
                 "properties": {
                     "name": {"type": "string", "required": true},
                     "url": {"type": "string", "required": true},
+                    "mapDisplayAttribute": {"type": "string", "required": false},
                     "attrs": {
                         "type": "object", 
                         "properties": {

--- a/src/GeositeFramework/plugins/feature_compare/feature_compare.css
+++ b/src/GeositeFramework/plugins/feature_compare/feature_compare.css
@@ -25,3 +25,14 @@
 .comparer-feature li, .comparer-feature-fields li {
     padding: 2px;
 }
+
+#feature-compare-tooltip > div.dijitTooltipContainer > div {
+    padding: 5px;
+}
+
+#feature-compare-tooltip .dijitTooltipContainer {
+    border:1px solid gray;
+    background-color: #c0c0c0;
+    background-color: rgba(192,192,192, 0.85);
+    border-radius: 2px;
+}


### PR DESCRIPTION
Show a designated feature attribute (usually name) on hover/tooltip for
the feature layer selected for comparison.
