### PR TITLE
Issue #242: Feature Compare plugin expects "OBJECTID".

### DIFF
--- a/src/GeositeFramework/plugins/feature_compare/compare_config.json
+++ b/src/GeositeFramework/plugins/feature_compare/compare_config.json
@@ -7,6 +7,7 @@
             "name": "HUC 8",
             "url": "http://50.18.215.52/arcgis/rest/services/Louisiana_Freshwater/Watershed_and_Political_Boundaries/MapServer/0",
             "mapDisplayAttribute": "SUBREGION",
+            "objectIdField": "OBJECTID",
             "attrs": [
                 {"name": "SUBREGION", "format": "text", "maxLength": 25},
                 {"name": "canal_idx", "format": "number", "digits": 3, "unit": " mi", "nonZeroCutoff": 0.001},

--- a/src/GeositeFramework/plugins/feature_compare/comparerSchema.json
+++ b/src/GeositeFramework/plugins/feature_compare/comparerSchema.json
@@ -15,6 +15,7 @@
                     "name": {"type": "string", "required": true},
                     "url": {"type": "string", "required": true},
                     "mapDisplayAttribute": {"type": "string", "required": false},
+                    "objectIdField": {"type": "string", "required": false},
                     "attrs": {
                         "type": "object", 
                         "properties": {


### PR DESCRIPTION
The following changes were made to the feature compare plugin:
- New layer option in compare_config.json called 'objectIdField' which
  is the name of the OBJECTID property on layer features.
- If no 'objectIdField' is configured, we look for an 'esriFieldTypeOID'
  field in the layer info and use that.
- If all else fails, we revert to the default behavior which just
  assumes that an OBJECTID property exists on the layer feature.
