### PR TITLE
Fix hiding of launchpad on init for IE.

### DIFF
--- a/src/GeositeFramework/js/App.js
+++ b/src/GeositeFramework/js/App.js
@@ -20,7 +20,7 @@
             N.plugins = pluginClasses;
 
             N.app.loadedWithState = false;
-            if (location.hash !== '') {
+            if (location.hash !== '' && location.hash !== '#') {
                 N.app.loadedWithState = true;
             }
 


### PR DESCRIPTION
* IE treats an empty hash differently than Chrome
and Firefox.