### PR TITLE
Issue #255: Checking a layer group with a layerId greater than 0 results...

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector/agsLoader.js
+++ b/src/GeositeFramework/plugins/layer_selector/agsLoader.js
@@ -617,7 +617,7 @@ define(["jquery", "use!underscore"],
                         if (layerNode.type === "layer-group") {
                             node.cascadeBy(function() {
                                 if (this.get('checked')) {
-                                    if (this.raw.layerId) {
+                                    if (this.raw.leaf) {
                                         layerIds = _.union(layerIds, this.raw.layerId);
                                     }
                                 }


### PR DESCRIPTION
... in all child layers being selected.

The logic which gathers the list of visibile layerIds when a layer group
is checked was faulty. Not only would it include all checked child
nodes, but it would also include the layer group parent node.

Due to 0 being falsy in JS this issue did not affect the first layer
group in a collection which lead to inconsistent behavior.

This is fixed by only adding a layer to the list of visible layerIds if
it is a leaf node.
