### PR TITLE
Clean identify primary field name

### DIFF
--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -288,6 +288,9 @@ define(["dojo/_base/declare",
                     var firstAttribute = getFirstAttribute(feature.feature.attributes);
 
                     feature.displayFieldName = feature.displayFieldName || firstAttribute.fieldName;
+                    // We don't have access to the alias for this field, so clean it up a little by
+                    // swapping underscores for spaces.
+                    feature.displayFieldName = feature.displayFieldName.replace(/_/g, ' ');
                     feature.value = feature.value || firstAttribute.value;
 
                     if (!feature.layerName) {


### PR DESCRIPTION
TNC wanted an alias display instead of field name, but the REST API does not provide alias information for primaryDisplayField.  We instead agreed to republish problematic field names with nicer names, and then swap out underscores in the name.
