### PR TITLE
Add ajax utils

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -208,18 +208,11 @@ require(['use!Geosite',
             legend.render(getVisibleLayers());
         };
 
-        // Ensure that redraw is executed only once per service.
-        // So if there are a dozen layers in a service, the layer selector
-        // is only redrawn once instead of a dozen times.
-        var redrawOnce = _.memoize(function() {
-            return _.once(redraw);
-        });
-
         function getServiceLegend(service) {
             var legendUrl = service.url + '/legend',
                 data = ajaxUtil.get(legendUrl);
             if (ajaxUtil.shouldFetch(legendUrl)) {
-                ajaxUtil.fetch(legendUrl).then(redrawOnce(legendUrl));
+                ajaxUtil.fetch(legendUrl).then(redraw);
             }
             return data && data.layers;
         }

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -100,7 +100,7 @@ require(['use!Geosite',
     function createMap(view) {
         var esriMap = new esri.Map(view.$el.attr('id')),
             resizeMap = _.debounce(function () {
-                // When the element containing the map resizes, the 
+                // When the element containing the map resizes, the
                 // map needs to be notified.  Do a slight delay so that
                 // the browser has time to actually make the element visible.
                     if (view.$el.is(':visible')) {
@@ -135,10 +135,10 @@ require(['use!Geosite',
             N.app.syncedMapManager.addMapView(view);
 
             initLegend(view, esriMap);
-            
+
             // Cache the parent of the infowindow rather than re-select it every time.
             // Occasionally, the infoWindow dom node as accessed from the underlaying esri.map
-            // would be detached from the body and the parent would not be accessible 
+            // would be detached from the body and the parent would not be accessible
             view.$infoWindowParent = $(esriMap.infoWindow.domNode).parent();
 
             setupSubregions(N.app.data.region.subregions, esriMap);

--- a/src/GeositeFramework/js/util/ajax.js
+++ b/src/GeositeFramework/js/util/ajax.js
@@ -1,0 +1,49 @@
+//= require underscore
+define(['esri/request'],
+    function(request) {
+        'use strict';
+
+        var cache = {},
+            promises = {};
+
+        function get(url) {
+            return cache[url];
+        }
+
+        // Fetch data from `url` and store the result in `cache` (memoized).
+        var fetch = function(url) {
+            if (typeof promises[url] === 'undefined') {
+                promises[url] = request({
+                    url: url,
+                    content: {f: 'json'},
+                    handleAs: 'json',
+                    callbackParamName: 'callback',
+                    timeout: 7000
+                }).then(function(data) {
+                    cache[url] = data;
+                }, function(error) {
+                    cache[url] = error;
+                });
+            }
+            return promises[url];
+        };
+
+        function isFetching(url) {
+            return typeof promises[url] !== 'undefined';
+        }
+
+        function isCached(url) {
+            return typeof cache[url] !== 'undefined';
+        }
+
+        function shouldFetch(url) {
+            return !isFetching(url) && !isCached(url);
+        }
+
+        return {
+            get: get,
+            fetch: fetch,
+            shouldFetch: shouldFetch
+        };
+    }
+);


### PR DESCRIPTION
This introduces a design pattern for fetching data from ajax requests
and consuming the result in a synchronous way (without callback
functions).

The implementation for the Legend widget has been generalized into ajax
utils that can be used for other components/plugins.

The purpose of this is to avoid deeply nested async callback trees (think
layer selector). Additionally, the cache is shared throughout the app so
plugins fetching the same data won't make extra ajax requests (Ex. if
you open the same plugin in Split View).

**To test:**
If this works as designed, the legend should work exactly as it did before.