### PR TITLE
Add simple csv and text export handler

### DIFF
--- a/src/GeositeFramework/App_Start/RouteConfig.cs
+++ b/src/GeositeFramework/App_Start/RouteConfig.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
 using System.Web.Routing;
 
 namespace GeositeFramework
@@ -14,10 +10,25 @@ namespace GeositeFramework
             routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
 
             routes.MapRoute(
+                name: "Csv",
+                url: "download/csv",
+                constraints: new { httpMethod = new HttpMethodConstraint("POST") },
+                defaults: new { controller = "Download", action = "csv" }
+            );
+
+            routes.MapRoute(
+                name: "Text",
+                url: "download/text",
+                constraints: new { httpMethod = new HttpMethodConstraint("POST") },
+                defaults: new { controller = "Download", action = "text" }
+            );
+
+            routes.MapRoute(
                 name: "Default",
                 url: "{controller}/{action}/{id}",
                 defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
             );
+
         }
     }
 }

--- a/src/GeositeFramework/Controllers/DownloadController.cs
+++ b/src/GeositeFramework/Controllers/DownloadController.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Text;
+using System.Web;
+using System.Web.Mvc;
+using GeositeFramework.Helpers;
+using log4net;
+
+namespace GeositeFramework.Controllers
+{
+    public class DownloadController : Controller
+    {
+        private static readonly ILog _log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>
+        /// Echos a JSON Array of Arrays as a CSV
+        /// </summary>
+        /// <returns></returns>
+        public ActionResult Csv()
+        {
+            var fileInfo = GetParameters(Request);
+
+            try
+            {
+                var output = CsvHelper.JsonToCsv(fileInfo.Content);
+                return File(Encoding.Unicode.GetBytes(output), "text/csv", fileInfo.Filename);
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex);
+                throw new HttpException(400, "Could not parse JSON.  Must be an array of arrays.");
+            }
+        }
+        
+        /// <summary>
+        /// Echo posted text payload as a text file.  To be used as an arbitrary structured file
+        /// downloader for plugins.
+        /// </summary>
+        /// <returns></returns>
+        public ActionResult Text()
+        {
+            var fileInfo = GetParameters(Request);
+            return File(Encoding.Unicode.GetBytes(fileInfo.Content), "text/plain", fileInfo.Filename);
+        }
+
+        private DownloadInfo GetParameters(HttpRequestBase request)
+        {
+            if (request.Form["content"] == null)
+            {
+                throw new HttpException(400, "Content parameter is required.");
+            }
+
+            return new DownloadInfo
+                {
+                    Content = request.Form["content"],
+                    Filename = Request.Form["filename"] ?? "download.csv"
+                };
+        }
+
+        private struct DownloadInfo
+        {
+            public string Content;
+            public string Filename;
+        }
+    }
+}

--- a/src/GeositeFramework/GeositeFramework.csproj
+++ b/src/GeositeFramework/GeositeFramework.csproj
@@ -119,15 +119,18 @@
   <ItemGroup>
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Controllers\LogController.cs" />
+    <Compile Include="Controllers\DownloadController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\CsvHelper.cs" />
     <Compile Include="Helpers\PluginLoader.cs" />
     <Compile Include="Helpers\JsonDataPlugin.cs" />
     <Compile Include="Helpers\JsonData.cs" />
     <Compile Include="Helpers\JsonDataRegion.cs" />
     <Compile Include="Models\Geosite.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tests\DownloadTests.cs" />
     <Compile Include="Tests\PluginLoaderTests.cs" />
     <Compile Include="Tests\GeositeTests.cs" />
   </ItemGroup>

--- a/src/GeositeFramework/Helpers/CsvHelper.cs
+++ b/src/GeositeFramework/Helpers/CsvHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+
+namespace GeositeFramework.Helpers
+{
+    public class CsvHelper
+    {
+        /// <summary>
+        /// Takes valid JSON array and returns simple CSV representation of the data.
+        /// Leans on the fact that any escapable characters are already quoted within
+        /// the json as strings.
+        /// </summary>
+        /// <param name="json">String representation of an Array [file] of Arrays [rows]</param>
+        /// <returns></returns>
+        public static string JsonToCsv(string json)
+        {
+            var csvJson = JArray.Parse(json);
+            return csvJson.Aggregate("", (current, row) => current + ArrayToRow(row));
+        }
+
+        private static string ArrayToRow(IEnumerable<JToken> rowValues)
+        {
+            return String.Join(",", rowValues.Select(GetFormattedValue)) + Environment.NewLine;
+        }
+
+        private static string GetFormattedValue(JToken val)
+        {
+            var output = val.ToString();
+ 
+            if (val.Type == JTokenType.String)
+            {
+                // Replace quotes (") as escaped quotes ("")
+                var escaped = val.ToString().Replace("\"", "\"\"");
+
+                // All string are quoted 
+                output = String.Format("\"{0}\"", escaped);
+            }
+            return output;
+        }
+    }
+}

--- a/src/GeositeFramework/Tests/DownloadTests.cs
+++ b/src/GeositeFramework/Tests/DownloadTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using GeositeFramework.Helpers;
+using NUnit.Framework;
+
+namespace GeositeFramework.Tests
+{
+    public class DownloadTests
+    {
+        private const string jsonStrings = "[\"a\", \"b\", \"c\"]";
+        readonly string jsonStringsExpected = "\"a\",\"b\",\"c\"" + Environment.NewLine;
+
+        private const string jsonMixed = "[\"a\", \"b\", 33]";
+        readonly string jsonMixedExpected = "\"a\",\"b\",33" + Environment.NewLine;
+
+        private static string Wrap(String[] lines)
+        {
+            return "[" + String.Join(",", lines) + "]";
+        }
+
+        [Test]
+        public void TestStrings()
+        {
+            var result = CsvHelper.JsonToCsv(Wrap(new [] {jsonStrings}));
+            Assert.AreEqual(jsonStringsExpected, result, "Did not format string CSV correctly");
+        }
+
+        [Test]
+        public void TestMixed()
+        {
+            var result = CsvHelper.JsonToCsv(Wrap(new [] {jsonMixed}));
+            Assert.AreEqual(jsonMixedExpected, result, "Did not format mixed string and non-string CSV correctly");
+        }
+
+        [Test]
+        public void TestMultiline()
+        {
+            var result = CsvHelper.JsonToCsv(Wrap( new [] {jsonStrings, jsonMixed }));
+            var expected = jsonStringsExpected + jsonMixedExpected;
+            Assert.AreEqual(expected, result, "Did not format mixed multiline CSV correctly");
+        }
+
+        [Test]
+        public void TestEscaped()
+        {
+            var withQuotes = "[\"\\\"hi\\\", he said\",2,4]";
+            var escapedExpected = "\"\"\"hi\"\", he said\",2,4" + Environment.NewLine;
+            
+            var result = CsvHelper.JsonToCsv(Wrap(new [] {withQuotes}));
+            Assert.AreEqual(escapedExpected, result, "Did not escape quoted string CSV correctly");
+        }
+    }
+}


### PR DESCRIPTION
Plugins may generate and display data in their UI, but have needed an
option to be able to export that data.  This handler will echo back an
JSON array of arrays as a csv file, or for more complicated/custom
structures will also simply initiate a download of the posted text.
