### PR TITLE
Closes #388: Block plugins on second map and fix regression

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -114,6 +114,11 @@
             "type": "array",
             "items": {"type": "string"}
         },
+        "map2PluginBlacklist": {
+            "type": "array",
+            "items": {"type": "string"},
+            "required": false
+        },
         "print": {
             "type": "object",
             "properties": {

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -158,7 +158,9 @@
                     mapNumber: mapNumber
                 });
             } else {
-                N.app.dispatcher.trigger('launchpad:deactivate-subregion');
+                N.app.dispatcher.trigger('launchpad:deactivate-subregion', {
+                    mapNumber: mapNumber
+                });
             }
 
             pane.get('plugins').each(function(pluginModel) {

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -101,9 +101,16 @@
                     pluginSrcFolder: model.get('regionData').pluginFolderNames[i]
                 });
 
-            // Load plugin only if it passes a compliance check
+            // Load plugin only if it passes a compliance check ...
             if (plugin.isCompliant()) {
-                plugins.add(plugin);
+                // ... and if we're on map 2, and the plugin isn't on the blacklist
+                if (model.get('paneNumber') === 1) {
+                    if (getPluginMap2Availability(plugin.getId())) {
+                        plugins.add(plugin);
+                    }
+                } else {
+                    plugins.add(plugin);
+                }
             } else {
                 console.log('Plugin: Pane[' + model.get('paneNumber') + '] - ' + 
                     pluginObject.toolbarName +
@@ -112,6 +119,14 @@
         });
 
         model.set('plugins', plugins);
+    }
+
+    function getPluginMap2Availability(pluginId) {
+        if (_.indexOf(N.app.data.region.map2PluginBlacklist, pluginId) === -1) {
+            return true;
+        }
+
+        return false;
     }
 
     // initPlugins() is separate from createPlugins() because:

--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -259,8 +259,7 @@
                '.control-container',
                '.esriSimpleSlider'
             ];
-            this.listenTo(N.app.dispatcher, 'launchpad:deactivate-subregion',
-                _.bind(this.deactivateSubregion, this));
+            this.listenTo(N.app.dispatcher, 'launchpad:deactivate-subregion', this.deactivateSubregion);
         },
 
         events: {
@@ -305,9 +304,14 @@
             this.subRegionManager.initializeSubregion(e.target.value, Polygon);
         },
 
-        deactivateSubregion: function() {
-            if ('map-' + N.app.models.screen.get('mainPaneNumber') ===
-                    this.subRegionManager.map.id) {
+        deactivateSubregion: function(e) {
+            var viewMapPane = this.subRegionManager.map.id,
+                activeMapPane = 'map-' + N.app.models.screen.get('mainPaneNumber'),
+                eventMapPane = 'map-' + e.mapNumber;
+
+            // Only deactivate the subregion if this view is managing the active pane and
+            // the event was triggered for the pane that this view is managing.
+            if (activeMapPane === viewMapPane && eventMapPane === viewMapPane) {
                 this.close();
             }
         },

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -81,6 +81,9 @@
         "full_extent",
         "subregion_toggle"
     ],
+    "map2PluginBlacklist": [
+        "custom_layer_selector"
+    ],
     "print": {
         "printServerUrl": "http://lr13:6080/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
         "customPrintTemplatePrefix": "Letter ANSI A GeositeFramework"


### PR DESCRIPTION
* Add a new key to the region config file that allows users
to blacklist plugins from map 2
* Fixes a regression that caused subregions to be activated
then quickly deactivated if the subregion was launched from
a scenario and split screen mode was active/activated.