### PR TITLE
Reset map layers on hibernate

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector/main.js
+++ b/src/GeositeFramework/plugins/layer_selector/main.js
@@ -91,8 +91,7 @@ define([
             },
 
             hibernate: function () {
-                this._currentState = this._layerManager.getServiceState();
-                this._layerManager.hideAllLayers(this.map);
+                this.clearAll();
             },
 
             resize: function (dx, dy) {

--- a/src/GeositeFramework/plugins/layer_selector/ui.js
+++ b/src/GeositeFramework/plugins/layer_selector/ui.js
@@ -46,6 +46,11 @@ define(["jquery", "use!underscore", "use!extjs", "./treeFilter"],
                 if (_$layerDialog) {
                     _$layerDialog.show();
                 }
+               
+                // Size to contents of window when displaying
+                // the form initially.  If it was resized while
+                // the container was hidden, w/h are equal to 0
+                this.onContainerSizeChanged();
             };
 
             this.hideAll = function () {


### PR DESCRIPTION
Client requests that plugins reset their state when closed and
reopened.  Map layers previously held onto state so it could
be recreated easily, but this is not the desired behavior.
