### PR TITLE
Add support for subregions

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector_v2/LayerNode.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/LayerNode.js
@@ -145,6 +145,10 @@ define([
                 return this.node.combine;
             },
 
+            isAvailableInRegion: function(regionId) {
+                return _.contains(this.node.availableInRegions || [], regionId);
+            },
+
             getOpacity: function() {
                 return this.node.opacity;
             }

--- a/src/GeositeFramework/plugins/layer_selector_v2/LayerNode.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/LayerNode.js
@@ -146,7 +146,10 @@ define([
             },
 
             isAvailableInRegion: function(regionId) {
-                return _.contains(this.node.availableInRegions || [], regionId);
+                if (_.isEmpty(this.node.availableInRegions)) {
+                    return true;
+                }
+                return _.contains(this.node.availableInRegions, regionId || 'main');
             },
 
             getOpacity: function() {

--- a/src/GeositeFramework/plugins/layer_selector_v2/State.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/State.js
@@ -156,7 +156,7 @@ define([
                 // Include all leaf nodes that partially match `filterText` and
                 // include all parent nodes that have at least one child.
                 return _.filter(layers, function filterLayer(layer) {
-                    if (!layer.hasChildren()) {
+                    if (!layer.isFolder()) {
                         // TODO: Fuzzy match?
                         return layer.getDisplayName().toLowerCase().indexOf(filterText) !== -1;
                     } else {

--- a/src/GeositeFramework/plugins/layer_selector_v2/State.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/State.js
@@ -146,11 +146,13 @@ define([
                 return result;
             },
 
-            filterLayers: function(layers) {
-                var filterText = this.getFilterText();
+            filterByName: function(layers, filterText) {
                 if (filterText.length === 0) {
                     return layers;
                 }
+
+                filterText = filterText.toLowerCase();
+
                 // Include all leaf nodes that partially match `filterText` and
                 // include all parent nodes that have at least one child.
                 return _.filter(layers, function filterLayer(layer) {
@@ -168,10 +170,13 @@ define([
             // data with data fetched from map services.
             rebuildLayers: function() {
                 this.layers = this.coalesceLayers();
-                // Unfortunately, we need to execute `coalesceLayers` twice because
-                // `filterLayers` mutates the data and I couldn't figure
-                // out a better way to do a recursive copy.
-                this.filteredLayers = this.filterLayers(this.coalesceLayers());
+
+                // `coalesceLayers` needs to be executed again because the filter
+                // logic mutates the data and we don't want to alter `layers`.
+                var filteredLayers = this.coalesceLayers();
+                filteredLayers = this.filterByName(filteredLayers, this.getFilterText());
+                this.filteredLayers = filteredLayers;
+
                 this.emit(LAYERS_CHANGED);
             },
 
@@ -297,7 +302,7 @@ define([
             },
 
             getFilterText: function() {
-                return this.savedState.filterText.trim().toLowerCase();
+                return this.savedState.filterText.trim();
             },
 
             filterTree: function(filterText) {

--- a/src/GeositeFramework/plugins/layer_selector_v2/layers.json
+++ b/src/GeositeFramework/plugins/layer_selector_v2/layers.json
@@ -32,7 +32,8 @@
                         "name": "Counties"
                     },
                     {
-                        "name": "Watershed Regions"
+                        "name": "Watershed Regions",
+                        "availableInRegions": ["galveston"]
                     }
                 ]
             },
@@ -64,6 +65,7 @@
                 "includeLayers": [
                     {
                         "name": "Sea Level Rise Impact Analysis",
+                        "availableInRegions": ["the-ocean", "main"],
                         "includeLayers": [
                             {
                                 "name": "Current sea level",

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -48,7 +48,9 @@ define([
 
             initialize: function (frameworkParameters, currentRegion) {
                 declare.safeMixin(this, frameworkParameters);
+
                 this.config = new Config();
+
                 this.pluginTmpl = _.template(this.getTemplateByName('plugin'));
                 this.filterTmpl = _.template(this.getTemplateByName('filter'));
                 this.treeTmpl = _.template(this.getTemplateByName('tree'));
@@ -56,6 +58,7 @@ define([
                 this.infoBoxTmpl = _.template(this.getTemplateByName('info-box'));
                 this.layerMenuTmpl = _.template(this.getTemplateByName('layer-menu'));
                 this.layerMenuId = _.uniqueId('layer-selector2-layer-menu-');
+
                 this.bindEvents();
             },
 
@@ -326,7 +329,7 @@ define([
                     this._cleanupPreviousState();
                 }
 
-                this.state = new State(this.config, data);
+                this.state = new State(this.config, data, this.currentRegion);
                 this.render();
 
                 var eventHandles = [
@@ -376,6 +379,16 @@ define([
                     this.state.clearAll();
                 }
                 this.setState(null);
+            },
+
+            subregionActivated: function(currentRegion) {
+                this.currentRegion = currentRegion.id;
+                this.setState(this.getState());
+            },
+
+            subregionDeactivated: function(currentRegion) {
+                this.currentRegion = null;
+                this.setState(this.getState());
             },
 
             zoomToLayerExtent: function(layerId) {

--- a/src/GeositeFramework/plugins/layer_selector_v2/schema.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/schema.js
@@ -22,6 +22,7 @@
                 name: { type: 'string' },
                 displayName: { type: 'string' },
                 description: { type: 'string' },
+                availableInRegions: { type: 'array', items: { type: 'string' } },
                 server: { '$ref': '#/definitions/server' },
                 includeAllLayers: { type: 'boolean' },
                 includeLayers: { type: 'array', items: { '$ref': '#/definitions/layer' } },


### PR DESCRIPTION
This adds a new layer filter for subregions.

Test by verifying:
* "Coastal Resilience > Boundaries > Watershed Regions" *only* appears in "Galveston Bay"
* "Coastal Resilience > Coastal Hazards > Sea Level Rise Impact Analysis" appears in both **main** and "Somewhere in the ocean"

Connects #547 
