### PR TITLE
Allow map plugins to be selectable in a subregion.

### DIFF
--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -124,6 +124,7 @@ input.code-like, textarea.code-like {
 .control-container {
     position: absolute;
     width: 100%;
+    z-index: 2;
 }
     .control-container.subregion-active {
         top: 40px;


### PR DESCRIPTION
* Layer the map plugins above the div element that is used to draw
the subregion border. Previously, they were under the div and
could not be selected.

Closes #361