### PR TITLE
Activate subregion specified in saveCode

### DIFF
--- a/src/GeositeFramework/js/Screen.js
+++ b/src/GeositeFramework/js/Screen.js
@@ -99,7 +99,7 @@
 
             N.app.hashModels.addModel(pane, {
                 id: 'pane' + pane.get('paneNumber').toString(),
-                attributes: ['paneNumber', 'stateOfPlugins']
+                attributes: ['paneNumber', 'stateOfPlugins', 'activeSubregion']
             });
 
 

--- a/src/GeositeFramework/plugins/layer_selector/main.js
+++ b/src/GeositeFramework/plugins/layer_selector/main.js
@@ -113,6 +113,10 @@ define([
             },
 
             clearAll: function () {
+                if (! this._ui.isRendered()) {
+                    return;
+                }
+
                 this._layerManager.hideAllLayers(this.map);
                 this._ui.uncheckAndCollapse();
                 this._currentState = {};

--- a/src/GeositeFramework/plugins/layer_selector/ui.js
+++ b/src/GeositeFramework/plugins/layer_selector/ui.js
@@ -15,6 +15,7 @@ define(["jquery", "use!underscore", "use!extjs", "./treeFilter"],
                 _tree = null,
                 _justClickedItemIcon = false,
                 _justClickedZoomIcon = false,
+                _isRendered = false,
 
                 renderExtTree;
 
@@ -35,8 +36,13 @@ define(["jquery", "use!underscore", "use!extjs", "./treeFilter"],
                 _tree.on("itemclick", onItemClick, this);
                 removeSpinner();
                 renderUi();
+                _isRendered = true;
                 this.display();
             };
+
+            this.isRendered = function() {
+                return _isRendered;
+            }
 
             this.display = function () {
                 renderExtTree();
@@ -73,7 +79,7 @@ define(["jquery", "use!underscore", "use!extjs", "./treeFilter"],
             };
 
             this.onContainerSizeChanged = function (dx, dy) {
-                // The ExtJS TreePanel can't be sized to fit its widest element, 
+                // The ExtJS TreePanel can't /be sized to fit its widest element, 
                 // nor can you discover those widths programatically.
                 // So we let users reveal more by resizing the container,
                 // setting here the tree panel width to the container's width.

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -118,15 +118,15 @@
                       "faIcon": "fa fa-leaf"
                     },
                     {
-                      "name": "Habitat",
+                      "name": "Galveston",
                       "description": "Lorem Ipsum",
-                      "saveCode": "e34df34rd3....3434",
+                      "saveCode": "eyJwYW5lMCI6xIDEgsSETnVtYmVyxIcwLCJzdGF0ZU9mUGx1Z2luc8SHxIBzZWxlY8SZZMSdxJ/EocSHbnVsbMSUcMSexKDEosSkfX3ElGHEqml2ZVN1YnJlxKBvbsSkImlkxIciZ2FsxYHElsWJIsSUZGlzxLZhecWPR8WSxZR0xYkgQsWdxZciZGXEl2lsxKM6IsWoc2hhcGXEh1tbLTk1LjI3MzQzNzUsMjkuOTjGgTg2NzE4NDc0Njk0XSzFusW8LjA0ODIxN8aixoHGg8aFxocuM8afxqE1MMaEMTQ1xofGmMaaxb3GlDAyMMasNzgxMsamOMaJNzkzxr0wM8aOMjLGlMazxbvFvTE2MzXGk8agOMaExobHgDg1OTHGrceSxoPGgMeMxpbFvsaQx5bGp8asNjU0xpY0xb84xo3GkMehNC44Oce1xrfGpMeWMzAux480xr3HkMaCx4/HnDk3x6HFvcW/x7jGpsaIxorGjMaOxpDGksaUxpZdxpgiY29sb8SRxbAjZmYwMDjEhsS7xJRtxbXEhsSIImV4xJludMWLdHnFtsWPyKrIrMiuxJR4bcSvOi3HnMaTxoTGnS7Hgjkwx6jHiTPElHnIucWKOjMzxqAyx4THs8eZxoAxNTbGjci3yKV4xIfIvMeGxo7GsMaIx7Q0yIE1MTHJiMmaxIfHkTbFvzcyx7PFvMmmMjYwxbzElMWbxJhpxZJSZWbEkGVuY8W3yKh3a8WNxIfHnMagyJ/Io8SVxKfEqcSrxabEpsilcEluxarJmzowxLs=",
                       "faIcon": "fa fa-leaf"
                     },
                     {
-                      "name": "Sea Rise",
+                      "name": "Flower Garden Hazard",
                       "description": "Lorem Ipsum",
-                      "saveCode": "e34df34rd3....3434",
+                      "saveCode": "eyJwYW5lMCI6xIDEgsSETnVtYmVyxIcwLCJzdGF0ZU9mUGx1Z2luc8SHxIBzZWxlY8SZZMSdxJ/EocSHxIHEnsSgxKIvbGF5xJBfxKbEqMSqb8SRxJRhxKppdmVTdWJyZcSgb27EpCJpZMSwZmxvd8SQLWdhcmRlxY3ElGRpc3DEtnnEsEbFlMWWciBHxZrFnG4gQsSDa3MgTcWaxKFlIFPEg8SqdcWaxaXFn2XEl2lsxKM6IlRoxblzxbx0xb5yeSBwcm/EmcSqxbRhxpLGlGR1xYLFhC7GoCLElHNoYXBlxIdbWy05NC43OTAwM8axNjI1LDI3xq84MDc3MTY0MzM0ODE5Nl0sxqvGrcavxrHGs8a1xrfGuTguNDk3NjYwODMyx4nHhTcyx4vHjTPGrzLHgzY1MseFMzfGuDLHlceXx5nHm8edx582x6HHo8eMxqzHpseix6nHq8etx6/Guca7N8a9xr/HgceDx4XHh8eJx6TGrMauxrDGssa0MMa2x7DIhMiGx4DHgseEx4bHiMeKx4siYXZhxoRhYsSoxK3Es8aGWyLFpMS5xLvEqXTEviJdfcSUxaPErsSixY7ItsioxLXEt8itxKfIr8ixxIgixpTGlS9Db2HElmFsIFJlc8aEacWdY8W5KE7EmGnFjMmLKS9Tb2NpyYsgxINkIEVjxYxvbWljxY5vxILJoHTFpTowxq/GuCJjxopja2XFkTpmyYvEpsSUdsWhacilxYXEkMqEyZTIqcqAxoVlLMqNyoLKkWXIs8SUyYR0yYbJiMmKyYzJjsmQbMmSbsmUIMmWyZjJmmzJnMmHyYnEl8mMSGF6xa3GhsSAya/FgWnJssSSLsm3ybnEqcm8yb50cnXKjyLKhMmQyodMyL1ySWTIqTDKlcmDb8mFyqnKm8mNyY/JkcmTyZXJl3TJmW7Jmy/Jp8S+xYrLmsaYbsmlUMaUyoTKocmPya7JsMq1ybPJtcq5ybrKvMSHypN9y7TItMifxp7FhcWHxYnFi8WNyYLFkMWSxajFl8WZxZvFncaiIsWgxaLFpMWmzIHFqsWszITFr8WxbsWzxbXFt8SExbrGjcaPxoDMh8aCyKLGhcSwxonGi8yYxb/GmsaVyK/GmMykxpzLuMagLsyGxqTGpsaoOsaqyI7Hj8iRx5LIlca8xr7ImMiJyJvIjMe7x47IkMeRyJPHk8exx5bHmMeax5zHnsegNMeiyI05x73HqDPHqsesx4PIgs2Ex7PNh8e2zYrNjMy+zY/Hv82Tx67Mt8iFzLnIiMiayIvHisy+yI/HkMiSyJTIg8y4yIfImciKyJxdyJ7IoMydyKTIpsSyxKHIqciry4fEusi/xL3Ekcizy7ZtxqbEhsmCZXjEmW50xY7JssanxLDOiM6KzozElHjJq8u9LTHGvjY5NTHHlceax54xMTMxxJR5zpbEh86kzpw0zYvGvDY3x67Gus6szpTOhHjEh86YxrM4xq3OsMm2ODXGvzU5OM6mzrXOqceDMcawMS7GvsiLx5fGtzbGo8SCy5nJi8mOZsSQy5bFjndry786zpkyzpnEk828xJnEllfPm8m+M86+N8u2X8SCcnTIqcSAzpHFnc6MyYLOjsywIs+yzovMhs6VxK86zrjHmc6czp4uzqDPn86jzqUizqfPvc6qNc6syJbOr86xN86zIs6VYc62z77Omc+ozrvHvTXPqcevz4LPhNCVz4bOpM+Jz4vIhceIz441z5DElc+SyaFsz5XPl8uoz5nPpsSHz57PoMSUxLbPo3TPpc+cz6jOv8u0xJRmcmFtZcuJy4vIs8uNyK7Eqsm9xbHEps6EcEnLo86IxIcyy7Q=",
                       "faIcon": "fa fa-leaf"
                     },
                     {


### PR DESCRIPTION
For scenarios and saved states, pass along the active subregion if one is
specified to the framework and to the plugins.

There are some persistant issues with the layer_selector plugin relating
to #314

Fixes #315