### PR TITLE
Allow Spaces in URLs via proxy

### DIFF
--- a/src/GeositeFramework/proxy.ashx
+++ b/src/GeositeFramework/proxy.ashx
@@ -26,7 +26,10 @@ public class proxy : IHttpHandler {
 
         // Get the URL requested by the client (take the entire querystring at once
         //  to handle the case of the URL itself containing querystring parameters)
-		string uri = Uri.UnescapeDataString(context.Request.QueryString.ToString());
+        //  Also replace + with encoded spaces, as this Uri method will replace a 
+        //  space with + which is not a valid Uri scheme for AGS.
+        string uri = Uri.UnescapeDataString(
+            context.Request.QueryString.ToString()).Replace("+", "%20");
 
         // Get token, if applicable, and append to the request
         string token = getTokenFromConfigFile(uri);


### PR DESCRIPTION
When the proxy decodes the destination URL, it replaces spaces with "+"
characters which then invalidate the URL path on an AGS.  Fix this by
then replacing + with "%20" for valid encode spaces in the URL.

Fixes #257
