### PR TITLE
Print map preview

### DIFF
--- a/src/GeositeFramework/GeositeFramework.csproj
+++ b/src/GeositeFramework/GeositeFramework.csproj
@@ -138,6 +138,8 @@
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="App_Start\WebApiConfig.cs" />
+    <Content Include="css\print-hide-map1.css" />
+    <Content Include="css\print-hide-map0.css" />
     <Content Include="css\jquery.dropdown.css" />
     <Content Include="css\jquery.mCustomScrollbar.css" />
     <Content Include="css\pageguide.min.css" />
@@ -237,6 +239,7 @@
     <Content Include="sample_plugins\identify_point\icon.png" />
     <Content Include="sample_plugins\identify_point\icon_active.png" />
     <Content Include="sample_plugins\identify_point\main.js" />
+    <Content Include="sample_plugins\identify_point\print.css" />
     <Content Include="sample_plugins\identify_point\splash.png" />
     <Content Include="Scripts\json2.js" />
     <Content Include="Scripts\json2.min.js" />

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -443,6 +443,19 @@
         </div>
     </script>
 
+    <script type="text/template" id="template-map-preview">
+        <div id="plugin-print-preview">
+            <div class="popover popover-header">
+                <h2><%= pluginName %> - Print Preview</h2>
+            </div>
+            <div class="print-preview-container">
+                <button id="print-preview-print" class="button radius">Print</button>
+                <p class="instructions">Zoom to the view that you want printed in your map.</p>
+                <div id="plugin-print-preview-map"></div>
+            </div>
+        </div>
+    </script>
+
     <!-- TOP BAR, FIXED TO THE TOP OF THE SCREEN -->
     <div class="fixed">
         <nav class="top-bar">
@@ -464,6 +477,10 @@
     
     @Html.Partial("TourInfo")
     
+    <!-- Area for plugins to arrange their markup independent
+        of their container -->
+    <div id="plugin-print-sandbox"></div>
+
     <!-- LEFT CONTENT AREA -->
     <div id="left-pane" class="content"></div>
     

--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -746,14 +746,13 @@ table.esriLegendLayerLabel tbody tr td {
 .tbox{
     top: 100px!important;
     min-width: 500px!important;
-    width: 60%!important;
 }
 
 .tinner {
     overflow: hidden;
     padding: 0!important;
     min-height: 380px!important;
-    width: 100%!important;
+    width: 100%;
 }
 
 .tinner .tclose{

--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -1042,3 +1042,19 @@ body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide_left:after {
     font-size: 12px;
     position: relative;
 }
+
+#plugin-print-sandbox {
+    position: absolute;
+    visibility: hidden;
+}
+
+.print-preview-container {
+    padding: 10px;
+}
+#print-preview-container p {
+    padding: 5px; 
+}
+
+#print-preview-print {
+    float: right;
+}

--- a/src/GeositeFramework/css/print.css
+++ b/src/GeositeFramework/css/print.css
@@ -1,9 +1,16 @@
 ﻿@media print {
-    /* Hide all body an map elements */
-    body { 
+    /* Hide all body an map elements and print preview map controls */
+    body,
+    #plugin-print-preview-map_zoom_slider {
         visibility: hidden;
     }
 
+
+    /* An issue in Chrome for Windows would display the borders of this
+       element in print media, despite it being selected by the clause above.*/
+    .plugin-launcher {
+        display: none; 
+    }
 
     /* Override the map tiles which have inline styles.
        This avoids having to have an !important on the broader
@@ -17,5 +24,13 @@
        allow that side to take up the entire width of the screen */
     body.view-split .content {
         width: 100%;
+    }
+
+    #plugin-print-sandbox {
+        visibility: visible;
+    }
+
+    #plugin-print-preview-map_container img { 
+        visibility: visible;
     }
 }

--- a/src/GeositeFramework/js/App.js
+++ b/src/GeositeFramework/js/App.js
@@ -118,8 +118,6 @@
             TINY.box.show({
                 iframe: url,
                 boxid: 'frameless',
-                width: 750,
-                height: 450,
                 fixed: false,
                 maskopacity: 40
             });

