### PR TITLE
Don't silence change event when updating extent

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -109,7 +109,7 @@ require(['use!Geosite',
         selectBasemap(view);
 
         view.esriMap.on('extent-change', function() {
-           view.model.set('extent', view.esriMap.extent, { 'silent': true });
+           view.model.set('extent', view.esriMap.extent);
         });
 
         // Wait for the map to load


### PR DESCRIPTION
* This caused the map extent to become stale. It was originally
thought that if the event wasn't silent, the map would get
stuck in an endless loop of saving the extent, firing a change
event, updating the map, then saving the extent, etc. However,
it appears that the ESRI map event 'extent-change' does not
get fired if the extent doesn't actually change.