### PR TITLE
Replace subregion border div w/ multiple elements

### DIFF
--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -1023,12 +1023,27 @@ body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide_left:after {
 
 .subregion-border-box {
     position: absolute;
-    width: 100%;
     z-index: 1;
-    border: solid 3px rgba(194, 32, 32, 0.5);
+    border: solid 2px rgba(194, 32, 32, 0.5);
     border-top: none;
-    top: 50px;
     bottom: 0px;
+}
+
+.subregion-border-box.bottom {
+    width: 100%;
+    border-width: 3px;
+    left: 4px;
+}
+
+.subregion-border-box.right {
+    right: 0px;
+    top: 50px;
+    bottom: 3px;
+}
+
+.subregion-border-box.left {
+    left: 0px;
+    top: 50px;
 }
 
 .subregion-header select{

--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -303,15 +303,17 @@
 
         toggleMapBorder: function () {
             var mapContainer = this.subRegionManager.map.__container,
-                className = 'subregion-border-box',
-                $borderBox = $(mapContainer).find('.' + className);
+                baseClassName = 'subregion-border-box',
+                $borderBoxes = $(mapContainer).find('.' + baseClassName);
 
-            if ($borderBox.length) {
-                $borderBox.remove();
+            if ($borderBoxes.length) {
+                $borderBoxes.remove();
             } else {
-                $('<div/>', {
-                    'class': className
-                }).prependTo(mapContainer);
+                _.each(['bottom', 'left', 'right'], function(borderClass) {
+                  $('<div/>', {
+                      'class': baseClassName + ' ' + borderClass
+                  }).prependTo(mapContainer);
+                });
             }
         },
 


### PR DESCRIPTION
* Instead of using one div to create the red subregion border
element, use multiple divs to piece together a border. This is
a bit more complicated, but has the effect of not covering up
other elements and causing z-index issues.

**Testing instructions**
- Activate a subregion. Verify that the red border is present, looks correct (check in various browsers) and that no DOM elements are covering up the map. 
- Leave the subregion. Verify that the red border disappears.
- When a subregion is active, open an instance of the layer selector and click one of the info buttons next to a layer. Verify that you can interact with the pop-up that appears.

Connects to #420