### PR TITLE
Feature compare has default display for nulls

### DIFF
--- a/src/GeositeFramework/plugins/feature_compare/ValueFormatter.js
+++ b/src/GeositeFramework/plugins/feature_compare/ValueFormatter.js
@@ -18,6 +18,10 @@
             };
         }
 
+        if (value === null) {
+            return { valid: true, origValue: value, value: '[No Value]' };
+        }
+
         if (this.options.format === 'number') {
             return this.number(value, this.options);
         }


### PR DESCRIPTION
Feature compare results table showing 'gaps' due to null values.  Places
default text to have all cells filled in.
