### PR TITLE
Add visibleSubLayerIds to layer selector

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector/layerConfigSchema.js
+++ b/src/GeositeFramework/plugins/layer_selector/layerConfigSchema.js
@@ -109,7 +109,8 @@ define(function () {
                 id: { type: 'integer' },
                 displayName: { type: 'string' },
                 parentLayerId: { type: 'integer' },
-                downloadUrl: { type: 'string' }
+                downloadUrl: { type: 'string' },
+				visibleSubLayerIds:  { type: 'array', items: { type: 'integer' } }
             }
         };
     }


### PR DESCRIPTION
Add functionality to show a group a layers in the tree as a single layer (intended to accommodate group layers in a service that represent a single layer but is using multiple scale dependent layers to do so; however can be used to group any arbitrary layers in a service).  Involves adding a visibleSubLayerIds property to the layer node that holds an array of layer indexes to be appended/removed from the visibleLayers array when checked/unchecked in the tree.