### PR TITLE
Fix #230: Export retry results in too many requests.

### DIFF
--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -144,7 +144,7 @@ require(['use!Geosite',
                     model.set('outputText', resultTemplate({ url: result.url }));
                     onFinish();
                 },
-                onFailure = function() {
+                onFailure = _.debounce(function() {
                     var result = [];
                     result.push('There was an error processing your request.');
                     if (attempts > 0) {
@@ -153,13 +153,14 @@ require(['use!Geosite',
                     }
                     model.set('outputText', result.join('<br />'));
                     tryCreatePdf();
-                },
+                }, 1000),
                 onFinish = function() {
                     model.set('submitEnabled', true);
                 },
                 tryCreatePdf = function() {
                     if (attempts <= 0) {
                         onFinish();
+                        return;
                     }
                     model.pdfManager.run(
                         model.getPrintTemplateName(),


### PR DESCRIPTION
The return statement was missing from the terminating condition.

I also added a debounce on the "Trying again X more times..."
message so that it doesn't flash by too quickly before you are able to
read it.
