### PR TITLE
Target correct map on subregion init from savecode

### DIFF
--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -133,12 +133,15 @@
 
         // Drop the plugin state setting until after the stack clears to prevent errors when the
         // map is not in a ready state.
-        setTimeout(function() {
-            var activeSubregion = pane.get('activeSubregion');
+        _.defer(function() {
+            var activeSubregion = pane.get('activeSubregion'),
+                mapNumber = pane.get('mapModel').get('mapNumber');
+
             if (activeSubregion) {
                 N.app.dispatcher.trigger('launchpad:activate-subregion', { 
                     id: activeSubregion.id,
-                    preventZoom: true
+                    preventZoom: true,
+                    mapNumber: mapNumber
                 });
             }
 
@@ -151,7 +154,7 @@
                 }
 
             });
-        }, 0);
+        });
     }
 
     N.models = N.models || {};

--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -46,12 +46,22 @@
             toggleSubRegions(e, self.map.id, self.subRegionLayer);
         });
 
-        N.app.dispatcher.on('launchpad:activate-subregion', function (e) {
+        N.app.dispatcher.on('launchpad:activate-subregion', function(e) {
             // Going to a subregion from the launchpad should only effect
-            // the active map or the first map in split screen view.
-            var activeMapId = 'map-' + N.app.models.screen.get('mainPaneNumber');
-            if (self.map.id === activeMapId) {
-                self.initializeSubregion(e.id, Polygon, e.preventZoom);
+            // the active map or the first map in split screen view, unless
+            // the map id/number has been provided (in the case of launching
+            // the scenario). Then the subregion should be activated on the
+            // map the state designates.
+            if (e.mapNumber) {
+                var savedMapId = 'map-' + e.mapNumber;
+                if (self.map.id === savedMapId) {
+                    self.initializeSubregion(e.id, Polygon, e.preventZoom);
+                }
+            } else {
+                var activeMapId = 'map-' + N.app.models.screen.get('mainPaneNumber');
+                if (self.map.id === activeMapId) {
+                    self.initializeSubregion(e.id, Polygon, e.preventZoom);
+                }
             }
         });
         


### PR DESCRIPTION
* When using a permalink or loading a scenario with activate
subregions on both maps or the second map, reactivate the
subregion on the correct map(s).
* Swap setTimeout for defer which is slightly cleaner.

Closes #338