### PR TITLE
Reorder plugins + just use URL hash for long permalink field.

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -352,8 +352,8 @@
                   <label>Embed Height (px)
                     <input type="number" class="embed-size height" value="<%= height %>" /></label>
                   <em>
-                    <label>Need the unshortened permalink? <a href="javascript:void(0);" class="show-long-permalink">Get it here.</a>
-                      <input class="code-like" id="long-permalink-textbox" type="text" value="<%= url %>"/>
+                    <label>Need the save code for this map? <a href="javascript:void(0);" class="show-long-permalink">Get it here.</a>
+                      <input class="code-like" id="long-permalink-textbox" type="text" value="<%= hash %>"/>
                     </label>
                   </em>
                 </div>

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -72,9 +72,9 @@
         "layer_selector",
         "custom_layer_selector",
         "zoom_to",
-        "full_extent",
         "measure",
         "legend_display",
+        "full_extent",
         "subregion_toggle"
     ],
     "print": {


### PR DESCRIPTION
- The subregion toggle and full extent button should be next to each other.
- The base url should no longer be displayed in the long permalink field of the save and share modal.