### PR TITLE
Remove use of reserved keyword `export`

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -75,7 +75,7 @@
             "type": "array",
             "items": {"type": "string"},
         },
-        "export": {
+        "print": {
             "type": "object",
             "properties": {
                 "printServerUrl": {

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -65,14 +65,14 @@ require(['use!Geosite',
               been specified in the region.json
             */
             var model = this,
-                url = N.app.data.region.export.printServerUrl;
+                url = N.app.data.region.print.printServerUrl;
 
             // If there is a custom template scheme for export, override the
             // default settings.  If no custom template is provided, the export
             // will work with the out-of-the-box ArcGIS Print Task settings
-            if (N.app.data.region.export.customPrintTemplatePrefix) {
+            if (N.app.data.region.print.customPrintTemplatePrefix) {
                 this.set('printLayoutTemplatePrefix',
-                    N.app.data.region.export.customPrintTemplatePrefix);
+                    N.app.data.region.print.customPrintTemplatePrefix);
                 this.set('useDifferentTemplateWithLegend', true);
             }
 

--- a/src/GeositeFramework/js/Screen.js
+++ b/src/GeositeFramework/js/Screen.js
@@ -42,7 +42,7 @@
         },
 
         initialize: function () {
-            if (N.app.data.region.export && N.app.data.region.export.printServerUrl) {
+            if (N.app.data.region.print && N.app.data.region.print.printServerUrl) {
                 this.set('showExportButton', true);
             }
             if (N.app.data.region.helpUrl) {

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -34,7 +34,7 @@
         "zoom_to",
         "measure"
     ],
-    "export": {
+    "print": {
         "printServerUrl": "http://lr13:6080/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
         "customPrintTemplatePrefix": "Letter ANSI A GeositeFramework"
     },


### PR DESCRIPTION
`export` is a future reserved keyword and IE8 fails execute
javascript which uses it as an identifier.  Since our region.json
becomes a javascript object, I changed the setting value to a
benign word (print), and IE8 works "great".

@msgraber heads up that the recent changes to region.json will need to be tweaked.
