### PR TITLE
Add a google api key to allow url shortening

### DIFF
--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -1,4 +1,5 @@
 {
+    "googleUrlShortenerApiKey": "AIzaSyDd5hwYX4vAMLOH425cnMSq3gte98w4VFA",
     "titleMain": {
         "text": "Geosite Framework Sample",
         "url": "http://www.azavea.com/"


### PR DESCRIPTION
This was built in originally, but the usage limits claim you get 1M free
shortens a day, which seemed unlikely to be exceeded.  Adding this key
allows the shortener to work properly again.

Connects #407 