### PR TITLE
Fix export and update ESRI JS

### DIFF
--- a/js_requirements.txt
+++ b/js_requirements.txt
@@ -521,3 +521,5 @@ dojox/charting/plot2d/Grid
 dojox/charting/action2d/Tooltip
 dojox/charting/axis2d/Default
 esri/dijit/Attribution
+esri/tasks/LegendLayer
+esri/tasks/PrintParameters

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -73,7 +73,7 @@
 
     <link rel="stylesheet" href="//js.arcgis.com/3.11/dijit/themes/claro/claro.css"> 
     <link rel="stylesheet" href="//js.arcgis.com/3.10/js/dojo/dojox/layout/resources/ResizeHandle.css">
-    <link rel="stylesheet" href="//js.arcgis.com/o/232546/geosite-v1.0.8/esri/css/esri.css">
+    <link rel="stylesheet" href="//js.arcgis.com/o/232546/geosite-v1.0.9/esri/css/esri.css">
 
     <link rel="stylesheet" href="css/print.css">
     <link rel="stylesheet" href="css/foundation.min.css">
@@ -499,7 +499,7 @@
     <script src="js/lib/jquery.mousewheel.min.js"></script>
     <script src="js/lib/jquery.mCustomScrollbar.concat.min.js"></script>
 
