### PR TITLE
Don't debounce updateLegend

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -197,9 +197,8 @@ require(['use!Geosite',
         // body of `updateLegend` immediately looks at visible layers, while some may
         // still asynchronously be in queue to become visible. As a protection, call
         // `updateLegend` explicitly when a layer has finished adding.
-        var updateLegendManager = _.debounce(updateLegend, 200);
-        dojo.connect(esriMap, 'onUpdateEnd', updateLegendManager);
-        dojo.connect(esriMap, 'onLayerAdd', updateLegendManager);
+        dojo.connect(esriMap, 'onUpdateEnd', updateLegend);
+        dojo.connect(esriMap, 'onLayerAdd', updateLegend);
 
         function updateLegend() {
             var services = esriMap.getLayersVisibleAtScale(esriMap.getScale()),


### PR DESCRIPTION
fixes #226 on github

Unfortunately, it's not clear why debouncing causes this not to work, or more precisely, why this doesn't work on the first call but does on the second. However, there will always be two calls when we don't debounce, and my experiments indicated that this fixes the bug, as reported. The answer is hidden in the unavailable source for legendDijit.refresh() (where legendDigit is a esri.dijit.Legend).
