### PR TITLE
Initiate Export custom print on layer selector

### DIFF
--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -267,6 +267,12 @@
         window.onorientationchange = function() {
             view.$('.side-nav.top').mCustomScrollbar('update');
         };
+
+        // For on demand export initialization. See Layer Selector print, for example.
+        var paneNumber = view.model.get('paneNumber');
+        N.app.dispatcher.on('export-map:pane-' + paneNumber, function() {
+            view.exportMap();
+        });
     }
 
     function render(view) {
@@ -411,7 +417,7 @@
             'click .export-button': 'exportMap'
         },
 
-        exportMap: function exportMap(selectedPaneNumber) {
+        exportMap: function exportMap() {
             var model = new N.models.ExportTool({
                     esriMap: this.mapView.esriMap,
                     paneNumber: this.model.get('paneNumber')

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -38,6 +38,7 @@ require(['use!Geosite',
                 app: {
                     version: N.app.version,
                     regionConfig: regionData,
+                    paneNumber: mapModel.get('mapNumber'),
                     info: _.bind(logger.info, logger),
                     warn: _.bind(logger.warn, logger),
                     error: _.bind(logger.error, logger),

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -60,7 +60,10 @@ define(["dojo/_base/declare",
             validate: function () { return true; },
 
             // Auto-resolve the print deferred if the plugin does not implement the function
-            beforePrint: function (printDeferred) { printDeferred.resolve();  },
+            // printDeferred: deferred object to resolve when the printing can commence
+            // $printSandbox: DOM element which the framework provides for printable element arrangement
+            // previewMap: an ESRI map object for the print preview, if `usePrintPreviewMap` is true
+            beforePrint: function (printDeferred, $printSandbox, previewMap) { printDeferred.resolve();  },
 
             // Called when switching from infographic to the primary view or vice versa.
             onContainerVisibilityChanged: function (visible) {},

--- a/src/GeositeFramework/plugins/layer_selector/main.js
+++ b/src/GeositeFramework/plugins/layer_selector/main.js
@@ -53,6 +53,7 @@ define([
             fullName: "Configure and control layers to be overlayed on the base map.",
             toolbarType: "sidebar",
             allowIdentifyWhenActive: true,
+            hasCustomPrint: true,
 
             _layerManager: null,
             _ui: null,
@@ -170,6 +171,15 @@ define([
             subregionDeactivated: function(subregion) {
                 this.clearAll();
                 this.initialize(null, 'main');
+            },
+
+            beforePrint: function(printDeferred) {
+                // We can short circuit the plugin print chain by simply
+                // rejecting this deferred object.  
+                printDeferred.reject();
+
+                // Trigger an export dialog for this pane.
+                this.app.dispatcher.trigger('export-map:pane-' + this.app.paneNumber);
             }
 
         });

--- a/src/GeositeFramework/plugins/layer_selector/print.css
+++ b/src/GeositeFramework/plugins/layer_selector/print.css
@@ -1,0 +1,2 @@
+﻿/* This file intentionally left blank to prevent browser 
+    404 errors due to custom print */


### PR DESCRIPTION
The layer selector specifies a custom print, but in reality just triggers
an export for the map pane it belongs to.

Test:
Each pane has it's own map and layer selector, so it's easiest to test in split screen mode.
- Open split screen and make the basemaps and extents obviously different
- Open the layer selector in either and click the new print button
- Check that the produced pdf is actually from the pane containing the plugin instance you used
- Repeat for the other pane.

Connects #428 