-    <script src="//js.arcgis.com/o/232546/geosite-v1.0.8/dojo/dojo.js"></script>
+    <script src="//js.arcgis.com/o/232546/geosite-v1.0.9/dojo/dojo.js"></script>
     <script src="Scripts/json2.min.js"></script> <!-- Can be removed when IE8 support is dropped -->
     <script src="js/lib/foundation/foundation.min.js"></script>
     <script src="js/lib/foundation/app.js"></script>

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -2,11 +2,17 @@
 
 require(['use!Geosite',
          'esri/tasks/PrintTask',
+         'esri/tasks/PrintParameters',
+         'esri/tasks/PrintTemplate',
+         'esri/tasks/LegendLayer',
          'dojo/Deferred',
          'dojo/request',
          'framework/Logger'],
     function(N,
              PrintTask,
+             PrintParameters,
+             PrintTemplate,
+             LegendLayer,
              Deferred,
              request,
              Logger) {
@@ -110,9 +116,9 @@ require(['use!Geosite',
         },
 
         getExportParams: function() {
-            var params = new esri.tasks.PrintParameters();
+            var params = new PrintParameters();
             params.map = this.get('esriMap');
-            params.template = new esri.tasks.PrintTemplate();
+            params.template = new PrintTemplate();
             params.template.format = "PDF";
             params.template.preserveScale = false;
             params.template.showAttribution = false;
@@ -146,7 +152,7 @@ require(['use!Geosite',
                 result = [];
             _.each(map.getLayersVisibleAtScale(), function(layer) {
                 if (layer.visibleLayers && layer.visibleLayers.length > 0 && layer.visibleLayers[0] !== -1) {
-                    var legendLayer = new esri.tasks.LegendLayer();
+                    var legendLayer = new LegendLayer();
                     legendLayer.layerId = layer.id;
                     legendLayer.subLayerIds = model.getLayerParents(layer, layer.visibleLayers);
                     result.push(legendLayer);

--- a/src/GeositeFramework/js/Launchpad.js
+++ b/src/GeositeFramework/js/Launchpad.js
@@ -1,7 +1,12 @@
 /*jslint nomen:true, devel:true */
 /*global Geosite, $, _, gapi*/
 
-require(['use!Geosite'], function (N) {
+require([
+    'use!Geosite',
+    'esri/geometry/Extent',
+    'esri/SpatialReference'
+    ],
+    function (N, Extent, SpatialReference) {
     'use strict';
 
     N.controllers.Launchpads = function (launchpadsConfig) {
@@ -187,9 +192,9 @@ require(['use!Geosite'], function (N) {
 
     function parseExtent(extent) {
         var x = N.app.data.region.initialExtent,
-            extent = new esri.geometry.Extent(
+            extent = new Extent(
                 x[0], x[1], x[2], x[3],
-                new esri.SpatialReference({ wkid: 4326 /*lat-long*/ })
+                new SpatialReference({ wkid: 4326 /*lat-long*/ })
             );
 
         return extent;

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -4,12 +4,18 @@
 require(['use!Geosite',
          'esri/dijit/Legend',
          'esri/map',
+         'esri/layers/ArcGISTiledMapServiceLayer',
+         'esri/geometry/Extent',
+         'esri/SpatialReference',
          'dojox/layout/ResizeHandle',
          'framework/widgets/ConstrainedMoveable'
         ],
     function(N,
              Legend,
              Map,
+             ArcGISTiledMapServiceLayer,
+             Extent,
+             SpatialReference,
              ResizeHandle,
              ConstrainedMoveable) {
     'use strict';
@@ -19,7 +25,7 @@ require(['use!Geosite',
         var basemap = getSelectedBasemap(model);
         if (basemap.layer === undefined) {
             // This basemap has no layer yet, so make one and cache it
-            basemap.layer = new esri.layers.ArcGISTiledMapServiceLayer(basemap.url);
+            basemap.layer = new ArcGISTiledMapServiceLayer(basemap.url);
             esriMap.addLayer(basemap.layer);
         }
         return basemap.layer;
@@ -98,7 +104,7 @@ require(['use!Geosite',
     }
 
     function createMap(view) {
-        var esriMap = new esri.Map(view.$el.attr('id')),
+        var esriMap = Map(view.$el.attr('id')),
             resizeMap = _.debounce(function () {
                 // When the element containing the map resizes, the 
                 // map needs to be notified.  Do a slight delay so that
@@ -178,9 +184,9 @@ require(['use!Geosite',
 
     function loadExtent(view) {
         var x = view.model.get('extent'),
-            extent = new esri.geometry.Extent(
+            extent = Extent(
                 x.xmin, x.ymin, x.xmax, x.ymax,
-                new esri.SpatialReference({ wkid: x.spatialReference.wkid })
+                new SpatialReference({ wkid: x.spatialReference.wkid })
             );
         view.esriMap.setExtent(extent);
     }

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -3,76 +3,80 @@
 
 // A pane represents the app work area and contains a sidebar and a map
 
-(function (N) {
-    'use strict';
+require([
+    'use!Geosite',
+    'esri/geometry/Extent',
+    'esri/SpatialReference'], function (N, Extent, SpatialReference) {
 
-    function initialize(model) {
-        initMap(model);
-        createPlugins(model);
-    }
+    (function () {
+        'use strict';
 
-    function initMap(model) {
-        var extent = getHomeExtent(model),
-            mapModel = new N.models.Map({
-                basemaps: model.get('regionData').basemaps,
-                extent: extent,
-                mapNumber: model.get('paneNumber')
-            });
-        model.set('mapModel', mapModel);
-
-        initializeSubregionDisplays(mapModel, model);
-
-    }
-
-    function initializeSubregionDisplays(mapModel, pane)
-    {
-        function turnOffPlugins() {
-            pane.get('plugins').invoke('turnOff');
+        function initialize(model) {
+            initMap(model);
+            createPlugins(model);
         }
 
-        mapModel.on('subregion-activate', function(activeRegion) {
-            pane.set('activeSubregion', activeRegion);
-            turnOffPlugins();
-            invokeOnPlugins(pane, 'subregionActivated', [activeRegion, pane]);
-            setSidebarPluginVisibility(pane, activeRegion.availablePlugins);
-        });
+        function initMap(model) {
+            var extent = getHomeExtent(model),
+                mapModel = new N.models.Map({
+                    basemaps: model.get('regionData').basemaps,
+                    extent: extent,
+                    mapNumber: model.get('paneNumber')
+                });
+            model.set('mapModel', mapModel);
 
-        mapModel.on('subregion-deactivate', function(deactivatedRegion) {
-            pane.set('activeSubregion', null);
-            invokeOnPlugins(pane, 'subregionDeactivated', [deactivatedRegion, pane]);
-            turnOffPlugins();
-            showAllSidebarPlugins(pane);
-        });
-    }
+            initializeSubregionDisplays(mapModel, model);
 
-    function showAllSidebarPlugins(pane) {
-        setSidebarPluginVisibility(pane, []);
-    }
+        }
 
-    function setSidebarPluginVisibility(pane, availablePlugins) {
-        // Hide any plugins which are not available, but if none are specifically made
-        // available, all will be available.
-
-        var plugins = pane.get('plugins'),
-            anyAvailable = !_.isEmpty(availablePlugins);
-        
-        plugins.each(function(plugin) {
-            var type = plugin.get('pluginObject').toolbarType,
-                pluginLauncherSelector = '.' + plugin.getId() + '-' + pane.get('paneNumber');
-
-            if (anyAvailable && type === 'sidebar'
-                    && !_.contains(availablePlugins, plugin.getId())) {
-                $(pluginLauncherSelector).hide();
-
-                // Also hide the ui container if it happens to be showing.
-                plugin.get('$uiContainer').hide();
-            } else {
-                $(pluginLauncherSelector).show();
+        function initializeSubregionDisplays(mapModel, pane) {
+            function turnOffPlugins() {
+                pane.get('plugins').invoke('turnOff');
             }
-        });
-    }
 
-    function invokeOnPlugins(model, methodName, args) {
+            mapModel.on('subregion-activate', function(activeRegion) {
+                pane.set('activeSubregion', activeRegion);
+                turnOffPlugins();
+                invokeOnPlugins(pane, 'subregionActivated', [activeRegion, pane]);
+                setSidebarPluginVisibility(pane, activeRegion.availablePlugins);
+            });
+
+            mapModel.on('subregion-deactivate', function(deactivatedRegion) {
+                pane.set('activeSubregion', null);
+                invokeOnPlugins(pane, 'subregionDeactivated', [deactivatedRegion, pane]);
+                turnOffPlugins();
+                showAllSidebarPlugins(pane);
+            });
+        }
+
+        function showAllSidebarPlugins(pane) {
+            setSidebarPluginVisibility(pane, []);
+        }
+
+        function setSidebarPluginVisibility(pane, availablePlugins) {
+            // Hide any plugins which are not available, but if none are specifically made
+            // available, all will be available.
+
+            var plugins = pane.get('plugins'),
+                anyAvailable = !_.isEmpty(availablePlugins);
+
+            plugins.each(function(plugin) {
+                var type = plugin.get('pluginObject').toolbarType,
+                    pluginLauncherSelector = '.' + plugin.getId() + '-' + pane.get('paneNumber');
+
+                if (anyAvailable && type === 'sidebar'
+                    && !_.contains(availablePlugins, plugin.getId())) {
+                    $(pluginLauncherSelector).hide();
+
+                    // Also hide the ui container if it happens to be showing.
+                    plugin.get('$uiContainer').hide();
+                } else {
+                    $(pluginLauncherSelector).show();
+                }
+            });
+        }
+
+        function invokeOnPlugins(model, methodName, args) {
             var plugins = model.get('plugins');
             plugins.each(function(plugin) {
                 var pluginObj = plugin.model.get('pluginObject');
@@ -80,396 +84,399 @@
                     pluginObj[methodName].apply(pluginObj, args);
                 }
             });
-    }
-    function getHomeExtent(model) {
-        var x = model.get('regionData').initialExtent,
-            extent = new esri.geometry.Extent(
-                x[0], x[1], x[2], x[3],
-                new esri.SpatialReference({ wkid: 4326 /*lat-long*/ })
-            );
-        return extent;
-    }
+        }
 
-    function createPlugins(model) {
-        // Iterate over plugin classes in top-level namespace,
-        // instantiate them, and wrap them in backbone objects
+        function getHomeExtent(model) {
+            var x = model.get('regionData').initialExtent,
+                extent = new Extent(
+                    x[0], x[1], x[2], x[3],
+                    new SpatialReference({
+                        wkid: 4326 /*lat-long*/
+                    })
+                );
+            return extent;
+        }
 
-        var plugins = new N.collections.Plugins();
+        function createPlugins(model) {
+            // Iterate over plugin classes in top-level namespace,
+            // instantiate them, and wrap them in backbone objects
 
-        _.each(N.plugins, function (PluginClass, i) {
-            var pluginObject = new PluginClass(),
-                plugin = new N.models.Plugin({
-                    pluginObject: pluginObject,
-                    pluginSrcFolder: model.get('regionData').pluginFolderNames[i]
-                });
+            var plugins = new N.collections.Plugins();
 
-            // Load plugin only if it passes a compliance check ...
-            if (plugin.isCompliant()) {
-                // ... and if we're on map 2, and the plugin isn't on the blacklist
-                if (model.get('paneNumber') === 1) {
-                    if (getPluginMap2Availability(plugin.getId())) {
+            _.each(N.plugins, function(PluginClass, i) {
+                var pluginObject = new PluginClass(),
+                    plugin = new N.models.Plugin({
+                        pluginObject: pluginObject,
+                        pluginSrcFolder: model.get('regionData').pluginFolderNames[i]
+                    });
+
+                // Load plugin only if it passes a compliance check ...
+                if (plugin.isCompliant()) {
+                    // ... and if we're on map 2, and the plugin isn't on the blacklist
+                    if (model.get('paneNumber') === 1) {
+                        if (getPluginMap2Availability(plugin.getId())) {
+                            plugins.add(plugin);
+                        }
+                    } else {
                         plugins.add(plugin);
                     }
                 } else {
-                    plugins.add(plugin);
+                    console.log('Plugin: Pane[' + model.get('paneNumber') + '] - ' +
+                        pluginObject.toolbarName +
+                        ' is not loaded due to improper interface');
                 }
-            } else {
-                console.log('Plugin: Pane[' + model.get('paneNumber') + '] - ' + 
-                    pluginObject.toolbarName +
-                    ' is not loaded due to improper interface');
+            });
+
+            model.set('plugins', plugins);
+        }
+
+        function getPluginMap2Availability(pluginId) {
+            if (_.indexOf(N.app.data.region.map2PluginBlacklist, pluginId) === -1) {
+                return true;
             }
-        });
 
-        model.set('plugins', plugins);
-    }
-
-    function getPluginMap2Availability(pluginId) {
-        if (_.indexOf(N.app.data.region.map2PluginBlacklist, pluginId) === -1) {
-            return true;
+            return false;
         }
 
-        return false;
-    }
+        // initPlugins() is separate from createPlugins() because:
+        //     - We need to create plugin objects before rendering (so we can render their toolbar names).
+        //     - We need to pass a map object to the plugin constructors, but that isn't available until after rendering. 
 
-    // initPlugins() is separate from createPlugins() because:
-    //     - We need to create plugin objects before rendering (so we can render their toolbar names).
-    //     - We need to pass a map object to the plugin constructors, but that isn't available until after rendering. 
+        function initPlugins(model, esriMap) {
+            var mapModel = model.get('mapModel'),
+                regionData = model.get('regionData'),
+                savedState = model.get('stateOfPlugins');
 
-    function initPlugins(model, esriMap) {
-        var mapModel = model.get('mapModel'),
-            regionData = model.get('regionData'),
-            savedState = model.get('stateOfPlugins');
-
-        model.get('plugins').each(function(pluginModel) {
-            pluginModel.initPluginObject(regionData, mapModel, esriMap);
-        });
-
-        // Wait a second before activating a permaline (scenario) to ensure the map
-        // layer is loaded.
-        _.delay(function() {
-            activateScenario(model, savedState, model.get('activeSubregion'));
-        }, 1000);
-    }
-
-    function activateScenario(pane, stateOfPlugins, activeSubregion) {
-        var mapNumber = pane.get('mapModel').get('mapNumber');
-        if (activeSubregion) {  
-            N.app.dispatcher.trigger('launchpad:activate-subregion', { 
-                id: activeSubregion.id,
-                preventZoom: true,
-                mapNumber: mapNumber
+            model.get('plugins').each(function(pluginModel) {
+                pluginModel.initPluginObject(regionData, mapModel, esriMap);
             });
-        } else {
-            N.app.dispatcher.trigger('launchpad:deactivate-subregion', {mapNumber: mapNumber});
+
+            // Wait a second before activating a permaline (scenario) to ensure the map
+            // layer is loaded.
+            _.delay(function() {
+                activateScenario(model, savedState, model.get('activeSubregion'));
+            }, 1000);
         }
 
-        // For each plugin, turn it off to remove any currently loaded state, then 
-        // once it is completely off, set the state of the plugin if it is participating
-        // in this scenario.  If it did have state, inform it that it is now active. 
-        pane.get('plugins').each(function(pluginModel) {
-            pluginModel.turnOff(function() {
-                var stateWasSet = pane.setPluginState(pluginModel, stateOfPlugins, activeSubregion);
-                if (stateWasSet) {
-                    pluginModel.get('pluginObject').activate(activeSubregion);
-                }
+        function activateScenario(pane, stateOfPlugins, activeSubregion) {
+            var mapNumber = pane.get('mapModel').get('mapNumber');
+            if (activeSubregion) {
+                N.app.dispatcher.trigger('launchpad:activate-subregion', {
+                    id: activeSubregion.id,
+                    preventZoom: true,
+                    mapNumber: mapNumber
+                });
+            } else {
+                N.app.dispatcher.trigger('launchpad:deactivate-subregion', { mapNumber: mapNumber });
+            }
+
+            // For each plugin, turn it off to remove any currently loaded state, then 
+            // once it is completely off, set the state of the plugin if it is participating
+            // in this scenario.  If it did have state, inform it that it is now active. 
+            pane.get('plugins').each(function(pluginModel) {
+                pluginModel.turnOff(function() {
+                    var stateWasSet = pane.setPluginState(pluginModel, stateOfPlugins, activeSubregion);
+                    if (stateWasSet) {
+                        pluginModel.get('pluginObject').activate(activeSubregion);
+                    }
+                });
             });
-        });
-    }
+        }
 
-    N.models = N.models || {};
-    N.models.Pane = Backbone.Model.extend({
-        defaults: {
-            paneNumber: 0,
-            regionData: null,
-            mapModel: null,
-            plugins: null,
-            stateOfPlugins: {}
-        },
+        N.models = N.models || {};
+        N.models.Pane = Backbone.Model.extend({
+            defaults: {
+                paneNumber: 0,
+                regionData: null,
+                mapModel: null,
+                plugins: null,
+                stateOfPlugins: {}
+            },
 
-        initialize: function () { 
-            var self = this;
+            initialize: function() {
+                var self = this;
 
-            N.app.dispatcher.on('launchpad:activate-scenario', function(scenarioState) {
-                var state = Backbone.HashModels.decodeStateObject(scenarioState),
-                    paneState = state['pane' + self.get('paneNumber')],
-                    pluginState = {},
-                    activeSubregion = null;
+                N.app.dispatcher.on('launchpad:activate-scenario', function(scenarioState) {
+                    var state = Backbone.HashModels.decodeStateObject(scenarioState),
+                        paneState = state['pane' + self.get('paneNumber')],
+                        pluginState = {},
+                        activeSubregion = null;
 
-                if (paneState && paneState.stateOfPlugins) {
-                    pluginState = paneState.stateOfPlugins;
-                    activeSubregion = paneState.activeSubregion;
-                }
+                    if (paneState && paneState.stateOfPlugins) {
+                        pluginState = paneState.stateOfPlugins;
+                        activeSubregion = paneState.activeSubregion;
+                    }
 
-                activateScenario(self, pluginState, activeSubregion);
-            });
+                    activateScenario(self, pluginState, activeSubregion);
+                });
 
-            return initialize(this); 
-        },
+                return initialize(this);
+            },
 
-        initPlugins: function (esriMap) { return initPlugins(this, esriMap); },
+            initPlugins: function(esriMap) { return initPlugins(this, esriMap); },
 
-        setPluginState: function(pluginModel, savedState) {
-            var stateWasSet = false;
+            setPluginState: function(pluginModel, savedState) {
+                var stateWasSet = false;
 
-            if (savedState) {
-                // If the saved state included data for this plugin, set it.
-                if (savedState.plugins) {
-                    var pluginState = savedState.plugins[pluginModel.name()],
-                        pluginObject = pluginModel.get('pluginObject');
+                if (savedState) {
+                    // If the saved state included data for this plugin, set it.
+                    if (savedState.plugins) {
+                        var pluginState = savedState.plugins[pluginModel.name()],
+                            pluginObject = pluginModel.get('pluginObject');
 
-                    if (pluginState) {
-                        // Turn the plugin off in case it has currently loaded state
-                        // which should be reset prior to setting the new state
-                        pluginObject.hibernate();
-                        pluginModel.setState(pluginState, savedState.activeSubregion);
-                        stateWasSet = true;
-                    } else {
-                        pluginObject.hibernate();
+                        if (pluginState) {
+                            // Turn the plugin off in case it has currently loaded state
+                            // which should be reset prior to setting the new state
+                            pluginObject.hibernate();
+                            pluginModel.setState(pluginState, savedState.activeSubregion);
+                            stateWasSet = true;
+                        } else {
+                            pluginObject.hibernate();
+                        }
+                    }
+
+                    // If this plugin was selected, whether it set data or not,
+                    // select the plugin to activate.
+                    if (savedState.selectedPlugin === pluginModel.name()) {
+                        pluginModel.select();
                     }
                 }
-                
-                // If this plugin was selected, whether it set data or not,
-                // select the plugin to activate.
-                if (savedState.selectedPlugin === pluginModel.name()) {
-                    pluginModel.select();
-                }
+
+                return stateWasSet;
             }
-
-            return stateWasSet;
-        }
-    });
-
-}(Geosite));
-
-(function (N) {
-    'use strict';
-
-    function initialize(view) {
-        render(view);
-        initBasemapSelector(view);
-        initMapView(view);
-        initPluginViews(view);
-        view.$('.side-nav.top').mCustomScrollbar({
-            advanced: { updateOnContentResize: true },
-            mouseWheelPixels: 75,
-            autoHideScrollbar: false,
-            contentTouchScroll: true
-        });
-        N.app.models.screen.on('change', function () { renderSidebar(view); });
-        
-        // The scrollbar is inconsistent in showing up, and I suspect that it is
-        // due to the content height not being specified when it calculates if it
-        // needs to be displayed or not.  Wait a little while and then update the
-        // scrollbar to let it determine visibility post render.
-        setTimeout(function () { view.$('.side-nav.top').mCustomScrollbar("update"); }, 1000);
-
-        // Detects orientation change and updates the scrollbar
-        window.onorientationchange = function() {
-            view.$('.side-nav.top').mCustomScrollbar('update');
-        };
-
-        // For on demand export initialization. See Layer Selector print, for example.
-        var paneNumber = view.model.get('paneNumber');
-        N.app.dispatcher.on('export-map:pane-' + paneNumber, function() {
-            view.exportMap();
-        });
-    }
-
-    function render(view) {
-        var paneTemplate = N.app.templates['template-pane'],
-            html = paneTemplate(view.model.toJSON());
-        view.$el.append(html);
-        renderSidebar(view);
-
-        renderSidebarLinks(view);
-    }
-
-    function renderSidebar(view) {
-        var sidebarTemplate = N.app.templates['template-sidebar'],
-            paneNumber = view.model.get('paneNumber'),
-            data = _.extend(N.app.models.screen.toJSON(), {
-                paneNumber: paneNumber,
-                isMain: paneNumber === N.app.models.screen.get('mainPaneNumber'),
-                alternatePaneNumber: paneNumber === 0 ? 1 : 0
-            }),
-            html = sidebarTemplate(data);
-
-        view.$('.bottom.side-nav').empty().append(html);
-    }
-
-    // TODO: Sidebar links aren't in the prototype - do we have anything for them?
-    function renderSidebarLinks(view) {
-        var regionData = view.model.get('regionData'),
-            linkTemplate = N.app.templates['template-sidebar-link'],
-            $links = view.$('.sidebar-links');
-        _.each(regionData.sidebarLinks, function (link) {
-            var html = linkTemplate({ link: link });
-            $links.append(html);
-        });
-    }
-
-    function initBasemapSelector(view) {
-        new N.views.BasemapSelector({
-            model: view.model.get('mapModel'),
-            el: view.$('.basemap-selector')
-        });
-    }
-
-    function initMapView(view) {
-        view.mapView = new N.views.Map({
-            model: view.model.get('mapModel'),
-            el: view.$('.map'),
-            paneNumber: view.model.get('paneNumber')
         });
 
-        var esriMap = view.mapView.esriMap;
+    }());
 
-        // Wait for the map to load
-        dojo.connect(esriMap, "onLoad", function () {
-            // Initialize plugins now that all map properties are available (e.g. extent)
-            view.model.initPlugins(esriMap);
+    (function () {
+        'use strict';
 
-            // Framework level support for identify is off by default and must
-            // be enabled in the region config
-            if (view.model.get('regionData').identifyEnabled) {
-                // Clicking the map means "Identify" contents at a point
-                dojo.connect(esriMap, "onClick", tryIdentify);
-            }
-            
-            adjustToolPositions(view, esriMap);
-        });
-
-        function tryIdentify(event) {
-            // Check if 'identify' is possible and then execute.
-            //
-            // the framework level 'identify' feature can be disabled by
-            // an active plugin if the plugin uses the map click for another
-            // purpose.
-            var pluginModels = view.model.get('plugins');
-            if (!pluginModels.selected ||
-                pluginModels.selected.get('pluginObject').allowIdentifyWhenActive) {
-                view.mapView.doIdentify(pluginModels, event);
-            }
-        }
-    }
-
-    function initPluginViews(view) {
-        // create a view for each plugin model (it will render), and add its element
-        // to the appropriate plugin section
-        var $sidebar = view.$('.plugins'),
-            $maptopbar = view.$('.top-tools'),
-            $mapbar = view.$('.tools'),
-            regionData = view.model.get('regionData'),
-            plugins = view.model.get('plugins'),
-            invalidPlugins = plugins.reject(function(plugin) {
-                return plugin.get('pluginObject').validate(regionData);
+        function initialize(view) {
+            render(view);
+            initBasemapSelector(view);
+            initMapView(view);
+            initPluginViews(view);
+            view.$('.side-nav.top').mCustomScrollbar({
+                advanced: { updateOnContentResize: true },
+                mouseWheelPixels: 75,
+                autoHideScrollbar: false,
+                contentTouchScroll: true
             });
+            N.app.models.screen.on('change', function() { renderSidebar(view); });
 
-        plugins.remove(invalidPlugins);
-        
-        plugins.each(function (plugin) {
-            var toolbarType = plugin.get('pluginObject').toolbarType;
-            if (toolbarType === 'sidebar') {
-                new N.views.SidebarPlugin({
-                    model: plugin,
-                    $parent: $sidebar,
-                    paneNumber: view.model.get('paneNumber')
-                });
-            } else {
-                var $parent = null;
-                if (toolbarType === 'maptop') {
-                    $parent = $maptopbar;
-                } else if (toolbarType === 'map') {
-                    $parent = $mapbar;
-                } else {
-                    throw "Invalid plugin toolbarType: '" + toolbarType + "'";
-                }
-                new N.views.TopbarPlugin({
-                    model: plugin,
-                    $parent: $parent
-                });
-            }
-        });
-    }
+            // The scrollbar is inconsistent in showing up, and I suspect that it is
+            // due to the content height not being specified when it calculates if it
+            // needs to be displayed or not.  Wait a little while and then update the
+            // scrollbar to let it determine visibility post render.
+            setTimeout(function() { view.$('.side-nav.top').mCustomScrollbar("update"); }, 1000);
 
-    function adjustToolPositions(view, esriMap) {
-        // If there are tools above the "+/-" zoom buttons, move everything down
-        var nMapTopPlugins = view.$('.top-tools').children().length;
-        if (nMapTopPlugins > 0) {
-            var $zoomButtons = view.$('#' + esriMap.id + '_zoom_slider'),
-                $mapbar = view.$('.tools');
-            lowerTool($zoomButtons, nMapTopPlugins);
-            lowerTool($mapbar, nMapTopPlugins);
+            // Detects orientation change and updates the scrollbar
+            window.onorientationchange = function() {
+                view.$('.side-nav.top').mCustomScrollbar('update');
+            };
+
+            // For on demand export initialization. See Layer Selector print, for example.
+            var paneNumber = view.model.get('paneNumber');
+            N.app.dispatcher.on('export-map:pane-' + paneNumber, function() {
+                view.exportMap();
+            });
         }
-    }
 
-    function lowerTool($el, toolCount) {
-        // Move $el lower on the page by "toolCount" slots
-        var pluginButtonHeight = 44,
-            offset = $el.offset();
-        offset.top += toolCount * pluginButtonHeight;
-        $el.offset(offset);
-    }
+        function render(view) {
+            var paneTemplate = N.app.templates['template-pane'],
+                html = paneTemplate(view.model.toJSON());
+            view.$el.append(html);
+            renderSidebar(view);
 
-    N.views = N.views || {};
-    N.views.Pane = Backbone.View.extend({
-        mapView: null,
+            renderSidebarLinks(view);
+        }
 
-        initialize: function (view) { initialize(this); },
-
-        events: {
-            'click .export-button': 'exportMap'
-        },
-
-        exportMap: function exportMap() {
-            var model = new N.models.ExportTool({
-                    esriMap: this.mapView.esriMap,
-                    paneNumber: this.model.get('paneNumber')
+        function renderSidebar(view) {
+            var sidebarTemplate = N.app.templates['template-sidebar'],
+                paneNumber = view.model.get('paneNumber'),
+                data = _.extend(N.app.models.screen.toJSON(), {
+                    paneNumber: paneNumber,
+                    isMain: paneNumber === N.app.models.screen.get('mainPaneNumber'),
+                    alternatePaneNumber: paneNumber === 0 ? 1 : 0
                 }),
-                view = new N.views.ExportTool({ model: model });
+                html = sidebarTemplate(data);
 
-            TINY.box.show({
-                html: view.render().el,
-                fixed: true,
-                maskopacity:50,
-                closejs: function () { view.remove(); }
+            view.$('.bottom.side-nav').empty().append(html);
+        }
+
+        // TODO: Sidebar links aren't in the prototype - do we have anything for them?
+        function renderSidebarLinks(view) {
+            var regionData = view.model.get('regionData'),
+                linkTemplate = N.app.templates['template-sidebar-link'],
+                $links = view.$('.sidebar-links');
+            _.each(regionData.sidebarLinks, function(link) {
+                var html = linkTemplate({ link: link });
+                $links.append(html);
             });
-        },
+        }
 
-        saveState: function () {
-            /*
+        function initBasemapSelector(view) {
+            new N.views.BasemapSelector({
+                model: view.model.get('mapModel'),
+                el: view.$('.basemap-selector')
+            });
+        }
+
+        function initMapView(view) {
+            view.mapView = new N.views.Map({
+                model: view.model.get('mapModel'),
+                el: view.$('.map'),
+                paneNumber: view.model.get('paneNumber')
+            });
+
+            var esriMap = view.mapView.esriMap;
+
+            // Wait for the map to load
+            dojo.connect(esriMap, "onLoad", function() {
+                // Initialize plugins now that all map properties are available (e.g. extent)
+                view.model.initPlugins(esriMap);
+
+                // Framework level support for identify is off by default and must
+                // be enabled in the region config
+                if (view.model.get('regionData').identifyEnabled) {
+                    // Clicking the map means "Identify" contents at a point
+                    dojo.connect(esriMap, "onClick", tryIdentify);
+                }
+
+                adjustToolPositions(view, esriMap);
+            });
+
+            function tryIdentify(event) {
+                // Check if 'identify' is possible and then execute.
+                //
+                // the framework level 'identify' feature can be disabled by
+                // an active plugin if the plugin uses the map click for another
+                // purpose.
+                var pluginModels = view.model.get('plugins');
+                if (!pluginModels.selected ||
+                    pluginModels.selected.get('pluginObject').allowIdentifyWhenActive) {
+                    view.mapView.doIdentify(pluginModels, event);
+                }
+            }
+        }
+
+        function initPluginViews(view) {
+            // create a view for each plugin model (it will render), and add its element
+            // to the appropriate plugin section
+            var $sidebar = view.$('.plugins'),
+                $maptopbar = view.$('.top-tools'),
+                $mapbar = view.$('.tools'),
+                regionData = view.model.get('regionData'),
+                plugins = view.model.get('plugins'),
+                invalidPlugins = plugins.reject(function(plugin) {
+                    return plugin.get('pluginObject').validate(regionData);
+                });
+
+            plugins.remove(invalidPlugins);
+
+            plugins.each(function(plugin) {
+                var toolbarType = plugin.get('pluginObject').toolbarType;
+                if (toolbarType === 'sidebar') {
+                    new N.views.SidebarPlugin({
+                        model: plugin,
+                        $parent: $sidebar,
+                        paneNumber: view.model.get('paneNumber')
+                    });
+                } else {
+                    var $parent = null;
+                    if (toolbarType === 'maptop') {
+                        $parent = $maptopbar;
+                    } else if (toolbarType === 'map') {
+                        $parent = $mapbar;
+                    } else {
+                        throw "Invalid plugin toolbarType: '" + toolbarType + "'";
+                    }
+                    new N.views.TopbarPlugin({
+                        model: plugin,
+                        $parent: $parent
+                    });
+                }
+            });
+        }
+
+        function adjustToolPositions(view, esriMap) {
+            // If there are tools above the "+/-" zoom buttons, move everything down
+            var nMapTopPlugins = view.$('.top-tools').children().length;
+            if (nMapTopPlugins > 0) {
+                var $zoomButtons = view.$('#' + esriMap.id + '_zoom_slider'),
+                    $mapbar = view.$('.tools');
+                lowerTool($zoomButtons, nMapTopPlugins);
+                lowerTool($mapbar, nMapTopPlugins);
+            }
+        }
+
+        function lowerTool($el, toolCount) {
+            // Move $el lower on the page by "toolCount" slots
+            var pluginButtonHeight = 44,
+                offset = $el.offset();
+            offset.top += toolCount * pluginButtonHeight;
+            $el.offset(offset);
+        }
+
+        N.views = N.views || {};
+        N.views.Pane = Backbone.View.extend({
+            mapView: null,
+
+            initialize: function(view) { initialize(this); },
+
+            events: {
+                'click .export-button': 'exportMap'
+            },
+
+            exportMap: function exportMap() {
+                var model = new N.models.ExportTool({
+                        esriMap: this.mapView.esriMap,
+                        paneNumber: this.model.get('paneNumber')
+                    }),
+                    view = new N.views.ExportTool({ model: model });
+
+                TINY.box.show({
+                    html: view.render().el,
+                    fixed: true,
+                    maskopacity: 50,
+                    closejs: function() { view.remove(); }
+                });
+            },
+
+            saveState: function() {
+                /*
                Traverse all child objects and either tell them to
                save their state if they are a backbone model registered
                with hashmodels, or get their state from them and stick
                it in our own model's pluginState object.
             */
-            var plugins = this.model.get('plugins'),
-                stateOfPlugins = {},
-                selected = null;
+                var plugins = this.model.get('plugins'),
+                    stateOfPlugins = {},
+                    selected = null;
 
-            plugins.each(function (plugin) {
-                var state = plugin.getState();
+                plugins.each(function(plugin) {
+                    var state = plugin.getState();
 
-                // Track which plugin is open
-                if (plugin.selected && !selected) {
-                    selected = plugin.name();
-                }
-                if (state && Object.keys(state).length > 0) {
-                    stateOfPlugins[plugin.name()] = state;
-                }
-            });
+                    // Track which plugin is open
+                    if (plugin.selected && !selected) {
+                        selected = plugin.name();
+                    }
+                    if (state && Object.keys(state).length > 0) {
+                        stateOfPlugins[plugin.name()] = state;
+                    }
+                });
 
-            var savedState = {
-                selectedPlugin: selected,
-                activeSubregion: this.model.get('activeSubregion'),
-                plugins: stateOfPlugins
-            };
-            this.model.set('stateOfPlugins', savedState);
+                var savedState = {
+                    selectedPlugin: selected,
+                    activeSubregion: this.model.get('activeSubregion'),
+                    plugins: stateOfPlugins
+                };
+                this.model.set('stateOfPlugins', savedState);
 
-            // backbone objects that are tracked by HashModels
-            this.mapView.saveState();
-        }
+                // backbone objects that are tracked by HashModels
+                this.mapView.saveState();
+            }
 
-    });
-
-}(Geosite));
+        });
+    }());
+});

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -4,6 +4,8 @@
 // A plugin wraps around a plugin object and manages it in backbone
 
 require(['use!Geosite',
+         'esri/map',
+         'esri/layers/ArcGISDynamicMapServiceLayer',
          'framework/Logger',
          'dojo/dom-style',
          'framework/widgets/ConstrainedMoveable',
@@ -12,6 +14,8 @@ require(['use!Geosite',
          'dijit/form/Button'
         ],
     function(N,
+             Map,
+             ArcGISDynamicMapServiceLayer,
              Logger,
              domStyle,
              ConstrainedMoveable,
@@ -500,10 +504,10 @@ require(['use!Geosite',
                     $('#plugin-print-preview-map').css({ height: mapHeight, width: mapWidth });
 
                     var originalMap = pluginObject.app._unsafeMap,
-                        map = new esri.Map('plugin-print-preview-map', { extent: originalMap.extent }),
+                        map = new Map('plugin-print-preview-map', { extent: originalMap.extent }),
                         currentBaseMapUrl = originalMap.getLayer(originalMap.layerIds[0]).url;
 
-                    map.addLayer(new esri.layers.ArcGISDynamicMapServiceLayer(currentBaseMapUrl));
+                    map.addLayer(new ArcGISDynamicMapServiceLayer(currentBaseMapUrl));
 
                     dojo.connect(map, 'onLoad', function() {
                         mapReadyDeferred.resolve(map);

--- a/src/GeositeFramework/js/SubRegion.js
+++ b/src/GeositeFramework/js/SubRegion.js
@@ -1,10 +1,22 @@
 ﻿require(['use!Geosite',
          'esri/dijit/Popup',
-         'esri/geometry/Polygon'
+         'esri/geometry/Polygon',
+         'esri/SpatialReference',
+         'esri/layers/GraphicsLayer',
+         'esri/symbols/SimpleFillSymbol',
+         'esri/symbols/SimpleLineSymbol',
+         'esri/InfoTemplate',
+         'esri/graphic'
         ],
     function(N,
              Popup,
-             Polygon) {
+             Polygon,
+             SpatialReference,
+             GraphicsLayer,
+             SimpleFillSymbol,
+             SimpleLineSymbol,
+             InfoTemplate,
+             Graphic) {
 
     'use strict';
 
@@ -26,7 +38,7 @@
         self.initialExtent = parseExtent(N.app.data.region.initialExtent);
 
         // Graphics layer that will hold the sub-region vectors
-        self.subRegionLayer = new esri.layers.GraphicsLayer();
+        self.subRegionLayer = GraphicsLayer();
         self.subRegionLayer.setOpacity(subregions.opacity);
         self.map.addLayer(self.subRegionLayer);
 
@@ -153,16 +165,16 @@
     function parseExtent(coords) {
         return esri.geometry.Extent(
             coords[0], coords[1], coords[2], coords[3],
-            new esri.SpatialReference({ wkid: 4326 /*lat-long*/ })
+            new SpatialReference({ wkid: 4326 /*lat-long*/ })
         );
     }
 
     function addSubRegionsToMap(subregions, layer) {
         _.each(subregions.areas, function(subregion) {
-            var geom = new esri.geometry.Polygon(subregion.shape);
-            var symbol = new esri.symbol.SimpleFillSymbol();
-            var outline = new esri.symbol.SimpleLineSymbol(
-                    esri.symbol.SimpleLineSymbol.STYLE_SOLID,
+            var geom = new Polygon(subregion.shape);
+            var symbol = SimpleFillSymbol();
+            var outline = new SimpleLineSymbol(
+                    SimpleLineSymbol.STYLE_SOLID,
                     new dojo.Color(subregion.outlineColor || subregions.outlineColor), 2);
 
             symbol.setColor(new dojo.Color(subregion.color || subregions.color));
@@ -171,11 +183,11 @@
                 symbol.setColor(new dojo.Color([0, 0, 0, 0]));
             }
 
-            var infoTemplate = new esri.InfoTemplate();
+            var infoTemplate = new InfoTemplate();
             // display is the field containing the subregion name
             infoTemplate.setContent("${display}");
 
-            var graphic = new esri.Graphic(geom, symbol, subregion, infoTemplate);
+            var graphic = new Graphic(geom, symbol, subregion, infoTemplate);
 
             layer.add(graphic);
         });

--- a/src/GeositeFramework/plugins/full_extent/main.js
+++ b/src/GeositeFramework/plugins/full_extent/main.js
@@ -21,16 +21,21 @@ require({
 });
 
 define(
-    ["dojo/_base/declare", "framework/PluginBase"],
-    function (declare, PluginBase) {
+    [
+    "dojo/_base/declare",
+    "framework/PluginBase",
+    "esri/geometry/Extent",
+    "esri/SpatialReference"],
+
+    function (declare, PluginBase, Extent, SpatialReference) {
         var _extent;
         
         function fullExtent (regionConfig)
         {
             var x = regionConfig.initialExtent,
-                extent = new esri.geometry.Extent(
+                extent = new Extent(
                     x[0], x[1], x[2], x[3],
-                    new esri.SpatialReference({ wkid: 4326 /*lat-long*/ })
+                    new SpatialReference({ wkid: 4326 /*lat-long*/ })
                 );
             return extent;   
         }

--- a/src/GeositeFramework/plugins/measure/AgsMeasure.js
+++ b/src/GeositeFramework/plugins/measure/AgsMeasure.js
@@ -8,7 +8,13 @@ define(["jquery",
         "esri/geometry/ScreenPoint",
         "esri/geometry/mathUtils",
         "esri/units",
-        "esri/dijit/InfoWindow"],
+        "esri/dijit/InfoWindow",
+        "esri/symbols/SimpleFillSymbol",
+        "esri/symbols/SimpleLineSymbol",
+        "esri/symbols/SimpleMarkerSymbol",
+        "esri/graphic",
+        "esri/layers/GraphicsLayer"
+],
     function($, _,
               Polyline,
               Polygon,
@@ -18,7 +24,13 @@ define(["jquery",
               ScreenPoint,
               mathUtils,
               units,
-              InfoWindow) {
+              InfoWindow,
+              SimpleFillSymbol,
+              SimpleLineSymbol,
+              SimpleMarkerSymbol,
+              Graphic,
+              GraphicsLayer) {
+
         var AgsMeasure = function (opts) {
 
             var options = _.extend({
@@ -29,29 +41,29 @@ define(["jquery",
                 // this url is non-warranty "production" ready
                 geomServiceUrl: 'http://tasks.arcgisonline.com/ArcGIS/rest/services/Geometry/GeometryServer',
 
-                pointSymbol: new esri.symbol.SimpleMarkerSymbol(
-                    esri.symbol.SimpleMarkerSymbol.STYLE_CIRCLE, 10,
-                    new esri.symbol.SimpleLineSymbol(esri.symbol.SimpleLineSymbol.STYLE_SOLID,
+                pointSymbol: new SimpleMarkerSymbol(
+                    SimpleMarkerSymbol.STYLE_CIRCLE, 10,
+                    new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
                         new dojo.Color([105, 105, 105]), 1),
                         new dojo.Color([80, 80, 80, 0.35])),
 
-                lineSymbol: new esri.symbol.SimpleLineSymbol(
+                lineSymbol: new SimpleLineSymbol(
                         esri.symbol.SimpleLineSymbol.STYLE_DASH,
                         new dojo.Color([105, 105, 105]), 2),
 
-                polygonSymbol: new esri.symbol.SimpleFillSymbol(
-                    esri.symbol.SimpleFillSymbol.STYLE_SOLID,
-                    new esri.symbol.SimpleLineSymbol(esri.symbol.SimpleLineSymbol.STYLE_DASH,
+                polygonSymbol: new SimpleFillSymbol(
+                    SimpleFillSymbol.STYLE_SOLID,
+                    new SimpleLineSymbol(SimpleLineSymbol.STYLE_DASH,
                         new dojo.Color([105, 105, 105]), 2),
                         new dojo.Color([105, 105, 105, 0.25])),
 
-                hoverLineSymbol: new esri.symbol.SimpleLineSymbol(
-                        esri.symbol.SimpleLineSymbol.STYLE_SOLID,
+                hoverLineSymbol: new SimpleLineSymbol(
+                        SimpleLineSymbol.STYLE_SOLID,
                         new dojo.Color([105, 105, 105]), 2),
 
-                hoverPointSymbol: new esri.symbol.SimpleMarkerSymbol(
-                    esri.symbol.SimpleMarkerSymbol.STYLE_CIRCLE, 15,
-                    new esri.symbol.SimpleLineSymbol(esri.symbol.SimpleLineSymbol.STYLE_SOLID,
+                hoverPointSymbol: new SimpleMarkerSymbol(
+                    SimpleMarkerSymbol.STYLE_CIRCLE, 15,
+                    new SimpleLineSymbol(SimpleLineSymbol.STYLE_SOLID,
                         new dojo.Color([255, 0, 0]), 1),
                         new dojo.Color([255, 0, 0, 0.35])),
 
@@ -247,7 +259,7 @@ define(["jquery",
 
                 // Add the graphic of the line node to the map.  An index attribute
                 // is added to the graphic to enable querying of node-added order
-                var pointGraphic = new esri.Graphic(evt.mapPoint, options.pointSymbol,
+                var pointGraphic = new Graphic(evt.mapPoint, options.pointSymbol,
                     { index: _points.length });
                 _pointLayer.add(pointGraphic);
 
@@ -266,7 +278,7 @@ define(["jquery",
                     options.map.disableDoubleClickZoom();
 
                     // Setup the hover line symbology and add to the map
-                    _hoverLine = new esri.Graphic();
+                    _hoverLine = new Graphic();
                     _hoverLine.setSymbol(options.hoverLineSymbol);
                     _outlineLayer.add(_hoverLine);
 
@@ -277,7 +289,7 @@ define(["jquery",
                     line.setSpatialReference(options.map.spatialReference);
                     line.addPath(_.last(_points, 2));
 
-                    var lineGraphic = new esri.Graphic(line, options.lineSymbol);
+                    var lineGraphic = new Graphic(line, options.lineSymbol);
                     _outlineLayer.add(lineGraphic);
                 }
 
@@ -382,7 +394,7 @@ define(["jquery",
                 // Remove our lines for the outline layer and replace them
                 // with the new polygon area
                 _outlineLayer.clear();
-                _outlineLayer.add(new esri.Graphic(polygon, options.polygonSymbol));
+                _outlineLayer.add(new Graphic(polygon, options.polygonSymbol));
 
                 // Change the first node symbol to the default as we finish
                 setDefaultOriginPointSymbol(_defaultOriginPointGraphic);
@@ -396,8 +408,8 @@ define(["jquery",
             // Public methods
             return {
                 initialize: function () {
-                    _outlineLayer = new esri.layers.GraphicsLayer();
-                    _pointLayer = new esri.layers.GraphicsLayer();
+                    _outlineLayer = new GraphicsLayer();
+                    _pointLayer = new GraphicsLayer();
 
                     // Ordering of layers is important to not get hover-out events
                     // from a point when a line graphic is intersects it.

--- a/src/GeositeFramework/plugins/zoom_to/main.js
+++ b/src/GeositeFramework/plugins/zoom_to/main.js
@@ -16,9 +16,12 @@ define(
      "framework/PluginBase",
      "./ui", 
      "dojo/text!plugins/zoom_to/zoom_to.json",
-     "jquery"
+     "jquery",
+     "esri/SpatialReference",
+     "esri/geometry/Point"
     ],
-    function (declare, PluginBase, ui, configString, $) {
+    function (declare, PluginBase, ui, configString, $,
+        SpatialReference, Point) {
 
 // Had trouble getting jquery-jsonp to load using AMD.
 // Because jquery-jsonp is executed on jquery, rather
@@ -45,8 +48,8 @@ define(
             },
             
             initialize: function (args) {
-                var spatialReference = new esri.SpatialReference({ wkid: 4326 /* lat-lng */ }),
-                    point = function (x, y) { return new esri.geometry.Point(x, y, spatialReference); };
+                var spatialReference = new SpatialReference({ wkid: 4326 /* lat-lng */ }),
+                    point = function (x, y) { return new Point(x, y, spatialReference); };
 
                 declare.safeMixin(this, args);
                 this.config = JSON.parse(configString);

--- a/src/GeositeFramework/plugins/zoom_to/ui.js
+++ b/src/GeositeFramework/plugins/zoom_to/ui.js
@@ -1,7 +1,7 @@
 ﻿/*global _, $, esri, Backbone */
 
-define([],
-    function () {
+define(['esri/geometry/Extent'],
+    function (Extent) {
 
         ////////////////////////////////
         // TEMPLATES
@@ -189,7 +189,7 @@ define([],
             },
 
             centerAndZoom: function (x, y, rawExtentObj) {
-                var extent = new esri.geometry.Extent(rawExtentObj);
+                var extent = new Extent(rawExtentObj);
                 this.model.locator.map.setExtent(extent);
             },
 


### PR DESCRIPTION
* Converts failing `esri.` calls in export module to correct syntax to fix the broken export feature
* Remove all existing (and currently functioning) `esri.` calls
* Update the esri JS Bundle

Connects #500 

Test:
* Attempt to export the map
* Attempt to geocode an address
* Attempt to use the Launchpad to activate a subregion