### PR TITLE
Rebuild layers after fetching data

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector_v2/State.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/State.js
@@ -282,7 +282,7 @@ define([
                 }
 
                 return fetch(layer)
-                        .then(self.rebuildLayers())
+                        .then(_.bind(this.rebuildLayers, this))
                         .then(function() {
                             return self.findLayer(layerId);
                         });
@@ -307,9 +307,7 @@ define([
 
                             return ajaxUtil.fetch(url);
                         })
-                        .then(function() {
-                            self.rebuildLayers();
-                        })
+                        .then(_.bind(this.rebuildLayers, this))
                         .then(function() {
                             return self.findLayer(layer.id());
                         });


### PR DESCRIPTION
Fixes a small bug where `rebuildLayers` is called  *before* the map service
has been fetched instead of *after* it has been fetched. Some layers
need to be activated twice to add them to the map without this fix.