### PR TITLE
Add support for adjusting layer opacity.

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector_v2/LayerNode.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/LayerNode.js
@@ -143,6 +143,10 @@ define([
 
             isCombined: function() {
                 return this.node.combine;
+            },
+
+            getOpacity: function() {
+                return this.node.opacity;
             }
         });
     }

--- a/src/GeositeFramework/plugins/layer_selector_v2/layers.json
+++ b/src/GeositeFramework/plugins/layer_selector_v2/layers.json
@@ -124,5 +124,27 @@
                 "displayName": "Hurricane Sandy - County Impact Analysis"
             }
         ]
+    },
+    {
+        "displayName": "Alabama",
+        "server": {
+            "type": "ags",
+            "layerType": "dynamic",
+            "url": "http://dev.services2.coastalresilience.org/arcgis/rest/services/Gulf_of_Mexico/",
+            "name": "Alabama"
+        },
+        "includeLayers": [
+            {
+                "name": "1880 Oyster Reefs",
+                "opacity": 0.8
+            },
+            {
+                "name": "1968 Oyster Reefs"
+            },
+            {
+                "name": "1995 Oyster Reefs",
+                "opacity": 0.2
+            }
+        ]
     }
 ]

--- a/src/GeositeFramework/plugins/layer_selector_v2/schema.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/schema.js
@@ -26,7 +26,8 @@
                 includeAllLayers: { type: 'boolean' },
                 includeLayers: { type: 'array', items: { '$ref': '#/definitions/layer' } },
                 excludeLayers: { type: 'array', items: { type: 'string' } },
-                combine: { type: 'boolean' }
+                combine: { type: 'boolean' },
+                opacity: { type: 'number' }
             }
         };
     }

--- a/src/GeositeFramework/plugins/layer_selector_v2/templates.html
+++ b/src/GeositeFramework/plugins/layer_selector_v2/templates.html
@@ -70,8 +70,10 @@
         <ul>
             <li><a href="javascript:;" class="download"><i class="icon-download"></i> Download</a></li>
             <li><a href="javascript:;" class="zoom"><i class="icon-zoom-in"></i> Zoom to Extent</a></li>
-            <li><a><i class="icon-ajust"></i> Opacity</a></li>
-            <li class="slider"><input type="range" min="0" max="255" step="1" /></li>
+            <% if (supportsOpacity) { %>
+                <li><a><i class="icon-ajust"></i> Opacity</a></li>
+                <li class="slider"><input type="range" min="0" max="1" step=".1" value="<%= opacity %>"/></li>
+            <% } %>
         </ul>
     </div>
 </script>


### PR DESCRIPTION
Allows users to set the opacity on a layer by layer basis for those
layers that are part of services that support dynamic layers.

* Set individual layer opacity using the LayerDrawingOptions class. This
feature is only supported for layers that are served from a service with
support for dynamic layers turned on. This is not the default setting.
* Save layer opacity settings are part of the state.
* Adjust the layer menu to show or hide the opacity slider depending on
the layer's support for opacity.
* Add opacity to the schema.
* Add NOAA layers to the config to demo the opacity slider.

**Testing instructions**
- Activate one of the NOAA layers (the server is pretty slow, be patient). Confirm that you can adjust the opacity.
- Turn on the other NOAA layer and confirm that it's opacity is not the same as the other layer.
- The opacity slider position should be preserved between opening and closing the menu.
- Select one of the other layers from the New Jersey service and confirm that the layer slider is not present (this may change if the dynamic service option is turned on).
- UPDATE: The first NOAA layer should now start at 80% opacity.

![image](https://cloud.githubusercontent.com/assets/1042475/13021227/ffc81b8e-d1a7-11e5-9adf-a61cc458425d.png)


Known issues:
- [X] Opacity settings in the config are ignored (working on this).
- [ ] Lazy loading prevents the slider from being present before the layer is loaded even for layers that support opacity. Should be fixed by #555.

Connects to #522