### PR TITLE
Fix issue #240: IE "search" by address not working.

### DIFF
--- a/src/GeositeFramework/plugins/zoom_to/main.css
+++ b/src/GeositeFramework/plugins/zoom_to/main.css
@@ -77,4 +77,6 @@
     width: 34px;
     height: 34px;
     cursor: pointer;
+    /* Fixes event propagation in IE10 (See issue #240) */
+    background: rgba(0, 0, 0, 0);
 }

--- a/src/GeositeFramework/plugins/zoom_to/main.js
+++ b/src/GeositeFramework/plugins/zoom_to/main.js
@@ -35,6 +35,7 @@ define(
             toolbarName: "Zoom To",
             fullName: "Zoom to a specific address.",
             toolbarType: "maptop",
+            closeOthersWhenActive: false,
 
             _initializeViews: function () {
                 if (!this.input) {


### PR DESCRIPTION
After discussing with Rick, I reverted my previous changes. Adding a transparent background to the zoom_to launcher div resolves this issue in IE10.
