### PR TITLE
Fix issue #225: Some plugins shouldn't force close others.

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -45,15 +45,7 @@ require(['use!Geosite',
                 },
                 map: N.createMapWrapper(esriMap, mapModel, pluginObject),
                 container: ($uiContainer ? $uiContainer.find('.plugin-container-inner')[0] : undefined),
-                legendContainer: ($legendContainer ? $legendContainer[0] : undefined),
-                forceDeactivate: function () {
-                    // Drop the turnOff call to the end of the stack because
-                    // if the plugin called this from it's initialize event, the
-                    // selection change events from backbone.picky will still 
-                    // fire the unchanged selection model state, resulting in an
-                    // infinite loop.
-                    setTimeout(function () { model.turnOff(); }, 0);
-                }
+                legendContainer: ($legendContainer ? $legendContainer[0] : undefined)
             });
         }
 
@@ -539,6 +531,15 @@ require(['use!Geosite',
                 N.views.BasePlugin.prototype.initialize.call(this);
             },
             render: render,
+            // Override handleLaunch so topbar plugins can have custom launch behavior.
+            handleLaunch: function() {
+                var pluginObject = this.model.get('pluginObject');
+                if (pluginObject.closeOthersWhenActive) {
+                    N.views.BasePlugin.prototype.handleLaunch.apply(this, arguments);
+                } else {
+                    pluginObject.activate();
+                }
+            },
             handleClear: function () {
                 this.model.turnOff();
             }

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -29,6 +29,13 @@ define(["dojo/_base/declare",
             toolbarType: "sidebar",
             showServiceLayersInLegend: true,
             allowIdentifyWhenActive: false,
+
+            // This option changes the default launch behavior and is only applicable to topbar plugins.
+            // If true, this will deselect other active plugins when launched. If false, this will
+            // not call the Picky select/deselect methods. Instead, only the plugin 'activate' method
+            // will be called.
+            closeOthersWhenActive: true,
+
             resizable: true,
             width: 300,
             height: 400,

--- a/src/GeositeFramework/plugins/full_extent/main.js
+++ b/src/GeositeFramework/plugins/full_extent/main.js
@@ -40,6 +40,7 @@ define(
             fullName: "Zoom out to the default map extent",
             toolbarType: "map",
             allowIdentifyWhenActive: true,
+            closeOthersWhenActive: false,
             
             initialize: function (args) {
                 declare.safeMixin(this, args);
@@ -53,7 +54,6 @@ define(
             activate: function () {
                 var self = this;
                 self.map.setExtent(_extent);
-                self.forceDeactivate();
             }
         });
     }

--- a/src/GeositeFramework/plugins/legend_display/main.js
+++ b/src/GeositeFramework/plugins/legend_display/main.js
@@ -8,6 +8,7 @@
             fullName: "Show/Hide the map legend",
             toolbarType: "map",
             allowIdentifyWhenActive: true,
+            closeOthersWhenActive: false,
             
             initialize: function (args) {
                 declare.safeMixin(this, args);
@@ -20,7 +21,6 @@
 
             activate: function () {
                 $legendEl.toggle();
-                this.forceDeactivate();
             }
         });
     }


### PR DESCRIPTION
Added an option called `closeOthersWhenActive` which defaults to true.
When set to false, it will only call the plugin `activate` method instead
of the Picky select/deselect methods.
