### PR TITLE
Add stylistic header to popup

### DIFF
--- a/src/GeositeFramework/js/App.js
+++ b/src/GeositeFramework/js/App.js
@@ -126,6 +126,9 @@
                     // to match other popups
                     var headerHtml = '<div class="popover-header"></div>';
                     $('#'+this.boxid).prepend(headerHtml);
+                },
+                closejs: function() {
+                    $('#'+this.boxid).find('.popover-header').remove();
                 }
             });
 

--- a/src/GeositeFramework/js/App.js
+++ b/src/GeositeFramework/js/App.js
@@ -120,7 +120,13 @@
                 iframe: url,
                 boxid: 'frameless',
                 fixed: false,
-                maskopacity: 40
+                maskopacity: 40,
+                openjs: function() {
+                    // Insert a header after iframe is open to get the look
+                    // to match other popups
+                    var headerHtml = '<div class="popover-header"></div>';
+                    $('#'+this.boxid).prepend(headerHtml);
+                }
             });
 
         });


### PR DESCRIPTION
IFrame based Framework popups, like Partners, were obscuring the close
button and didn't have the header style of other popup types.

Connects #486 

Test:
* Click "GIS" on the test site and see if there is a blue border on the popup header.

![popups](https://cloud.githubusercontent.com/assets/1014341/12766810/81c0910c-c9d3-11e5-833b-ea58f7c87acd.png)
