### PR TITLE
Always refresh app state when launching scenarios.

### DIFF
--- a/src/GeositeFramework/js/App.js
+++ b/src/GeositeFramework/js/App.js
@@ -48,7 +48,8 @@
             });
 
             N.app.dispatcher.on('launchpad:activate-scenario', function(state) {
-                self.hashModels.triggerStateChange(state);
+                var forceHashChange = true;
+                self.hashModels.triggerStateChange(state, forceHashChange);
             });
 
             N.app.views.screen = new N.views.Screen({

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -107,7 +107,10 @@ require(['use!Geosite',
         view.esriMap = esriMap;
         loadExtent(view);
         selectBasemap(view);
-        
+
+        view.esriMap.on('extent-change', function() {
+           view.model.set('extent', view.esriMap.extent, { 'silent': true });
+        });
 
         // Wait for the map to load
         dojo.connect(esriMap, "onLoad", function () {

--- a/src/GeositeFramework/js/lib/backbone.hashmodels.js
+++ b/src/GeositeFramework/js/lib/backbone.hashmodels.js
@@ -287,10 +287,10 @@ Backbone.HashModels = (function(Backbone, _, $){
         }
     };
 
-    var handleHashChanged = function (hash) {
+    var handleHashChanged = function (hash, force) {
         var newState = {};
         var newStateString = '';
-        if (hash === stateString) {
+        if (hash === stateString && !force) {
             return;
         }
         if (hash) {
@@ -413,12 +413,11 @@ Backbone.HashModels = (function(Backbone, _, $){
                 state = _.extend(state, pendingState);
                 stateString = encodeStateObject(state);
             }
-            updateHash(stateString);
-            HashModels.trigger('change', stateString);
+            this.triggerStateChange(stateString);
         },
 
-        triggerStateChange: function(hash) {
-            handleHashChanged(hash);
+        triggerStateChange: function(stateString, force) {
+            handleHashChanged(stateString, force);
         },
 
         decodeStateObject: decodeStateObject,


### PR DESCRIPTION
* Turn off all plugins, reset the map extent and basemap,
and exit any active subregions when launching a scenario.
This prevents scenario states from bleeding into one
another. It also allows a user to reactivate the same
scenario no matter what actions were taken on the map
after the scenario was initially launched.

Closes #349, #356