### PR TITLE
Upgrade ESRI JSAPI

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -66,9 +66,11 @@
     {
         <link rel="stylesheet" href="@url">
     }
-    <link rel="stylesheet" href="http://serverapi.arcgisonline.com/jsapi/arcgis/3.5/js/dojo/dijit/themes/claro/claro.css">
-    <link rel="stylesheet" href="http://js.arcgis.com/3.8/js/dojo/dojox/layout/resources/ResizeHandle.css">
-    <link rel="stylesheet" href="http://serverapi.arcgisonline.com/jsapi/arcgis/3.5/js/esri/css/esri.css">
+
+    <link rel="stylesheet" href="//serverapi.arcgisonline.com/jsapi/arcgis/3.11/js/dojo/dijit/themes/claro/claro.css">
+    <link rel="stylesheet" href="//js.arcgis.com/3.10/js/dojo/dojox/layout/resources/ResizeHandle.css">
+    <link rel="stylesheet" href="//js.arcgis.com/3.11/esri/css/esri.css">
+
     <link rel="stylesheet" href="css/foundation.min.css">
     <link rel="stylesheet" href="css/TinyBox2.css">
     <link rel="stylesheet" href="css/jquery.mCustomScrollbar.css">
@@ -357,7 +359,7 @@
     <script src="js/polyfill.js"></script>
     
     <script src="//apis.google.com/js/client.js"></script>
-    <script src="//serverapi.arcgisonline.com/jsapi/arcgis/?v=3.5compact"></script>
+    <script src="//js.arcgis.com/3.11/"></script>
     <script src="Scripts/json2.min.js"></script>
     <script src="js/lib/foundation/foundation.min.js"></script>
     <script src="js/lib/foundation/app.js"></script>


### PR DESCRIPTION
Update JS and CSS files to the latest versions provided by ESRI.
Note that the dojo resource for ResizeHandle.css is not available
at 3.11 but I did upgrade from 3.8 -> 3.10.

I encountered no framework or core issues, though other plugins may
need to make updates to be compatible

Fixes #279
