### PR TITLE
Fix error on permalink mouseup

### DIFF
--- a/src/GeositeFramework/js/Permalink.js
+++ b/src/GeositeFramework/js/Permalink.js
@@ -80,7 +80,7 @@
 
                     $domElement.mouseup(
                         function() {
-                            _doSelect($domElement, box);
+                            view.selectText($domElement);
                         }
                     );
                 },


### PR DESCRIPTION
Call the new method which replaced _doSelect.  Correctly selects text now.

Fixes #409 