### PR TITLE
Add launchpad configuration to config

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -134,7 +134,36 @@
         "identifyBlacklist": {
             "type": "array",
             "items": { "type": "string" }
-        }
+        },
+        "launchpad": {
+            "type": "object",
+            "required": false,
+            "properties": {
+                "showSubRegions": { "type": "boolean", "required": false },
+                "categories": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": { "type": "string" },
+                            "description": { "type": "string" },
+                            "issues": { 
+                                "type": "array", 
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": { "type": "string" },
+                                        "description": { "type": "string" },
+                                        "saveCode": { "type": "string" },
+                                        "faIcon": { "type": "string" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+		}
     },
     "additionalProperties": false
 }

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -12,7 +12,7 @@
                 { "text": "Cat", "url": "https://en.wikipedia.org/wiki/Cat" },
                 { "text": "Dog", "popup": true, "url": "https://en.wikipedia.org/wiki/Dog" },
                 { "text": "Fish", "url": "https://en.wikipedia.org/wiki/Fish" },
-                { "text": "Tour Again", "url": "javascript:;", "elementId": "help-overlay-start"},
+                { "text": "Tour Again", "url": "javascript:;", "elementId": "help-overlay-start"}
             ]
         },
         { "text": "Azavea", "url": "http://www.azavea.com/" },
@@ -82,5 +82,46 @@
         "primary": "#26648E",
         "secondary": "#26648E"
     },
-    "identifyBlacklist": ["OBJECTID", "OBJECTID_1"]
+    "identifyBlacklist": ["OBJECTID", "OBJECTID_1"],
+	"launchpad": {
+        "showSubRegions": true,
+        "categories": [
+          {
+            "name": "What's new?",
+            "description": "Lorem Ipsum",
+            "issues": [
+                { 
+                  "name": "Sea Rise",
+                  "description": "Lorem Ipsum",
+                  "saveCode": "e34df34rd3....3434",
+                  "faIcon": "fa-map"
+                },
+                { 
+                  "name": "Habitat",
+                  "description": "Lorem Ipsum",
+                  "saveCode": "e34df34rd3....3434",
+                  "faIcon": "fa-animal"
+                }
+              ]
+          },
+          {
+            "name": "Use Cases",
+            "description": "Lorem Ipsum",
+            "issues": [
+                { 
+                  "name": "Transportation",
+                  "description": "Lorem Ipsum",
+                  "saveCode": "e34df34rd3....3434",
+                  "faIcon": "fa-train"
+                },
+                { 
+                  "name": "Climate Change",
+                  "description": "Lorem Ipsum",
+                  "saveCode": "e34df34rd3....3434",
+                  "faIcon": "fa-ocean"
+                }
+              ]
+          }      
+        ]
+    }	
 }


### PR DESCRIPTION
The site admin can optionally create a configurable launchpad to show a
"get started" modal that specifies any subgeographies specific
categorized "issues" which are buttons that activate a specified "save
and share" state.

Fixes #292