### PR TITLE
Add visibleSubLayerIds to layer selector; comment out deracinate node

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector/LayerManager.js
+++ b/src/GeositeFramework/plugins/layer_selector/LayerManager.js
@@ -214,6 +214,7 @@ define([
                     isNew: config ? config.isNew : undefined,
                     downloadUrl: config ? config.downloadUrl : undefined
                 };
+				if (_.has(config,"visibleSubLayerIds")) { node.visibleSubLayerIds = config.visibleSubLayerIds;  }
                 if (!parentNode.children) { parentNode.children = []; }
                 parentNode.children.push(node);
                 return node;

--- a/src/GeositeFramework/plugins/layer_selector/agsLoader.js
+++ b/src/GeositeFramework/plugins/layer_selector/agsLoader.js
@@ -305,6 +305,9 @@ define(["jquery", "use!underscore"],
                             if (_.has(layerConfig, "downloadUrl")) {
                                 layer.downloadUrl = layerConfig.downloadUrl;
                             }
+							if (_.has(layerConfig, "visibleSubLayerIds")) {
+                                layer.visibleSubLayerIds = layerConfig.visibleSubLayerIds;
+                            }
                             return layer;
                         });
                         loadLayers(layers, node);
@@ -325,16 +328,16 @@ define(["jquery", "use!underscore"],
                 _.each(layerSpecs, function (layerSpec) {
                     // A layer might specify a parent layer; otherwise it hangs off the service
                     var parentNode = (layerSpec.parentLayerId === -1 ? serviceNode : layerNodes[layerSpec.parentLayerId]);
-                    if (layerSpec.subLayerIds === null) {
-                        // This is an actual layer
+                    if (layerSpec.subLayerIds === null || _.has(layerSpec,"visibleSubLayerIds")) {
+                        // This is an actual layer or has visibleSubLayerIds and should be treated as an actual layer
                         var node = _makeLeafNode(layerSpec.name, layerSpec.id, showOrHideLayer, parentNode, layerSpec);
                         node.fetchMetadata = fetchMetadata;
                     } else {
                         // This is a layer group
-                        layerNodes[layerSpec.id] = _makeContainerNode(layerSpec.name, "layer-group", parentNode);
-                        layerNodes[layerSpec.id].checked = false;
-                        layerNodes[layerSpec.id].showOrHideLayer = showOrHideLayer;
-                        layerNodes[layerSpec.id].layerId = layerSpec.id;
+						layerNodes[layerSpec.id] = _makeContainerNode(layerSpec.name, "layer-group", parentNode);
+						layerNodes[layerSpec.id].checked = false;
+						layerNodes[layerSpec.id].showOrHideLayer = showOrHideLayer;
+						layerNodes[layerSpec.id].layerId = layerSpec.id;
 						layerNodes[layerSpec.id].fetchMetadata = fetchMetadata;
                     }
                 }, this);
@@ -662,6 +665,7 @@ define(["jquery", "use!underscore"],
                                 }
                             });
                         }
+						if (layerNode.visibleSubLayerIds) { layerIds = _.union(layerIds, layerNode.visibleSubLayerIds); }
                     } else {
                         //remove unchecked layer from the visible layers array
                         if (layerNode.type === "layer") {
@@ -672,6 +676,11 @@ define(["jquery", "use!underscore"],
                                 layerIds = _.without(layerIds, this.raw.layerId);
                             });
                         }
+						if (layerNode.visibleSubLayerIds) { 
+							_.each(layerNode.visibleSubLayerIds, function(subLayer) {
+								layerIds = _.without(layerIds, subLayer);
+							});
+						}
                     }
                     //set visible layers in the dynamic map service based on checked layerIds
                     if (layerIds.length === 0) {

--- a/src/GeositeFramework/plugins/layer_selector/layerConfigSchema.js
+++ b/src/GeositeFramework/plugins/layer_selector/layerConfigSchema.js
@@ -110,7 +110,7 @@ define(function () {
                 displayName: { type: 'string' },
                 parentLayerId: { type: 'integer' },
                 downloadUrl: { type: 'string' },
-				visibleSubLayerIds:  { type: 'array', items: { type: 'integer' } }
+				visibleSubLayerIds:  { type: 'array', items: { type: 'integer' } } 
             }
         };
     }

--- a/src/GeositeFramework/plugins/layer_selector/layerConfigSchema.js
+++ b/src/GeositeFramework/plugins/layer_selector/layerConfigSchema.js
@@ -109,7 +109,8 @@ define(function () {
                 id: { type: 'integer' },
                 displayName: { type: 'string' },
                 parentLayerId: { type: 'integer' },
-                downloadUrl: { type: 'string' }
+                downloadUrl: { type: 'string' },
+				visibleSubLayerIds:  { type: 'array', items: { type: 'integer' } }
             }
         };
     }

--- a/src/GeositeFramework/plugins/layer_selector/ui.js
+++ b/src/GeositeFramework/plugins/layer_selector/ui.js
@@ -114,11 +114,13 @@ define(["jquery", "use!underscore", "use!extjs", "./treeFilter"],
                   click into multiple generations of a tree to get to
                   the services they want to use.
                  */
-                if (rootNode.children && rootNode.children.length === 1) {
+                /* if (rootNode.children && rootNode.children.length === 1) {
                     return rootNode.children[0];
                 } else {
                     return rootNode;
-                }
+                } */
+				
+				return rootNode;
             }
 
             function addZoomButtons(node) {


### PR DESCRIPTION
1) visibleSubLayerIds: Add functionality to show a group a layers in the tree as a single layer (intended to accommodate group layers in a service that represent a single layer but is using multiple scale dependent layers to do so; however can be used to group any arbitrary layers in a service). Involves adding a visibleSubLayerIds property to the layer node that holds an array of layer indexes to be appended/removed from the visibleLayers array when checked/unchecked in the tree.

2) deracinate: Preferred behavior would be to force users to specify in the config that a node should be placed at the root of the tree as opposed to the framework automatically doing so; there are some edge cases where the automatic deracination is undesirable.  Specifying an empty string as the folder title in the config can emulate the same behavior and makes it more explicit and transparent for the config developer.