### PR TITLE
Hide subregion polygons at zoom level

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -69,6 +69,7 @@
             "type": "object",
             "required": false,
             "properties": {
+                "hideAtZoomLevel": {"type": "number", "required": false},
                 "color": {"type": "string", "required": false},
                 "outlineColor": {"type": "string", "required": false},
                 "opacity": {"type": "number", "required": false},

--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -14,6 +14,7 @@
         self.map = map;
         self.subregions = subregions;
         self.currentRegionId = null;
+        self.hasBeenToggledOff = subregions.hideByDefault;
 
         // List of functions to call when a sub-region is de/activated
         self.activateCallbacks = [];
@@ -44,6 +45,10 @@
         // Event fired from the subregion-toggle plugin on click
         N.app.dispatcher.on('subregion-toggle:toggle', function(e) {
             toggleSubRegions(e, self.map.id, self.subRegionLayer);
+            self.hasBeenToggledOff = !self.subRegionLayer.visible;
+            self.hasBeenToggledOnWhileHidden =
+                self.subRegionLayer.visible &&
+                self.map.getZoom() >= self.subregions.hideAtZoomLevel;
         });
 
         N.app.dispatcher.on('launchpad:activate-subregion', function(e) {
@@ -76,6 +81,16 @@
                 e.stopPropagation();
             });
         };
+
+        if (subregions.hideAtZoomLevel) {
+            map.on('zoom-end', function(e) {
+                if (e.level >= subregions.hideAtZoomLevel && !self.hasBeenToggledOnWhileHidden) {
+                    self.subRegionLayer.hide();
+                } else if (!self.hasBeenToggledOff) {
+                    self.subRegionLayer.show();
+                }
+            });
+        }
     }
 
     N.controllers.SubRegion.prototype.onActivated = function(callback) {

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -27,6 +27,7 @@
         31.653381399664
     ],
     "subregions": {
+        "hideAtZoomLevel": 8,
         "color": "#00C5CD",
         "outlineColor": "#008000",
         "opacity": 0.2,


### PR DESCRIPTION
Allow hiding the subregion shapes from the map when zooming in to a
customized zoom level.  Works sensibly with the toggle region plugin.

To test:
* Zoom in to level 8 and the polygons should disappear
* Zoom back out and they should reappear
* While visible, toggle them off
* Zoom in, stays off, zoom back out - still off
* If `hideByDefault` is set to true initially, zoom in and zoom out, still off.
* While zoomed in and non-visible, toggle back on - should stay visible while zooming below 8 still.

Phew.
Fixes #392 