### PR TITLE
Stop subregion feature click from propagating.

### DIFF
--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -72,6 +72,8 @@
 
             self.subRegionLayer.on('click', function (e) {
                 self.activateSubRegion(e.graphic, Polygon);
+
+                e.stopPropagation();
             });
         };
     }


### PR DESCRIPTION
* Make sure the event does not propagate to the map
and trigger an identify point event.

Closes #352