### PR TITLE
Make Identify optional and off by default

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -151,6 +151,10 @@
             "type": "array",
             "items": { "type": "string" }
         },
+        "identifyEnabled": {
+            "type": "boolean",
+            "required": false
+        },
         "launchpads": {
             "type": "array",
             "required": false,

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -329,8 +329,12 @@
             // Initialize plugins now that all map properties are available (e.g. extent)
             view.model.initPlugins(esriMap);
 
-            // Clicking the map means "Identify" contents at a point
-            dojo.connect(esriMap, "onClick", tryIdentify);
+            // Framework level support for identify is off by default and must
+            // be enabled in the region config
+            if (view.model.get('regionData').identifyEnabled) {
+                // Clicking the map means "Identify" contents at a point
+                dojo.connect(esriMap, "onClick", tryIdentify);
+            }
             
             adjustToolPositions(view, esriMap);
         });

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -96,6 +96,7 @@
         "secondary": "#26648E"
     },
     "identifyBlacklist": ["OBJECTID", "OBJECTID_1"],
+    "identifyEnabled": true,
     "launchpads": [
         {
             "id": "get-started",


### PR DESCRIPTION
TNC would like to transition identify results into the plugins to give
more meaningful results, as the framework version is inherently
context-free and doesn't do a great job of showing meaningful attributes.

* Make Identify a framework option in region.json via `identifyEnabled`
* `identifyEnabled` is false by default

##### Test:
* Set `identifyEnabled` to `true`: Map clicks should attempt an identify
* Remove `identifyEnabled`: Map clicks should not attempt an identify

You'll have to bounce your app or kill the dev IIS process between tests because the region data is cached on app start.

Connects #435 