### PR TITLE
Remove unneeded call to stopPropagation

### DIFF
--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -122,11 +122,6 @@
                 callback(subRegionLayerAttributes);
             }
         });
-
-        // Prevent the map click from getting to the map, so no identify
-        if (event) {
-            event.stopPropagation();
-        }
     }
 
     function parseExtent(coords) {


### PR DESCRIPTION
* This was causing errors in IE and is no longer needed
since the function it is in is not directly called from
a click event.

Closes #342