### PR TITLE
Fix saving of map state

### DIFF
--- a/src/GeositeFramework/js/lib/backbone.hashmodels.js
+++ b/src/GeositeFramework/js/lib/backbone.hashmodels.js
@@ -413,7 +413,8 @@ Backbone.HashModels = (function(Backbone, _, $){
                 state = _.extend(state, pendingState);
                 stateString = encodeStateObject(state);
             }
-            this.triggerStateChange(stateString);
+            updateHash(stateString);
+            HashModels.trigger('change', stateString);
         },
 
         triggerStateChange: function(stateString, force) {


### PR DESCRIPTION
* It's important to directly call updateHash and trigger a change
event in update and not rely on handleHashChange since it may not fire
a change event if the hash did not change and force was not set to
true.

Fixes #375