### PR TITLE
Fix #235: Custom Map Layers plugins share "clear" event.

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector/main.js
+++ b/src/GeositeFramework/plugins/layer_selector/main.js
@@ -70,7 +70,9 @@ define([
                         self._layerManager.setServiceState(self._currentState, self.map);
                     }
                     self._ui.render(tree);
-                    $('a.pluginLayerSelector-clear').click(function () { self.clearAll(); });
+                    $('a.pluginLayerSelector-clear', self.container).click(function() {
+                        self.clearAll();
+                    });
                 });
             },
 


### PR DESCRIPTION
We need to bind the "Clear All" click handler to the plugin that it
belongs to instead of binding the click handler to every "Clear All"
link on the page.
