### PR TITLE
Custom legend jumps

### DIFF
--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -1072,3 +1072,7 @@ body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide_left:after {
 #print-preview-print {
     float: right;
 }
+
+.esriLegendMsg {
+    display: none;
+}

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -322,7 +322,7 @@ require(['use!Geosite',
                 expectedMissingLayerCount = 1 + customLegendsActive + serviceOptOut;
 
             if ((totalVisibleLayers.length - expectedMissingLayerCount) !== nuggetCount) {
-                _.delay(updateLegend, 250);
+                _.delay(updateLegend, 750);
             }
         }
     }

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -307,8 +307,13 @@ require(['use!Geosite',
                 return !layer.graphics && layer.visible;
             });
 
-            // Subtract one for the base layer.
-            if ((totalVisibleLayers.length - 1) !== nuggetCount) {
+            // Subtract one for the base layer and one for each 
+            // custom legend that is visible and has children
+            var customLegendsActive = view.$legendEl.parent()
+                    .find('.custom-legend:visible').has('*').length,
+                expectedMissingLayerCount = 1 + customLegendsActive;
+
+            if ((totalVisibleLayers.length - expectedMissingLayerCount) !== nuggetCount) {
                 _.delay(updateLegend, 250);
             }
         }

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -248,7 +248,9 @@ require(['use!Geosite',
 
         function updateLegend() {
             var services = esriMap.getLayersVisibleAtScale(esriMap.getScale()),
-                layerInfos = [];
+                layerInfos = [],
+                serviceOptOut = 0;
+
             _.each(services, function (service) {
                 var serviceInfo = view.model.serviceInfos[service.id];
                 if (serviceInfo && serviceInfo.pluginObject.showServiceLayersInLegend) {
@@ -260,7 +262,13 @@ require(['use!Geosite',
                         layer = { layer: serviceInfo.service };
                     }
                     layerInfos.push(layer);
+                } else if (serviceInfo &&
+                    serviceInfo.service.declaredClass !== "esri.layers.FeatureLayer") {
+                    // Track layers that have opted out of having their 
+                    // services shown in the legend
+                    serviceOptOut++;
                 }
+
             });
             if (view.arrangedLegend) {
                 view.arrangedLegend.destroy();
@@ -311,7 +319,7 @@ require(['use!Geosite',
             // custom legend that is visible and has children
             var customLegendsActive = view.$legendEl.parent()
                     .find('.custom-legend:visible').has('*').length,
-                expectedMissingLayerCount = 1 + customLegendsActive;
+                expectedMissingLayerCount = 1 + customLegendsActive + serviceOptOut;
 
             if ((totalVisibleLayers.length - expectedMissingLayerCount) !== nuggetCount) {
                 _.delay(updateLegend, 250);


### PR DESCRIPTION
This is a stopgap measure to prevent legend flickering when using the
Habitat Explorer.  The comparison of layers on the map vs legends in the
Legend is expanded to account for possible custom legend.  The need to do
the comparison is a result of the existing unreliability of the JSAPI to
notify of `layerAdd` events.

Connects #502 

#### To test:

* Check that the legend does not flicker in the development build.
* Check that the future habitat plugin in split screen does not flicker (attached)
* Check that after turning on and turning off the Community Rating System plugin, there is no flicker.

#### Test Plugins

(Make sure these extract like `plugins/future_habitat/main.js`, the zip may double up the plugin directory path)
* [future_habitat.zip](https://github.com/CoastalResilienceNetwork/GeositeFramework/files/116013/future_habitat.zip)
* [community-rating-system.zip](https://github.com/CoastalResilienceNetwork/GeositeFramework/files/116309/community-rating-system.zip)
