### PR TITLE
Fix subregion events

### DIFF
--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -101,7 +101,6 @@
             var oldRegion = _.findWhere(this.subregions.areas, { id: this.currentRegionId });
             // Use the full extent when exiting this subregion
             extentOnExit = this.initialExtent;
-            deactivateSubRegion(this, this.map.extent, oldRegion);
             if (this.currentHeader) {
                 this.currentHeader.close();
             }
@@ -292,17 +291,13 @@
         },
 
         activateSubregion: function(e) {
-            // Don't reset the current region id when activting a subregion
-            // when another is activated.  This is how we tell that the "last"
-            // extent should be the full extent, not this current regions extent
-            this.close(false);
             this.subRegionManager.initializeSubregion(e.target.value, Polygon);
         },
 
         deactivateSubregion: function() {
             if ('map-' + N.app.models.screen.get('mainPaneNumber') ===
                     this.subRegionManager.map.id) {
-                this.close();
+                this.close(true);
             }
         },
 
@@ -317,6 +312,9 @@
 
             this.deactivateFn(oldRegion);
 
+            // Don't reset the current region id when activting a subregion
+            // when another is activated.  This is how we tell that the "last"
+            // extent should be the full extent, not this current regions extent
             if (resetCurrentRegionId) {
                 this.subRegionManager.currentRegionId = null;
             }

--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -93,6 +93,7 @@
         var newRegionId = subRegionGraphic.attributes.id,
             extentOnExit = this.map.extent;
 
+        // Deactivate the current subregion if one is active
         if (this.currentRegionId) {
             if (this.currentRegionId === newRegionId) {
                 return;
@@ -101,6 +102,9 @@
             // Use the full extent when exiting this subregion
             extentOnExit = this.initialExtent;
             deactivateSubRegion(this, this.map.extent, oldRegion);
+            if (this.currentHeader) {
+                this.currentHeader.close();
+            }
         }
 
         this.currentRegionId = newRegionId;
@@ -120,10 +124,6 @@
         changeSubregionActivation(subRegionManager.deactivateCallbacks, subRegionLayerAttributes);
         subRegionManager.map.setExtent(mapExtent);
         subRegionManager.subRegionLayer.show();
-
-        if (subRegionManager.currentHeader) {
-            subRegionManager.currentHeader.remove();
-        }
     }
 
     function changeSubregionActivation(callbacks, subRegionLayerAttributes) {


### PR DESCRIPTION
See the commit messages for details.

A couple things to test:

- Activate a subregion from the launchpad. Open up the launchpad again, and select a different subregion.
Leave the subregion. Click on any of the subregions on the map. The subregion should activate
- Activate a subregion through any method. Switch subregions using the drop down menu. The map border and map elements should not be moved or removed.
- Activate a subregion. Open the launchpad. Select free explore. The subregion should exit. Click the same same subregion you just exited. The subregion should activate.

Try these things with multiple maps open and with map 2 as the active map.

Also, keep an eye on the console. The messages indicating subregion activation/deactivation should never be duplicated. The pattern should be enter > leave > enter > leave, etc.

Closes #353 