### PR TITLE
Track inner exception to prevent compiler warning

### DIFF
--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -185,7 +185,7 @@ namespace GeositeFramework.Models
             catch (Exception e)
             {
                 const string msg = "Bad color config for key: `{0}`. Please use Hex (HTML) notation, ex. #FFCC66";
-                throw new Exception(String.Format(msg, key));
+                throw new Exception(String.Format(msg, key), e);
             }
         }
 


### PR DESCRIPTION
Creating the build scripts exposed a compiler warning.  Updated to include
the unused variable as the inner exception.

The compile portion of the build script lists warnings, so this reduces
the noise of the script a bit.
