### PR TITLE
Prevent events from being handled on both maps.

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -53,6 +53,7 @@ define([
                 this.layerTmpl = _.template(this.getTemplateByName('layer'));
                 this.infoBoxTmpl = _.template(this.getTemplateByName('info-box'));
                 this.layerMenuTmpl = _.template(this.getTemplateByName('layer-menu'));
+                this.layerMenuId = _.uniqueId('layer-selector2-layer-menu-');
                 this.bindEvents();
             },
 
@@ -90,12 +91,12 @@ define([
                     });
 
                 $('body')
-                    .on('click', '.layer-selector2-layer-menu a.download', function() {
+                    .on('click', '#' + this.layerMenuId + ' a.download', function() {
                         var layerId = self.getClosestLayerId(this);
                         console.log('Download', layerId);
                         self.destroyLayerMenu();
                     })
-                    .on('click', '.layer-selector2-layer-menu a.zoom', function() {
+                    .on('click', '#' + this.layerMenuId + ' a.zoom', function() {
                         self.zoomToLayerExtent(self.getClosestLayerId(this));
                         self.destroyLayerMenu();
                     });
@@ -112,7 +113,8 @@ define([
             createLayerMenu: function(layerId) {
                 var layer = this.state.findLayer(layerId),
                     html = this.layerMenuTmpl({
-                        layer: layer
+                        layer: layer,
+                        id: this.layerMenuId
                     });
                 return $(html);
             },

--- a/src/GeositeFramework/plugins/layer_selector_v2/templates.html
+++ b/src/GeositeFramework/plugins/layer_selector_v2/templates.html
@@ -66,7 +66,7 @@
 </script>
 
 <script type="text/template" id="layer-menu">
-    <div class="layer-selector2-layer-menu" data-layer-id="<%- layer.id() %>">
+    <div class="layer-selector2-layer-menu" id="<%= id %>" data-layer-id="<%- layer.id() %>">
         <ul>
             <li><a href="javascript:;" class="download"><i class="icon-download"></i> Download</a></li>
             <li><a href="javascript:;" class="zoom"><i class="icon-zoom-in"></i> Zoom to Extent</a></li>


### PR DESCRIPTION
* Previously, two events were fired from listeners on the
layer menu. I believe this was because each layer selector
instance has it's own set of templates, and because of the
way the listener is set up, both instances of the layer
menu were being captured. To fix this, we give each
instance of the layer menu a unique id that we can bind
events to. We could have also created the layer selector
DOM element as a child of the layer selector, but this made
positioning the element difficult.

**Testing instructions**
- Activate split screen mode and activate the new layer selector on both maps.
- On one of the maps, zoom to the extent of a layer, and verify that only that map is zoomed. Do the same on the other map.

Connects to #553