### PR TITLE
Fix layer selector plugins with infographics not rendering.

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -392,7 +392,8 @@ require(['use!Geosite',
 
             // Disable resizing when infographic is active
             setResizable(this, pluginObject.resizable && !showInfoGraphic);
-            // Plugin window should expand to fit content when infographic is active
+
+            // Expand plugin panel to fit content when infographic is active
             if (showInfoGraphic) {
                 setWidth(this, null);
                 setHeight(this, null);
@@ -400,6 +401,9 @@ require(['use!Geosite',
                 setWidth(this, pluginObject.width);
                 setHeight(this, pluginObject.height);
             }
+
+            var primaryContainerVisible = !showInfoGraphic;
+            pluginObject.onContainerVisibilityChanged(primaryContainerVisible);
         }
 
         // Draw resize handle if resizable, destroy it if not resizable.

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -47,6 +47,8 @@ define(["dojo/_base/declare",
             resize: function () {},
             getState: function () {},
             setState: function () {},
+            // Called when switching from infographic to the primary view or vice versa.
+            onContainerVisibilityChanged: function (visible) {},
 
             identify: identify,
 

--- a/src/GeositeFramework/plugins/layer_selector/main.js
+++ b/src/GeositeFramework/plugins/layer_selector/main.js
@@ -90,6 +90,10 @@ define([
                 this._currentState = this._layerManager.getServiceState();
             },
 
+            onContainerVisibilityChanged: function(visible) {
+                this._ui.display();
+            },
+
             hibernate: function () {
                 this.clearAll();
             },


### PR DESCRIPTION
Since the container node for plugins with infographics is not visible
upon activation, there is no place for ExtJS to render the tree.

To resolve this problem, we added a new method that is called when the
plugin view changes from the infographic to the primary view, and vice
versa.
