### PR TITLE
Fix legend container selector

### DIFF
--- a/src/GeositeFramework/plugins/legend_display/main.js
+++ b/src/GeositeFramework/plugins/legend_display/main.js
@@ -12,7 +12,7 @@
             
             initialize: function (args) {
                 declare.safeMixin(this, args);
-                $legendEl = $(this.legendContainer.parentElement);
+                $legendEl = $(this.legendContainer).parents('.legend');
             },
             
             renderLauncher: function () {


### PR DESCRIPTION
Instead of incorrectly assuming the legend container is the parent of
the legend item, select it explicitly.

Fixes #260
