### PR TITLE
Legend to be selectable after subregion launch

### DIFF
--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -595,7 +595,7 @@ input.code-like, textarea.code-like {
     right: 105px;
     width: 250px;
     height: 200px;
-    z-index: 1;
+    z-index: 2;
     font-weight: bold;
     background: #FFF;
     font-size: 12px;


### PR DESCRIPTION
The Subregion panel was overlaid on the legend prevent it from receiving
focus.

Fixes #372