### PR TITLE
Fix issue with two plugin windows active at once.

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -211,8 +211,15 @@ require(['use!Geosite',
             var model = view.model;
             view.render();
             model.on('selected deselected', function () {
-                view.render();
-                model.onSelectedChanged();
+                // Pushing this to the end of the call stack
+                // fixes an issue that caused the layer selector
+                // to not be handled properly as part of a picky
+                // collection until all it's layers were loaded.
+                // See #288
+                _.defer(function() {
+                    view.render();
+                    model.onSelectedChanged();
+                });
             });
             model.on('change:active', function () {
                 view.render();


### PR DESCRIPTION
This fixes the following scenario:

When the map first loaded, if the user activated the layer selector,
and then activated another plugin, and the layer selector was still
retrieving layers, the layer selector window would not close when
the other plugin was activated. Likewise, if a user activated
a different plugin when the map first loaded, then activated
the layer selector plugin, the first plugin window would not be
closed and the layer selector plugin window would open.

Once all of the layer selectors layers were retrieved, the plugins
would behave normally, i.e. activating one plugin would close any
other active plugin window.

It's not totally clear why this was happening, but it maybe has
something to do with the backbone.picky collection select method not
recognizing that the layer selector was selected if it was selected
when it was still loading.

Deferring the running of the event handler functions until after the
current call stack cleared fixes the issue.

Closes #288