### PR TITLE
Don't show the launchpad on init for permalinks.

### DIFF
--- a/src/GeositeFramework/js/App.js
+++ b/src/GeositeFramework/js/App.js
@@ -19,6 +19,11 @@
             N.app.data.region = regionData;
             N.plugins = pluginClasses;
 
+            N.app.loadedWithState = false;
+            if (location.hash !== '') {
+                N.app.loadedWithState = true;
+            }
+
             // Set up the google url shortener service
             gapi.client.load('urlshortener', 'v1');
             if (regionData.googleUrlShortenerApiKey) {

--- a/src/GeositeFramework/js/Launchpad.js
+++ b/src/GeositeFramework/js/Launchpad.js
@@ -30,7 +30,7 @@ require(['use!Geosite'], function (N) {
             this.template = N.app.templates['template-launchpad'];
             this.initialExtent = parseExtent(N.app.data.region.initialExtent);
 
-            if (this.model.get('showByDefault')) {
+            if (this.model.get('showByDefault') && N.app.loadedWithState === false) {
                 this.render();
             }
         },


### PR DESCRIPTION
If the user came to the page through a URL that has
a hash, i.e. application state, don't show the launchpad
on initalization even if the showByDefault launchpad
config setting is set to true.

The presumption is that if the user was given a permalink,
the person who shared the link wants the user to go right
to the map, and not clear out that saved state by clicking
on an issue on the launchpad.

Closes #333