### PR TITLE
Fix #265: Fixed Title Bar overlaps portion of top map.

### DIFF
--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -104,8 +104,19 @@ input.code-like, textarea.code-like {
         color: white;
         text-transform: uppercase;
     }
-    
-    
+
+    /* Copied from foundation */
+    .top-bar>ul .name h1,
+    .top-bar>ul .name h2 {
+        margin: 0;
+    }
+
+    /* Copied from foundation */
+    .top-bar ul>li.name h1 a,
+    .top-bar ul>li.name h2 a {
+        line-height: 45px !important;
+    }
+
 /* -----------------------------------------
    Content Area - Helpers
 ----------------------------------------- */

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -1,6 +1,12 @@
 {
-    "titleMain": { "text": "Geosite Framework Sample", "url": "http://www.azavea.com/" },
-	"titleDetail": { "text": "Sample Region"},
+    "titleMain": {
+        "text": "Geosite Framework Sample",
+        "url": "http://www.azavea.com/"
+    },
+    "titleDetail": {
+        "text": "Sample Region",
+        "url": "http://www.azavea.com/"
+    },
     "headerLinks": [
         { "text": "Menu", "url":"#", "items": [
                 { "text": "Cat", "url": "https://en.wikipedia.org/wiki/Cat" },


### PR DESCRIPTION
The navbar height was larger than it appeared to be when using the URL
property of the titleDetail setting in region.json. This invisible
bounding box would swallow mouse events and cause dialog windows that
were dragged underneath the title bar to become stuck there.

Foundation CSS has specific line-height and margin settings on the title
bar H1 element but is missing these styles for the H2 element. I copied
these H1 styles for the H2 element to resolve this issue.
