### PR TITLE
Add border to map when subregion is active.

### DIFF
--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -948,4 +948,14 @@ body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide_left:after {
 
     .subregion-header a, a.visited, a.link, a.active {
         color: #fff;
-    } 
+    }
+
+.subregion-border-box {
+    position: absolute;
+    width: 100%;
+    z-index: 1;
+    border: solid 3px rgba(194, 32, 32, 0.5);
+    border-top: none;
+    top: 50px;
+    bottom: 0px;
+}

--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -255,6 +255,7 @@
 
         render: function () {
             this.toggleMapControlPositions();
+            this.toggleMapBorder();
             this.$el.html(this.template(this.model.attributes));
             return this;
         },
@@ -269,6 +270,20 @@
                     $control.addClass('subregion-active');
                 }
             }, this);
+        },
+
+        toggleMapBorder: function () {
+            var mapContainer = this.subRegionManager.map.__container,
+                className = 'subregion-border-box',
+                $borderBox = $(mapContainer).find('.' + className);
+
+            if ($borderBox.length) {
+                $borderBox.remove();
+            } else {
+                $('<div/>', {
+                    'class': className
+                }).prependTo(mapContainer);
+            }
         },
 
         activateSubregion: function(e) {
@@ -290,6 +305,7 @@
             this.remove();
             this.stopListening();
             this.toggleMapControlPositions();
+            this.toggleMapBorder();
 
             var oldRegion = _.findWhere(this.model.attributes.subregions,
                 { id: this.model.attributes.selectedId });


### PR DESCRIPTION
* Per the wireframes, there should be a border around the map
when a subregion is active that matches the color of the
subregion header.

Closes #335