### PR TITLE
Fix #262: Infographic on small split screen mis-aligns map pane.

### DIFF
--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -263,6 +263,7 @@ input.code-like, textarea.code-like {
 
         .content .plugin-infographic .graphic {
             display: block;
+            max-width: none;
         }
 
         .content  .plugin-infographic label {


### PR DESCRIPTION
The dynamic image width was causing calculation errors on the
dialog widget movers.
