### PR TITLE
Always activate plugin when plugin is selected.

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -142,10 +142,7 @@ require(['use!Geosite',
                     }
 
                     this.set('active', true);
-
-                    if (!active) {
-                        this.get('pluginObject').activate();
-                    }
+                    this.get('pluginObject').activate();
                 } else {
                     this.get('pluginObject').deactivate();
                     this.trigger('plugin:deselected');


### PR DESCRIPTION
In an earlier attempt to decrease the number of events
and function calls related to activating the layer selector
and plugins in general, a check was added to see if a
plugin needed activation before activating it.

However, this did not account for plugins that are minimized
They are active when they are selected by the user, but still
need their activate function called when they are clicked.

Removing this check ensures that a plugin's activation function
is always called when it is selected.

Fixes #412