### PR TITLE
Check for legend config before using

### DIFF
--- a/src/GeositeFramework/js/Legend.js
+++ b/src/GeositeFramework/js/Legend.js
@@ -15,7 +15,7 @@ define(['use!Geosite',
         },
 
         getLayerSettings: function(service, layer) {
-            if (this.config.layers) {
+            if (this.config && this.config.layers) {
                 return _.findWhere(this.config.layers, {
                     serviceUrl: service.url,
                     layerName: layer.name


### PR DESCRIPTION
The region legend configuration is optional.  Don't fail if it is not
found.