### PR TITLE
Closes #390: Make the legend wider by default.

### DIFF
--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -589,7 +589,7 @@ input.code-like, textarea.code-like {
     position: absolute;
     bottom: 45px;
     right: 105px;
-    width: 180px;
+    width: 250px;
     height: 200px;
     z-index: 1;
     font-weight: bold;


### PR DESCRIPTION
* Most layers had their titles cut-off with the current
sizing.

Closes #390