### PR TITLE
Add "Free Explore" button to launchpad

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -380,6 +380,7 @@
                         </div>
                         <div class="thumbs">
                             <ul>
+                                <li class="free-explore"><i class="fa fa-globe"></i><label>Explore the map</label>
                                 <% _.each(subregions.areas, function(subregion) { %>
                                 <li class="subregion" data-subregion-id="<%= subregion.id %>"><i class="fa fa-map-marker"></i><label><%= subregion.display %></label></li>
                                 <% }); %>

--- a/src/GeositeFramework/Web.config
+++ b/src/GeositeFramework/Web.config
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <!--
   For more information on how to configure your ASP.NET application, please visit
   http://go.microsoft.com/fwlink/?LinkId=169433

--- a/src/GeositeFramework/js/Launchpad.js
+++ b/src/GeositeFramework/js/Launchpad.js
@@ -35,6 +35,7 @@ require(['use!Geosite'], function (N) {
         },
 
         events: {
+            'click .free-explore': 'freeExplore',
             'click .subregion': 'activateSubRegion',
             'click .lp-issue-btn': 'activateScenario'
         },
@@ -91,12 +92,20 @@ require(['use!Geosite'], function (N) {
                 this.activateLaunchpadEvent('launchpad:activate-scenario', saveCode);
             }
         },
+
+        freeExplore: function() {
+            this.activateLaunchpadEvent('launchpad:deactivate-subregion');
+            this.activateLaunchpadEvent('launchpad:free-explore');
+        },
         
         activateLaunchpadEvent: function(eventName, eventData) {
+            this.close();
+            N.app.dispatcher.trigger(eventName, eventData);
+        },
+
+        close: function() {
             this.remove();
             TINY.box.hide();
-            N.app.dispatcher.trigger(eventName, eventData);
-            
         }
     });
 

