### PR TITLE
Closes #387: Call plugin resize method on continue.

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -525,6 +525,7 @@ require(['use!Geosite',
                     label: "Continue",
                     onClick: function() {
                         pluginModel.set('displayHelp', false);
+                        pluginObject.resize();
                     }
                 }, buttonnode);
             }


### PR DESCRIPTION
* When the continue button is clicked on an infographic, call
the resize method of the plugin. Most implementations of this
method expect two arguments indicating the new size of the
element. Since nothing was actually resized, it made sense
to me to pass nothing to the method.

Closes #387