### PR TITLE
Change extjs 4.1.1 to pull from TNC CDN

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector/main.js
+++ b/src/GeositeFramework/plugins/layer_selector/main.js
@@ -21,7 +21,7 @@ require({
         },
         {
             name: "extjs",
-            location: "//cdn.sencha.io/ext-4.1.1-gpl",
+            location: "//d16l3xhd6wlg5a.cloudfront.net",
             main: "ext-all"
         },
         {

--- a/src/GeositeFramework/plugins/layer_selector/plugin.json
+++ b/src/GeositeFramework/plugins/layer_selector/plugin.json
@@ -1,7 +1,7 @@
 {
     "css": [
         "plugins/layer_selector/main.css",
-        "//cdn.sencha.io/ext-4.1.1-gpl/resources/css/ext-all.css"
+        "//d16l3xhd6wlg5a.cloudfront.net/resources/css/ext-all.css"
     ],
     "use": {
         "underscore": { "attach": "_" },


### PR DESCRIPTION
The Sencha CDN for 4.1.1 stopped working and this broke every TNC site.
