### PR TITLE
Add subregion header

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -158,13 +158,15 @@
         </div>
         <div class="map-outer">
             <div id="map-<%= paneNumber %>" class="map">
-                <div class="top-tools"></div>
-                <div class="tools"></div>
-                <div class="basemap-selector">
-                    <div class="basemap-selector-title"></div>
-                    <div class="basemap-selector-list">
-                        <ul>
-                        </ul>
+                <div class="control-container">
+                    <div class="top-tools"></div>
+                    <div class="tools"></div>
+                    <div class="basemap-selector">
+                        <div class="basemap-selector-title"></div>
+                        <div class="basemap-selector-list">
+                            <ul>
+                            </ul>
+                        </div>
                     </div>
                 </div>
                 <div id="legend-container-<%= paneNumber %>" class="legend">
@@ -369,6 +371,13 @@
               <% }); %>
             </div>
           <% }); %>
+        </div>
+    </script>
+
+    <script type="text/template" id="template-subregion">
+        <div class="subregion-header">
+            <p>You are currently in <%= display %></p>
+            <p class="leave"><a href="javascript:void(0);"><i class="fa fa-times-circle"></i>Leave Region</a></p>
         </div>
     </script>
 

--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -121,6 +121,14 @@ input.code-like, textarea.code-like {
         line-height: 45px !important;
     }
 
+.control-container {
+    position: absolute;
+    width: 100%;
+}
+    .control-container.subregion-active {
+        top: 40px;
+    }
+
 /* -----------------------------------------
    Content Area - Helpers
 ----------------------------------------- */
@@ -417,6 +425,9 @@ input.code-like, textarea.code-like {
             }
             .esriSimpleSlider div {
                 width: 32px;
+            }
+            .esriSimpleSlider.subregion-active {
+                top: 103px !important;
             }
             
         .content .map .basemap-selector {
@@ -774,7 +785,7 @@ body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide_left:after {
     display: none;
 }
 /* ----------------------------------------
-    Subregion Tooltip
+    Subregions
 ------------------------------------------- */
 .subregion-tooltip.esriPopup .titlePane, .subregion-tooltip.esriPopup .actionsPane { 
     display: none;
@@ -798,3 +809,26 @@ body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide_left:after {
 .subregion-tooltip.esriPopup .pointer {
     background-color: #444;
 }
+
+.subregion-header {
+    z-index: 10;
+    width: 100%;
+    position: absolute;
+    height: 50px;
+    background-color: rgba(194, 32, 32, 0.5);
+}
+    .subregion-header p {
+        color: #fff;
+        opacity: 1.0;
+        padding: 15px;
+        display: inline-block;
+    }
+
+    .subregion-header .leave {
+        float: right;
+        width: 200px;
+    }
+
+    .subregion-header a, a.visited, a.link, a.active {
+        color: #fff;
+    }

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -27,13 +27,13 @@
     function initializeSubregionDisplays(mapModel, pane)
     {
         mapModel.on('subregion-activate', function(activeRegion) {
-            invokeOnPlugins(pane, 'subregionActivated', [activeRegion]);
+            invokeOnPlugins(pane, 'subregionActivated', [activeRegion, pane]);
             invokeOnPlugins(pane, 'hibernate', [activeRegion]);
             setSidebarPluginVisibility(pane, activeRegion.availablePlugins);
         });
 
         mapModel.on('subregion-deactivate', function(deactivatedRegion) {
-            invokeOnPlugins(pane, 'subregionDeactivated', [deactivatedRegion]);
+            invokeOnPlugins(pane, 'subregionDeactivated', [deactivatedRegion, pane]);
             showAllSidebarPlugins(pane);
         });
     }

--- a/src/GeositeFramework/plugins/subregion_toggle/main.js
+++ b/src/GeositeFramework/plugins/subregion_toggle/main.js
@@ -17,7 +17,7 @@ define(
             },
 
             renderLauncher: function () {
-                return '<div class="subregion-toggle"></div>';
+                return '<div class="' + this.getClassName() + '"></div>';
             },
 
             activate: function () {
@@ -28,7 +28,20 @@ define(
             validate: function(regionData) {
                 // This plugin is only valid if there are subregions present in the config
                 return !!regionData.subregions;
+            },
+
+            getClassName: function() {
+                return 'subregion-toggle';
+            },
+
+            subregionActivated: function(subregion, pane) {
+                $('#map-' + pane.get('paneNumber')).find('.' + this.getClassName()).hide();
+            },
+
+            subregionDeactivated: function(subregion, pane) {
+                $('#map-' + pane.get('paneNumber')).find('.' + this.getClassName()).show();
             }
+
         });
     }
 );

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -30,7 +30,7 @@
         "color": "#00C5CD",
         "opacity": 0.2,
         "clickToFocus": true,
-        "hideByDefault": true,
+        "hideByDefault": false,
         "areas": [
             {
                 "id": "flower-garden",


### PR DESCRIPTION
Show the subregion header when a subregion is active. Also hide the subregion toggle button when a subregion is active.

Some things to test:

- Enter a subregion. The header should appear, and the subregion toggle button will disappear. Leave the subregion via the leave button in the header.
- Enter and leave a subregion with two maps open. Entering a subregion on one map should not effect the other map.
- Enter a subregion on one map, switch to the other map, open a subregion on that map, then switch back to the first map. The subregion status should be preserved on the first map.
- Drag the map from the initial position, then enter a subregion. When you leave the subregion, you should be back in the position you left the map in before entering the subregion.