--- a/src/GeositeFramework/js/Launchpad.js
+++ b/src/GeositeFramework/js/Launchpad.js
@@ -28,6 +28,7 @@ require(['use!Geosite'], function (N) {
     N.views.Launchpad = Backbone.View.extend({
         initialize: function () {
             this.template = N.app.templates['template-launchpad'];
+            this.initialExtent = parseExtent(N.app.data.region.initialExtent);
 
             if (this.model.get('showByDefault')) {
                 this.render();
@@ -95,7 +96,9 @@ require(['use!Geosite'], function (N) {
 
         freeExplore: function() {
             this.activateLaunchpadEvent('launchpad:deactivate-subregion');
-            this.activateLaunchpadEvent('launchpad:free-explore');
+            this.activateLaunchpadEvent('launchpad:free-explore', {
+                extent: this.initialExtent
+            });
         },
         
         activateLaunchpadEvent: function(eventName, eventData) {
@@ -161,6 +164,16 @@ require(['use!Geosite'], function (N) {
 
            return N.app.hashModels.encodeStateObject(modifiedState);
         }
+    }
+
+    function parseExtent(extent) {
+        var x = N.app.data.region.initialExtent,
+            extent = new esri.geometry.Extent(
+                x[0], x[1], x[2], x[3],
+                new esri.SpatialReference({ wkid: 4326 /*lat-long*/ })
+            );
+
+        return extent;
     }
 
     // Get the pane number of the saved state.

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -79,11 +79,7 @@ require(['use!Geosite',
     function initialize(view) {
         view.model.on('change:selectedBasemapIndex', function () { selectBasemap(view); });
         view.model.on('change:extent',               function () { loadExtent(view); });
-        N.app.dispatcher.on('launchpad:free-explore', function () {
-            if (N.app.models.screen.get('mainPaneNumber') === view.model.get('mapNumber')) {
-                loadExtent(view);
-            }
-        });
+        N.app.dispatcher.on('launchpad:free-explore', function (e) { freeExplore(e, view); });
 
         // Configure the esri proxy, for (at least) 2 cases:
         // 1) For WMS "GetCapabilities" requests
@@ -92,6 +88,7 @@ require(['use!Geosite',
 
         createMap(view);
     }
+
 
     function createMap(view) {
         var esriMap = new esri.Map(view.$el.attr('id')),
@@ -156,6 +153,12 @@ require(['use!Geosite',
                 if (esriMap.loaded) esriMap.onLoad(esriMap);
             }
         }, 2500);
+    }
+
+    function freeExplore(e, view) {
+        if (N.app.models.screen.get('mainPaneNumber') === view.model.get('mapNumber')) {
+            view.esriMap.setExtent(e.extent);
+        }
     }
 
     function loadExtent(view) {

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -79,6 +79,11 @@ require(['use!Geosite',
     function initialize(view) {
         view.model.on('change:selectedBasemapIndex', function () { selectBasemap(view); });
         view.model.on('change:extent',               function () { loadExtent(view); });
+        N.app.dispatcher.on('launchpad:free-explore', function () {
+            if (N.app.models.screen.get('mainPaneNumber') === view.model.get('mapNumber')) {
+                loadExtent(view);
+            }
+        });
 
         // Configure the esri proxy, for (at least) 2 cases:
         // 1) For WMS "GetCapabilities" requests

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -89,7 +89,6 @@ require(['use!Geosite',
         createMap(view);
     }
 
-
     function createMap(view) {
         var esriMap = new esri.Map(view.$el.attr('id')),
             resizeMap = _.debounce(function () {

--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -76,7 +76,7 @@
 
     N.controllers.SubRegion.prototype.initializeSubregion = function(subRegionId, Polygon) {
         var subRegionGraphic = getSubRegionById(subRegionId, this.subRegionLayer);
-        activateSubRegion(this, subRegionGraphic, Polygon);
+        this.activateSubRegion(subRegionGraphic, Polygon);
     };
 
     N.controllers.SubRegion.prototype.activateSubRegion = function(subRegionGraphic, Polygon) {
@@ -218,7 +218,7 @@
                     deactivateSubRegion,
                     subRegionManager,
                     extentOnExit
-                )
+                ),
             });
 
         $mapContainer.prepend(subRegionHeader.render().$el);
@@ -237,6 +237,8 @@
                '.control-container',
                '.esriSimpleSlider'
             ];
+            this.listenTo(N.app.dispatcher, 'launchpad:deactivate-subregion',
+                _.bind(this.deactivateSubregion, this));
         },
 
         events: {
@@ -270,8 +272,16 @@
             this.subRegionManager.initializeSubregion(e.target.value, Polygon);
         },
 
+        deactivateSubregion: function() {
+            if ('map-' + N.app.models.screen.get('mainPaneNumber')
+                    === this.subRegionManager.map.id) {
+                this.close();
+            }
+        },
+
         close: function (resetCurrentRegionId) {
             this.remove();
+            this.stopListening();
             this.toggleMapControlPositions();
 
             var oldRegion = _.findWhere(this.model.attributes.subregions,

--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -48,7 +48,7 @@
 
         N.app.dispatcher.on('launchpad:activate-subregion', function (e) {
             // Going to a subregion from the launchpad should only effect
-            // the first map.
+            // the active map or the first map in split screen view.
             var activeMapId = 'map-' + N.app.models.screen.get('mainPaneNumber');
             if (self.map.id === activeMapId) {
                 self.initializeSubregion(e.id, Polygon);

--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -218,7 +218,7 @@
                     deactivateSubRegion,
                     subRegionManager,
                     extentOnExit
-                ),
+                )
             });
 
         $mapContainer.prepend(subRegionHeader.render().$el);
@@ -273,8 +273,8 @@
         },
 
         deactivateSubregion: function() {
-            if ('map-' + N.app.models.screen.get('mainPaneNumber')
-                    === this.subRegionManager.map.id) {
+            if ('map-' + N.app.models.screen.get('mainPaneNumber') ===
+                    this.subRegionManager.map.id) {
                 this.close();
             }
         },


### PR DESCRIPTION
* Add a button to the launchpad that allows the user to close
the launchpad without activating a subregion or issue.
* If a subregion is active, pressing the button deactivates the
subregion and resets the map to the initial view.
* If no subregion is activate, but the map was moved from the
initial view, pressing the button resets the map to the
initial view.
* Pressing the button only effects the active map or the first
map in split screen view.