### PR TITLE
Ensure print map is loaded before handoff

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -500,7 +500,9 @@ require(['use!Geosite',
 
                     map.addLayer(new esri.layers.ArcGISDynamicMapServiceLayer(currentBaseMapUrl));
 
-                    mapReadyDeferred.resolve(map);
+                    dojo.connect(map, 'onLoad', function() {
+                        mapReadyDeferred.resolve(map);
+                    });
 
                     $('#print-preview-print').on('click', function() {
                         // Move the map from the plugin print preview dialog to the sandbox where


### PR DESCRIPTION
Plugins may have errors accessing certain map features if `map.loaded` is
not `true`.  Don't resolve the deferred for map ready until the map is
loaded.

Connects #439 

Test:
Open the sample identify plugin, click on the map and then hit the print button.  The preview map should be displayed as usual, but you can test that `main.js/beforePrint:mapObject.loaded === true`