### PR TITLE
Implement download link

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector_v2/LayerNode.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/LayerNode.js
@@ -154,6 +154,10 @@ define([
 
             getOpacity: function() {
                 return this.node.opacity;
+            },
+
+            getDownloadUrl: function() {
+                return this.node.downloadUrl;
             }
         });
 

--- a/src/GeositeFramework/plugins/layer_selector_v2/layers.json
+++ b/src/GeositeFramework/plugins/layer_selector_v2/layers.json
@@ -26,7 +26,8 @@
                         "description": "This polygon layer delineates the US Congressional District boundaries in New Jersey, 2012 - 2022."
                     },
                     {
-                        "name": "Town,city, village"
+                        "name": "Town,city, village",
+                        "downloadUrl": "http://www2.census.gov/geo/tiger/GENZ2014/shp/cb_2014_us_ua10_500k.zip"
                     },
                     {
                         "name": "Counties"

--- a/src/GeositeFramework/plugins/layer_selector_v2/layers.json
+++ b/src/GeositeFramework/plugins/layer_selector_v2/layers.json
@@ -146,7 +146,8 @@
             },
             {
                 "name": "1995 Oyster Reefs",
-                "opacity": 0.2
+                "opacity": 0.2,
+                "downloadUrl": "http://www.tceq.texas.gov/assets/public/gis/exports/au_oysterwaters.zip"
             }
         ]
     }

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -120,12 +120,11 @@ define([
                     supportsOpacity = this.state.serviceSupportsOpacity(layer.getServiceUrl()),
                     $menu = this._createLayerMenu(layerId),
                     $shadow = this._createLayerMenuShadow(),
-                    pos = $el.offset(),
-                    top = supportsOpacity ? pos.top : pos.top + 55;
+                    position = this.determineLayerMenuPosition($el, layerId);
 
                 $menu.css({
-                    top: top,
-                    left: pos.left
+                    top: position.top,
+                    left: position.left
                 });
 
                 $('body').append($shadow).append($menu);
@@ -425,6 +424,30 @@ define([
 
             setLayerOpacity: function(layerId, opacity) {
                 this.state.setLayerOpacity(layerId, opacity);
+            },
+
+            // Depending on what features are supported by the selected layer,
+            // the top of the layer menu should be positioned differently.
+            determineLayerMenuPosition: function($el, layerId) {
+                var offset = $el.offset(),
+                    layer = this.state.findLayer(layerId),
+                    supportsOpacity = this.state.serviceSupportsOpacity(layer.getServiceUrl()),
+                    top = offset.top;
+
+                // Account for the height of the layer menu option if
+                // the option won't be shown in the menu.
+                if (!supportsOpacity) {
+                    top = top + 59;
+                }
+
+                if (!layer.getDownloadUrl()) {
+                    top = top + 32;
+                }
+
+                return {
+                    top: top,
+                    left: offset.left
+                };
             }
         });
     }

--- a/src/GeositeFramework/plugins/layer_selector_v2/schema.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/schema.js
@@ -28,7 +28,8 @@
                 includeLayers: { type: 'array', items: { '$ref': '#/definitions/layer' } },
                 excludeLayers: { type: 'array', items: { type: 'string' } },
                 combine: { type: 'boolean' },
-                opacity: { type: 'number' }
+                opacity: { type: 'number' },
+                downloadUrl: { type: 'string' }
             }
         };
     }

--- a/src/GeositeFramework/plugins/layer_selector_v2/templates.html
+++ b/src/GeositeFramework/plugins/layer_selector_v2/templates.html
@@ -68,7 +68,9 @@
 <script type="text/template" id="layer-menu">
     <div class="layer-selector2-layer-menu" id="<%= id %>" data-layer-id="<%- layer.id() %>">
         <ul>
-            <li><a href="javascript:;" class="download"><i class="icon-download"></i> Download</a></li>
+            <% if (layer.getDownloadUrl()) { %>
+                <li><a href="<%- layer.getDownloadUrl() %>" target="_blank" class="download"><i class="icon-download"></i> Download</a></li>
+            <% } %>
             <li><a href="javascript:;" class="zoom"><i class="icon-zoom-in"></i> Zoom to Extent</a></li>
             <% if (supportsOpacity) { %>
                 <li><a><i class="icon-ajust"></i> Opacity</a></li>


### PR DESCRIPTION
 Implements the download link and attempts to better position the layer menu. 

**Testing instructions**
- Open the layer menu for the "Town, City, Village" layer and click the download link. It should download a zip file. Also note the position of the layer menu and verify that it looks okay.
- Open the layer menu for the "Study Area" layer. It should only show the "zoom to extent" option and be positioned correctly.
- Open the layer menu for the "1880 Oyster Reefs" layer. It should show the "zoom to extent" and opacity options and be positioned correctly.
- Open the layer menu for the "1995 Oyster Reefs" layer. It should show all of the options and be positioned correctly.

Connects to #521