### PR TITLE
Make excess legends break visibility toggleable.

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -199,15 +199,28 @@
     <script type="text/template" id="template-legend-item-multiple">
         <div class="legend-layer multiple">
             <div class="legend-title"><%- layerName %></div>
-            <% _.each(legend, function(item) { %>
-                <div class="item">
+            <% _.each(legend, function(item, index) { %>
+                <div class="item <% if (index > 2 && index <= (legend.length - 3)) { %>extra<% } %>">
                     <img src="data:<%= item.contentType %>;base64,<%= item.imageData %>"
                         width="<%- item.width %>"
                         height="<%- item.height %>"
                         title="<%- item.label %>" alt="" />
                     <span class="item-label"><%- item.label %></span>
                 </div>
+                <% if (legend.length > 5 && index === 3) { %>
+                    <div class="item expand">
+                        <span>...</span>
+                    </div>
+                <% } %>
             <% }) %>
+            <% if (legend.length > 5) { %>
+                <div class="item expand">
+                    <a href="#" class="expand-legend">View <% print(legend.length - 5) %> more</a>
+                </div>
+                <div class="item extra collapse">
+                    <a href="#" class="expand-legend">View less</a>
+                </div>
+            <% } %>
         </div>
     </script>
 

--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -630,6 +630,15 @@ input.code-like, textarea.code-like {
         float: left;
         clear: left;
     }
+    .legend-layer .extra {
+        display: none;
+    }
+    .legend-layer.show-extras .extra {
+        display: block;
+    }
+    .legend-layer.show-extras .expand {
+        display: none;
+    }
     .legend-layer.scale .item {
         clear: none;
     }

--- a/src/GeositeFramework/js/Legend.js
+++ b/src/GeositeFramework/js/Legend.js
@@ -90,6 +90,20 @@ define(['use!Geosite',
             });
 
             this.$el.find('.legend-body').html($container.html());
+            this.assignLegendEvents();
+        },
+
+        assignLegendEvents: function() {
+            this.$el.find('.expand-legend').on('click', $.proxy(function(e) {
+                this.toggleExtraLegendItems(e);
+            }, this));
+        },
+
+        toggleExtraLegendItems: function(e) {
+            var $extraLegendControl = $(e.target),
+                $extraLegendItems = $extraLegendControl.parents('.legend-layer');
+
+            $extraLegendItems.toggleClass('show-extras');
         }
     });
 

--- a/src/GeositeFramework/js/Legend.js
+++ b/src/GeositeFramework/js/Legend.js
@@ -21,6 +21,7 @@ define(['use!Geosite',
                     layerName: layer.name
                 });
             }
+
             return null;
         }
     });
@@ -57,6 +58,7 @@ define(['use!Geosite',
 
         getLayerTemplate: function(legend, service, layer) {
             var layerSettings = this.config.getLayerSettings(service, layer);
+
             if (layerSettings) {
                 if (layerSettings.legendType === 'single') {
                     return this.tmplLegendItemSingle;
@@ -66,22 +68,27 @@ define(['use!Geosite',
                     return this.tmplLegendItemScale;
                 }
             }
+
             if (legend.legend.length === 1) {
                 return this.tmplLegendItemSingle;
             }
+
             return this.tmplLegendItemMultiple;
         },
 
         render: function(legendGroups) {
             var self = this,
                 $container = $('<div>');
+
             _.each(legendGroups, function(legendGroup) {
                 var service = legendGroup.service,
                     layer = legendGroup.layer,
                     legend = legendGroup.legend,
                     tmpl = self.getLayerTemplate(legend, service, layer);
-                    $container.append(tmpl(legend));
+
+                $container.append(tmpl(legend));
             });
+
             this.$el.find('.legend-body').html($container.html());
         }
     });


### PR DESCRIPTION
* If the legend for an individual layer contains more than 5 breaks/classes, hide the additional items to conserve space.
* Add an element to allow the user to toggle the visibility of the extra items.

**Testing instructions**
- Turn on a layer that has more than 5 breaks/classes. Louisiana > Species > ESI Waterfowl (LDWF 2001) is a good example.
- Verify that only 5 breaks are showing, and that there is an option to show more breaks that toggles the amount of visible breaks.
- Add another layer with more than 5 breaks and verify that you can toggle this layer, and that it doesn't affect the other layer with lots of breaks. Try Florida > Species > Bottlenose Dolphin Abundance.
- Verify that legends with exactly 5 items do not generate a toggle option. Louisiana > Salinity > Low Salinity Season (ppt) has 5.

<img width="277" alt="screen shot 2016-01-18 at 12 26 01 pm" src="https://cloud.githubusercontent.com/assets/1042475/12397977/b44396a2-bdde-11e5-93b6-5c5b62e81d6c.png">
<img width="273" alt="screen shot 2016-01-18 at 12 26 07 pm" src="https://cloud.githubusercontent.com/assets/1042475/12397976/b4435732-bdde-11e5-9cd6-d4eede5188ab.png">


Connects to #492