### PR TITLE
Allow custom legends

### DIFF
--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -597,10 +597,13 @@ input.code-like, textarea.code-like {
         display: none;
     }
 
-#legend-0 > div, #legend-1 > div {
+#legend-0 > div, #legend-1 > div, .custom-legend {
     padding-bottom: 8px;
     float: left;
     width: 215px;
+    }
+    .legend-body .esriLegendService {
+        padding-bottom: 0;
     }
     .esriLegendService table {
         margin: 0;

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -200,8 +200,8 @@ require(['use!Geosite',
 
         function createLegendContainer(view) {
             // Create container for custom legend and attach to legend element
-            var $legendContainer = $('<div>').hide()
-                .appendTo(view.$el.parents('.content').find('.legend'));
+            var $legendContainer = $('<div>', {'class': 'custom-legend'}).hide()
+                .appendTo(view.$el.parents('.content').find('.legend .legend-body'));
 
             // Tell the model about $legendContainer so it can pass it to the plugin object
             view.model.set('$legendContainer', $legendContainer);


### PR DESCRIPTION
Custom legends were appearing off of the legend container due to
a previous refactor/update.  This restores the custom legends to the
container.
