### PR TITLE
Subregion schema flexibility

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -380,7 +380,7 @@
                 <div class="row">
                     <p><%= description %></p>
                 </div>
-                <% if (typeof(showSubRegions) !== "undefined" && showSubRegions) { %>
+                <% if (typeof(showSubRegions) !== "undefined" && showSubRegions && subregions) { %>
                 <div class="row">
                     <div class="well">
                         <div class="description">

--- a/src/GeositeFramework/plugins/subregion_toggle/main.js
+++ b/src/GeositeFramework/plugins/subregion_toggle/main.js
@@ -27,7 +27,7 @@ define(
             
             validate: function(regionData) {
                 // This plugin is only valid if there are subregions present in the config
-                return !!regionData.subregions;
+                return !!regionData.subregions || !_.isEmpty(regionData.subregions);
             },
 
             getClassName: function() {


### PR DESCRIPTION
Some tidying up to ensure that subregions can be easily removed without
exceptions.  The visibility of the button was already tied to the validate
function, checking that the region data had subregions enabled.

Connects #527 

#### Test
* Remove the subregion node from region.js
* See that there are no runtime errors from the launchpad reference
* See that the hide/show toggle is not visible

Supersedes #562 