--- a/src/GeositeFramework/js/Launchpad.js
+++ b/src/GeositeFramework/js/Launchpad.js
@@ -51,7 +51,6 @@ require(['use!Geosite'], function (N) {
             TINY.box.show({
                 html: self.template(self.model.toJSON()),
                 boxid: 'launchpad',
-                width: 750,
                 fixed: false,
                 maskopacity: 40,
                 openjs: function () {

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -420,8 +420,6 @@
 
             TINY.box.show({
                 html: view.render().el,
-                width: 450,
-                height: 275,
                 fixed: true,
                 maskopacity:50,
                 closejs: function () { view.remove(); }

--- a/src/GeositeFramework/js/Permalink.js
+++ b/src/GeositeFramework/js/Permalink.js
@@ -61,8 +61,6 @@
             
             TINY.box.show({
                 html: this.template(view.model.toJSON()),
-                width: 500,
-                height: 435,
                 fixed: true,
                 openjs: function () {
                     view.setElement($('#permalink-dialog'));

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -464,7 +464,9 @@ require(['use!Geosite',
             var mapMarkup = N.app.templates['template-map-preview']({ pluginName: pluginObject.toolbarName }),
                 $mapPrint = $($.trim(mapMarkup)),
                 $printPreview = $('#print-preview-sandbox'),
-                mapReadyDeferred = $.Deferred();
+                mapReadyDeferred = $.Deferred(),
+                mapHeight = pluginObject.previewMapSize[1],
+                mapWidth = pluginObject.previewMapSize[0];
 
             // If the plugin is not set up for map print preview, don't set up a map
             // and resolve any pending print-preview map operations
@@ -476,16 +478,20 @@ require(['use!Geosite',
 
             // Setup a print-preview window for the user to select an extent and zoom level
             // that will be persisted at print due to its fixed size.
-            $mapPrint.css({ height: 500, width: 500 });
-
             TINY.box.show({
                 animate: false,
                 html: $mapPrint[0].outerHTML,
                 boxid: 'print-preview-container',
-                width: 500,
+                width: _.max([mapWidth, 500]),
                 fixed: true,
                 maskopacity: 40,
                 openjs: function () {
+                    // Remove any calculated size so that it contains the full map
+                    $('#print-preview-container').css({ height: 'initial', width: 'initial' });
+
+                    // Set the supplied height & width on the map
+                    $('#plugin-print-preview-map').css({ height: mapHeight, width: mapWidth });
+
                     var map = new esri.Map('plugin-print-preview-map', { basemap: 'topo' });
 
                     mapReadyDeferred.resolve(map);

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -404,14 +404,18 @@ require(['use!Geosite',
                 .find('.plugin-print').on('click', function() {
                     var pluginDeferred = $.Deferred(),
                         parseDeferred = $.Deferred(),
+                        previewDeferred = $.Deferred(),
                         pluginCssPath = model.get('pluginSrcFolder') + '/print.css',
                         printCssClass = 'plugin-print-css',
                         oppositePaneHideCssPath = 'css/print-hide-map' +
-                            (paneNumber === 0 ? 1 : 0) + '.css';
-
-                    // Any previous plugin-prints may have left their print CSS loaded
-                    // clear them and any pane hiding css prior to this new print operation
+                            (paneNumber === 0 ? 1 : 0) + '.css',
+                        $printSandbox = $('#plugin-print-sandbox');
+                    
+                    // Any previous plugin-prints may have left specific print css
+                    // or sandbox elements.  Clear all so that this new print routine
+                    // has no conflicts with other plugins.
                     $('.' + printCssClass).remove();
+                    $printSandbox.empty();
 
                     // Add the plugin css
                     addCss(pluginCssPath, printCssClass);
@@ -424,10 +428,20 @@ require(['use!Geosite',
                     // not be present and print features wouldn't show up.
                     _.delay(parseDeferred.resolve, 200);
 
-                    pluginObject.beforePrint(pluginDeferred);
+                    var mapReadyDeferred = setupPrintableMap(pluginObject, $printSandbox, previewDeferred);
 
-                    $.when(pluginDeferred, parseDeferred).then(function() {
-                        window.print();
+                    mapReadyDeferred.then(function(previewMap) {
+                        // The plugin is given a deferred object to resolve when the page is ready
+                        // to be printed, a reference to an element where it can place printable
+                        // elements outside of its container and a reference to an esriMap which
+                        // is used as a print preview box.
+                        pluginObject.beforePrint(pluginDeferred, $printSandbox, previewMap);
+
+                        // Exectue the browser print when the plugin and print preview (if used)
+                        // have responded, as well as a slight delay for css parsing.
+                        $.when(pluginDeferred, parseDeferred, previewDeferred).then(function() {
+                            window.print();
+                        });
                     });
                 }).end()
                 .hide();
@@ -444,6 +458,50 @@ require(['use!Geosite',
 
             // Tell the model about $uiContainer so it can pass it to the plugin object
             model.set('$uiContainer', $uiContainer);
+        }
+
+        function setupPrintableMap(pluginObject, $printSandbox, previewDeferred) {
+            var mapMarkup = N.app.templates['template-map-preview']({ pluginName: pluginObject.toolbarName }),
+                $mapPrint = $($.trim(mapMarkup)),
+                $printPreview = $('#print-preview-sandbox'),
+                mapReadyDeferred = $.Deferred();
+
+            // If the plugin is not set up for map print preview, don't set up a map
+            // and resolve any pending print-preview map operations
+            if (!pluginObject.usePrintPreviewMap) {
+                previewDeferred.resolve();
+                mapReadyDeferred.resolve();
+                return mapReadyDeferred;
+            }
+
+            // Setup a print-preview window for the user to select an extent and zoom level
+            // that will be persisted at print due to its fixed size.
+            $mapPrint.css({ height: 500, width: 500 });
+
+            TINY.box.show({
+                animate: false,
+                html: $mapPrint[0].outerHTML,
+                boxid: 'print-preview-container',
+                width: 500,
+                fixed: true,
+                maskopacity: 40,
+                openjs: function () {
+                    var map = new esri.Map('plugin-print-preview-map', { basemap: 'topo' });
+
+                    mapReadyDeferred.resolve(map);
+
+                    $('#print-preview-print').on('click', function() {
+                        // Move the map from the print preview dialog to the sandbox where
+                        // the plugin can mess with it's positioning among its other elements
+                        $(map.container).detach().appendTo($printSandbox);
+                        TINY.box.hide();
+                        $printPreview.hide();
+                        previewDeferred.resolve();
+                    });
+                }
+            });
+
+            return mapReadyDeferred;
         }
 
         function addCss(path, className) {

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -32,6 +32,9 @@ define(["dojo/_base/declare",
             // Allow the framework to put a custom print button for this plugin
             hasCustomPrint: false,
 
+            // Show a print preview map for plugin printing
+            usePrintPreviewMap: false,
+
             // This option changes the default launch behavior and is only applicable to topbar plugins.
             // If true, this will deselect other active plugins when launched. If false, this will
             // not call the Picky select/deselect methods. Instead, only the plugin 'activate' method

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -35,6 +35,9 @@ define(["dojo/_base/declare",
             // Show a print preview map for plugin printing
             usePrintPreviewMap: false,
 
+            // The [width, height] of the print preview map
+            previewMapSize: [500, 400],
+
             // This option changes the default launch behavior and is only applicable to topbar plugins.
             // If true, this will deselect other active plugins when launched. If false, this will
             // not call the Picky select/deselect methods. Instead, only the plugin 'activate' method

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -10,12 +10,12 @@ define(["dojo/_base/declare", "framework/PluginBase"],
             width: 320,
             height: 'auto',
             hasCustomPrint: true,
+            usePrintPreviewMap: true,
 
             initialize: function(args) {
                 declare.safeMixin(this, args);
                 $(this.container).append(
-                    '<h4 style="padding: 5px;">Click any point on the map to display Latitude and Longitude</h4>' + 
-                    '<img id="sample-graphic-print" src="' + this.infoGraphic + '" >');
+                    '<h4 style="padding: 5px;">Click any point on the map to display Latitude and Longitude</h4>');
             },
 
             identify: function(mapPoint, clickPoint, processResults) {
@@ -24,8 +24,17 @@ define(["dojo/_base/declare", "framework/PluginBase"],
                 processResults(text, identifyWidth);
             },
 
-            beforePrint: function(printDeferred) {
-                // Prepare plugin markup for print...
+            beforePrint: function(printDeferred, $printArea, mapObject) {
+                var layer = new esri.layers.ArcGISDynamicMapServiceLayer("http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer", {
+                        "opacity": 0.8
+                    });
+                
+                mapObject.addLayer(layer);
+                mapObject.centerAt(new esri.geometry.Point(-118.15, 33.80));
+                mapObject.setZoom(5);
+
+                $printArea.append('<img id="sample-graphic-print" src="' + this.infoGraphic + '" >');
+
                 printDeferred.resolve();
             }
         });

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -11,6 +11,7 @@ define(["dojo/_base/declare", "framework/PluginBase"],
             height: 'auto',
             hasCustomPrint: true,
             usePrintPreviewMap: true,
+            previewMapSize: [500, 350],
 
             initialize: function(args) {
                 declare.safeMixin(this, args);

--- a/src/GeositeFramework/sample_plugins/identify_point/print.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/print.css
@@ -2,7 +2,11 @@
     #sample-graphic-print {
         visibility: visible;
         position: absolute;
-        left: 10px;
-        top: 10px;
+        top: 510px;
+        -webkit-transform: rotate(45deg);
     }    
+
+    #plugin-print-preview-map {
+        visibility: visible;
+    }
 }


### PR DESCRIPTION
Add a print preview map to plugins which request one.  The plugin is responsible for setting the layers of  the map, but lets the user select a zoom and extent that will likely results in a printable map.  The preview map is added to a sandbox element which is only available in `@media print`.  The plugin is also passed a reference to this sandbox so they can place additional elements and construct their own print.css to manage that layout.

Connects #427 
To Test:

The Sample Identify Plugin has been kitted out to support all the new features.
* Launch the Identify Plugin
* Click new Print button (fig 1)
* Navigate the preview map (fig 2)
* Click print to see your map & also a custom style graphic (fig 3)

*fig 1:*
![print button](https://cloud.githubusercontent.com/assets/1014341/10612959/19705ed4-7721-11e5-9a4e-b41c6f478065.PNG)

*fig 2:*
![preview](https://cloud.githubusercontent.com/assets/1014341/10612960/1973f044-7721-11e5-8bf2-0a70b63ef5cb.PNG)

*fig 3:*
![output print](https://cloud.githubusercontent.com/assets/1014341/10612961/1974016a-7721-11e5-8916-1f23c983e830.PNG)
