### PR TITLE
Fix search plugin auto-closing

### DIFF
--- a/src/GeositeFramework/plugins/zoom_to/main.js
+++ b/src/GeositeFramework/plugins/zoom_to/main.js
@@ -14,7 +14,7 @@ require({
 define(
     ["dojo/_base/declare",
      "framework/PluginBase",
-     "./ui", 
+     "./ui",
      "dojo/text!plugins/zoom_to/zoom_to.json",
      "jquery",
      "esri/SpatialReference",
@@ -46,7 +46,7 @@ define(
                     this.inputView = new ui.UiInputView({ model: this.input });
                 }
             },
-            
+
             initialize: function (args) {
                 var spatialReference = new SpatialReference({ wkid: 4326 /* lat-lng */ }),
                     point = function (x, y) { return new Point(x, y, spatialReference); };
@@ -63,11 +63,10 @@ define(
                 this._initializeViews();
                 return this.inputView.render().$el;
             },
-            
+
             hibernate: function() {
                 this.inputView.clear();
             }
-
         });
     }
 );

--- a/src/GeositeFramework/plugins/zoom_to/main.js
+++ b/src/GeositeFramework/plugins/zoom_to/main.js
@@ -62,10 +62,6 @@ define(
             renderLauncher: function () {
                 this._initializeViews();
                 return this.inputView.render().$el;
-            },
-
-            hibernate: function() {
-                this.inputView.clear();
             }
         });
     }


### PR DESCRIPTION
Remove the hibernate implementation for the search plugin so that
it cannot be closed programmatically. TNC wants it to persist it's
state through subregion and scenario activations/deactivations.

**Testing instructions**
- Verify the plugin remains open when on start-up, when activating scenarios and subregions.
- Verify the "X" button can still clear results and close the plugin.

Connects to #541
