### PR TITLE
Add plugin print css

### DIFF
--- a/src/GeositeFramework/css/print-hide-map0.css
+++ b/src/GeositeFramework/css/print-hide-map0.css
@@ -1,0 +1,7 @@
+﻿@media print {
+    /* For split screen print, only 1 plugin from one map should be enabled.  This hides
+        any active from map-0 which uses the same print style and lets map-1 plugins show. */
+    #map-0, #left-pane {
+        display: none;
+    }
+}

--- a/src/GeositeFramework/css/print-hide-map1.css
+++ b/src/GeositeFramework/css/print-hide-map1.css
@@ -1,0 +1,7 @@
+﻿@media print {
+    /* For split screen print, only 1 plugin from one map should be enabled.  This hides
+        any active from map-1 which uses the same print style and lets map-0 plugins show. */
+    #map-1, #right-pane {
+        display: none;
+    }
+}

--- a/src/GeositeFramework/css/print.css
+++ b/src/GeositeFramework/css/print.css
@@ -12,4 +12,10 @@
     #map-1_root, #map-1_root img.layerTile {
         visibility: hidden !important;
     }
+
+    /* Plugin print will only be one side of a split view map ever, so
+       allow that side to take up the entire width of the screen */
+    body.view-split .content {
+        width: 100%;
+    }
 }

--- a/src/GeositeFramework/css/print.css
+++ b/src/GeositeFramework/css/print.css
@@ -1,10 +1,4 @@
 ﻿@media print {
-    /* For testing, the body of a plugin container 
-       can be made visible for printing using CSS specificity */
-    #map-0 div.plugin-container-inner {
-        visibility: visible;
-    }
-
     /* Hide all body an map elements */
     body { 
         visibility: hidden;

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -404,29 +404,31 @@ require(['use!Geosite',
                 .find('.plugin-print').on('click', function() {
                     var pluginDeferred = $.Deferred(),
                         parseDeferred = $.Deferred(),
-                        pluginPath = model.get('pluginSrcFolder') + '/print.css',
-                        printCssClass = 'plugin-print-css';
+                        pluginCssPath = model.get('pluginSrcFolder') + '/print.css',
+                        printCssClass = 'plugin-print-css',
+                        oppositePaneHideCssPath = 'css/print-hide-map' +
+                            (paneNumber === 0 ? 1 : 0) + '.css';
 
-                    // Clear all .plugin-print-css
+                    // Any previous plugin-prints may have left their print CSS loaded
+                    // clear them and any pane hiding css prior to this new print operation
                     $('.' + printCssClass).remove();
 
                     // Add the plugin css
-                    $('<link>', {
-                        rel: 'stylesheet',
-                        href: pluginPath,
-                        className: printCssClass
-                    }).appendTo('head');
+                    addCss(pluginCssPath, printCssClass);
+
+                    // Hide the possible same plugin from the opposite map pane
+                    addCss(oppositePaneHideCssPath, printCssClass);
 
                     // Give some time for the browser to parse the new CSS, 
                     // if this wasn't slightly delayed, occasionally the override would
                     // not be present and print features wouldn't show up.
                     _.delay(parseDeferred.resolve, 200);
 
+                    pluginObject.beforePrint(pluginDeferred);
+
                     $.when(pluginDeferred, parseDeferred).then(function() {
                         window.print();
                     });
-
-                    pluginObject.beforePrint(pluginDeferred);
                 }).end()
                 .hide();
 
@@ -442,6 +444,14 @@ require(['use!Geosite',
 
             // Tell the model about $uiContainer so it can pass it to the plugin object
             model.set('$uiContainer', $uiContainer);
+        }
+
+        function addCss(path, className) {
+            $('<link>', {
+                rel: 'stylesheet',
+                href: path,
+                'class': className
+            }).appendTo('head');
         }
 
         function onContainerResize(view, resizeHandle, event) {

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -402,13 +402,31 @@ require(['use!Geosite',
                     model.set('displayHelp', true);
                 }).end()
                 .find('.plugin-print').on('click', function() {
-                    var deferred = $.Deferred();
+                    var pluginDeferred = $.Deferred(),
+                        parseDeferred = $.Deferred(),
+                        pluginPath = model.get('pluginSrcFolder') + '/print.css',
+                        printCssClass = 'plugin-print-css';
 
-                    deferred.then(function() {
+                    // Clear all .plugin-print-css
+                    $('.' + printCssClass).remove();
+
+                    // Add the plugin css
+                    $('<link>', {
+                        rel: 'stylesheet',
+                        href: pluginPath,
+                        className: printCssClass
+                    }).appendTo('head');
+
+                    // Give some time for the browser to parse the new CSS, 
+                    // if this wasn't slightly delayed, occasionally the override would
+                    // not be present and print features wouldn't show up.
+                    _.delay(parseDeferred.resolve, 200);
+
+                    $.when(pluginDeferred, parseDeferred).then(function() {
                         window.print();
                     });
 
-                    pluginObject.beforePrint(deferred);
+                    pluginObject.beforePrint(pluginDeferred);
                 }).end()
                 .hide();
 

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -13,7 +13,9 @@ define(["dojo/_base/declare", "framework/PluginBase"],
 
             initialize: function(args) {
                 declare.safeMixin(this, args);
-                $(this.container).append('<h4 style="padding: 5px;">Click any point on the map to display Latitude and Longitude</h4>');
+                $(this.container).append(
+                    '<h4 style="padding: 5px;">Click any point on the map to display Latitude and Longitude</h4>' + 
+                    '<img id="sample-graphic-print" src="' + this.infoGraphic + '" >');
             },
 
             identify: function(mapPoint, clickPoint, processResults) {

--- a/src/GeositeFramework/sample_plugins/identify_point/print.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/print.css
@@ -1,0 +1,8 @@
+﻿@media print {
+    #sample-graphic-print {
+        visibility: visible;
+        position: absolute;
+        left: 10px;
+        top: 10px;
+    }    
+}


### PR DESCRIPTION
Plugins can specify the css that they want enabled during plugin print.

##### To Test
* Open the Identify Point sample plugin, get passed the Info Graphic screen and click print
* The print preview should show the info graphic
* Open Split View and have both maps have an active Identify Point plugin
* Print one of the two plugins and ensure that only one is print previewed

Note that I didn't spend much time on actually positioning the graphic for print nicely, just demonstrating that plugins have the ability to do so.

Only the last three commits are relevant to this PR

Connects #426 