### PR TITLE
Reduce legend container scope to instance

### DIFF
--- a/src/GeositeFramework/plugins/legend_display/main.js
+++ b/src/GeositeFramework/plugins/legend_display/main.js
@@ -1,18 +1,17 @@
 ﻿define(
     ["dojo/_base/declare", "framework/PluginBase"],
     function (declare, PluginBase) {
-        var $legendEl = null;
-        
+
         return declare(PluginBase, {
             toolbarName: "LegendDisplay",
             fullName: "Show/Hide the map legend",
             toolbarType: "map",
             allowIdentifyWhenActive: true,
             closeOthersWhenActive: false,
-            
+
             initialize: function (args) {
                 declare.safeMixin(this, args);
-                $legendEl = $(this.legendContainer).parents('.legend');
+                this.$legendEl = $(this.legendContainer).parents('.legend');
             },
             
             renderLauncher: function () {
@@ -20,7 +19,7 @@
             },
 
             activate: function () {
-                $legendEl.toggle();
+                this.$legendEl.toggle();
             }
         });
     }


### PR DESCRIPTION
The legendEl variable was not scoped to the instance, so both map
map buttons targeted the most recent value.
Fixes #263 
