### PR TITLE
Remove invalid plugins before app loads

### DIFF
--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -20,13 +20,20 @@
             });
         model.set('mapModel', mapModel);
 
+        initializeSubregionDisplays(mapModel, model);
+
+    }
+
+    function initializeSubregionDisplays(mapModel, pane)
+    {
         mapModel.on('subregion-activate', function(activeRegion) {
-            invokeOnPlugins(model, 'subregionActivated', [activeRegion]);
+            invokeOnPlugins(pane, 'subregionActivated', [activeRegion]);
         });
 
         mapModel.on('subregion-deactivate', function(deactivatedRegion) {
-            invokeOnPlugins(model, 'subregionDeactivated', [deactivatedRegion]);
+            invokeOnPlugins(pane, 'subregionDeactivated', [deactivatedRegion]);
         });
+        
     }
 
     function invokeOnPlugins(model, methodName, args) {
@@ -234,9 +241,16 @@
         // to the appropriate plugin section
         var $sidebar = view.$('.plugins'),
             $maptopbar = view.$('.top-tools'),
-            $mapbar = view.$('.tools');
+            $mapbar = view.$('.tools'),
+            regionData = view.model.get('regionData'),
+            plugins = view.model.get('plugins'),
+            invalidPlugins = plugins.reject(function(plugin) {
+                return plugin.get('pluginObject').validate(regionData);
+            });
 
-        view.model.get('plugins').each(function (plugin) {
+        plugins.remove(invalidPlugins);
+        
+        plugins.each(function (plugin) {
             var toolbarType = plugin.get('pluginObject').toolbarType;
             if (toolbarType === 'sidebar') {
                 new N.views.SidebarPlugin({

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -49,6 +49,7 @@ define(["dojo/_base/declare",
             setState: function () {},
             subregionActivated: function() {},
             subregionDeactivated: function() {},
+            validate: function () { return true; },
 
             // Called when switching from infographic to the primary view or vice versa.
             onContainerVisibilityChanged: function (visible) {},

--- a/src/GeositeFramework/plugins/subregion_toggle/main.js
+++ b/src/GeositeFramework/plugins/subregion_toggle/main.js
@@ -23,6 +23,11 @@ define(
             activate: function () {
                 var mapId = this.map.getMapId();
                 this.app.dispatcher.trigger('subregion-toggle:toggle', mapId);
+            },
+            
+            validate: function(regionData) {
+                // This plugin is only valid if there are subregions present in the config
+                return !!regionData.subregions;
             }
         });
     }


### PR DESCRIPTION
Perform custom validation checks on plugins before loading them.
Currently, the only invalide plugin would be the toggle-subregion plugin
when there are no subregions defined, but more could be added.

Fixes #302