### PR TITLE
Issue #253: Root level service info buttons don't work until service is ...

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector/ui.js
+++ b/src/GeositeFramework/plugins/layer_selector/ui.js
@@ -52,6 +52,8 @@ define(["jquery", "use!underscore", "use!extjs", "./treeFilter"],
                 // the form initially.  If it was resized while
                 // the container was hidden, w/h are equal to 0
                 this.onContainerSizeChanged();
+
+                enableIconClick();
             };
 
             this.hideAll = function () {


### PR DESCRIPTION
...expanded.

The service info button click handler was only added after a checkbox
click or item expand event. This change adds the click event handler
immediately after rendering the layer selector tree.
