### PR TITLE
Add print setting and button

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -251,6 +251,11 @@
                     <h6><%- title %></h6>
                     <a class="plugin-off" href="javascript:;">&#10006;</a>
                     <a class="plugin-close" href="javascript:;">&#95;</a>
+
+                    <% if (hasCustomPrint) { %>
+                        <a class="plugin-print" href="javascript:;" title="Print Contents"><i class="fa fa-print"></i></a>
+                    <% } %>
+
                     <% if (isHelpButtonVisible) { %>
                         <a class="plugin-help" href="javascript:;" title="View the info-graphic">?</a>
                     <% } %>

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -374,7 +374,8 @@ require(['use!Geosite',
                 bindings = {
                     title: pluginObject.toolbarName,
                     id: containerId,
-                    isHelpButtonVisible: isHelpButtonVisible(view)
+                    isHelpButtonVisible: isHelpButtonVisible(view),
+                    hasCustomPrint: pluginObject.hasCustomPrint
                 },
                 $uiContainer = $($.trim(N.app.templates['template-plugin-container'](bindings))),
                 calculatePosition = function ($el) {
@@ -384,7 +385,6 @@ require(['use!Geosite',
                     };
                 };
 
-            $uiContainer = $($.trim(N.app.templates['template-plugin-container'](bindings)));
             view.$uiContainer = $uiContainer;
 
             $uiContainer
@@ -400,6 +400,15 @@ require(['use!Geosite',
                 }).end()
                 .find('.plugin-help').on('click', function () {
                     model.set('displayHelp', true);
+                }).end()
+                .find('.plugin-print').on('click', function() {
+                    var deferred = $.Deferred();
+
+                    deferred.then(function() {
+                        window.print();
+                    });
+
+                    pluginObject.beforePrint(deferred);
                 }).end()
                 .hide();
 

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -29,6 +29,8 @@ define(["dojo/_base/declare",
             toolbarType: "sidebar",
             showServiceLayersInLegend: true,
             allowIdentifyWhenActive: false,
+            // Allow the framework to put a custom print button for this plugin
+            hasCustomPrint: false,
 
             // This option changes the default launch behavior and is only applicable to topbar plugins.
             // If true, this will deselect other active plugins when launched. If false, this will
@@ -50,6 +52,7 @@ define(["dojo/_base/declare",
             subregionActivated: function() {},
             subregionDeactivated: function() {},
             validate: function () { return true; },
+            beforePrint: function () {},
 
             // Called when switching from infographic to the primary view or vice versa.
             onContainerVisibilityChanged: function (visible) {},

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -52,7 +52,9 @@ define(["dojo/_base/declare",
             subregionActivated: function() {},
             subregionDeactivated: function() {},
             validate: function () { return true; },
-            beforePrint: function () {},
+
+            // Auto-resolve the print deferred if the plugin does not implement the function
+            beforePrint: function (printDeferred) { printDeferred.resolve();  },
 
             // Called when switching from infographic to the primary view or vice versa.
             onContainerVisibilityChanged: function (visible) {},

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -9,6 +9,7 @@ define(["dojo/_base/declare", "framework/PluginBase"],
             resizable: false,
             width: 320,
             height: 'auto',
+            hasCustomPrint: true,
 
             initialize: function(args) {
                 declare.safeMixin(this, args);
@@ -19,6 +20,11 @@ define(["dojo/_base/declare", "framework/PluginBase"],
                 var text = "You clicked on latitude " + mapPoint.getLatitude() + " longitude " + mapPoint.getLongitude(),
                     identifyWidth = 300;
                 processResults(text, identifyWidth);
+            },
+
+            beforePrint: function(printDeferred) {
+                // Prepare plugin markup for print...
+                printDeferred.resolve();
             }
         });
     }


### PR DESCRIPTION
Plugins can specify that they want a print event for their particular app.
The framework provides the UI element and a notification for when the
plugin is in a state for print to be called.

Connects #424 

##### To test:
* Open the sample Identify Point plugin
* Observe that a print button is added to the UI Container
* Clicking the print button will activate the print preview dialog
* Other plugins do not show the print icon
