### PR TITLE
Hide all page content on print, with exceptions

### DIFF
--- a/src/GeositeFramework/GeositeFramework.csproj
+++ b/src/GeositeFramework/GeositeFramework.csproj
@@ -141,6 +141,7 @@
     <Content Include="css\jquery.dropdown.css" />
     <Content Include="css\jquery.mCustomScrollbar.css" />
     <Content Include="css\pageguide.min.css" />
+    <Content Include="css\print.css" />
     <Content Include="css\TinyBox2.css" />
     <Content Include="Error.html" />
     <Content Include="Error404.html" />

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -75,6 +75,7 @@
     <link rel="stylesheet" href="//js.arcgis.com/3.10/js/dojo/dojox/layout/resources/ResizeHandle.css">
     <link rel="stylesheet" href="//js.arcgis.com/3.11/esri/css/esri.css">
 
+    <link rel="stylesheet" href="css/print.css">
     <link rel="stylesheet" href="css/foundation.min.css">
     <link rel="stylesheet" href="css/TinyBox2.css">
     <link rel="stylesheet" href="css/jquery.mCustomScrollbar.css">

--- a/src/GeositeFramework/css/print.css
+++ b/src/GeositeFramework/css/print.css
@@ -1,0 +1,21 @@
+﻿@media print {
+    /* For testing, the body of a plugin container 
+       can be made visible for printing using CSS specificity */
+    #map-0 div.plugin-container-inner {
+        visibility: visible;
+    }
+
+    /* Hide all body an map elements */
+    body { 
+        visibility: hidden;
+    }
+
+
+    /* Override the map tiles which have inline styles.
+       This avoids having to have an !important on the broader
+       selectors for the rest of the page elements */
+    #map-0_root, #map-0_root img.layerTile,
+    #map-1_root, #map-1_root img.layerTile {
+        visibility: hidden !important;
+    }
+}


### PR DESCRIPTION
By adding a wide-ranging print media CSS selector to hide page content, we
set the stage for allowing active plugins to develop their own print
capabilities.

Connects #423 