### PR TITLE
Closes #393: Make the subregion row launchpad text configurable.

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -155,6 +155,7 @@
                     "title": { "type": "string", "required": true },
                     "description": { "type": "string", "required": true },
                     "showSubRegions": { "type": "boolean", "required": false },
+                    "subRegionDescription": { "type": "string", "required": false },
                     "showByDefault": { "type": "boolean", "required": false },
                     "categories": {
                         "type": "array",

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -374,12 +374,12 @@
                 <div class="row">
                     <p><%= description %></p>
                 </div>
-                <% if (showSubRegions) { %>
+                <% if (typeof(showSubRegions) !== "undefined" && showSubRegions) { %>
                 <div class="row">
                     <div class="well">
                         <div class="description">
                             <h3>Pick a Geography</h3>
-                            <p>Picking a Geography allows you to Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt</p>
+                            <p><% if (typeof(subRegionDescription) !== "undefined") { %> <%= subRegionDescription %> <% } %></p>
                         </div>
                         <div class="thumbs">
                             <ul>

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -96,6 +96,7 @@
             "title": "Getting Started",
             "description": "This is the launchpad description",
             "showSubRegions": true,
+            "subRegionDescription": "These are the subregions you can launch. Or you can just explore the map. It is up to you.",
             "showByDefault": true,
             "categories": [
               {


### PR DESCRIPTION
* Add an option to the region config file so users can specify
what text is displayed in the launchpad for the subregion row.
* Also fix an issue that prevented the app from loading if the
the key showSubRegions was missing from the region config file.

Closes #393