### PR TITLE
Fix state not being restored properly

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector_v2/State.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/State.js
@@ -208,17 +208,6 @@ define([
                 return _.map(this.savedState.selectedLayers, this.findLayer, this);
             },
 
-            getSelectedLayersForService: function(serviceUrl) {
-                var self = this;
-                return _.reduce(this.savedState.selectedLayers, function(memo, layer) {
-                    var layerNode = self.findLayer(layer);
-                    if (layerNode && layerNode.getServiceUrl() === serviceUrl) {
-                        memo.push(layer);
-                    }
-                    return memo;
-                }, []);
-            },
-
             clearAll: function() {
                 this.filterTree('');
                 this.setSelectedLayers([]);

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -332,6 +332,7 @@ define([
                 }
 
                 this.state = new State(this.config, data, this.currentRegion);
+                this.updateMap();
                 this.render();
 
                 var eventHandles = [


### PR DESCRIPTION
Changes:

* Ensure `updateMap` is called after setting state
* Fetch map service data when restoring state

Test instructions:

* Verify that restoring saved state from "Save & Share" URL restores
selected layers, expanded folders, and the tree filter

Connects #554