### PR TITLE
Implement style for layer tools

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector_v2/State.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/State.js
@@ -22,7 +22,8 @@ define([
             SELECTED_LAYERS_CHANGED = 'change:selectedLayers',
             FILTER_CHANGED = 'change:filter',
             EVERYTHING_CHANGED = 'change:all',
-            OPACITY_CHANGED = 'change:opacity';
+            OPACITY_CHANGED = 'change:opacity',
+            LAYER_INFO_ID_CHANGED = 'change:layerInfoId';
 
         // Return true if layer data has been fetched.
         function isLoaded(layer) {
@@ -85,7 +86,9 @@ define([
                     // Expanded layerIds.
                     expandedLayers: [],
                     // List of objects as { layerId: opacityValue }.
-                    layerOpacity: []
+                    layerOpacity: [],
+                    // Layer id that infobox is display for.
+                    infoBoxLayerId: null
                 });
 
                 // Create initial working layer objects.
@@ -373,6 +376,24 @@ define([
             serviceSupportsOpacity: function(serviceUrl) {
                 var serviceData = getServiceData(serviceUrl);
                 return serviceData && serviceData.supportsDynamicLayers;
+            },
+
+            setInfoBoxLayerId: function(layerId) {
+                this.savedState.infoBoxLayerId = layerId;
+                this.emit(LAYER_INFO_ID_CHANGED);
+            },
+
+            clearInfoBoxLayerId: function() {
+                this.savedState.infoBoxLayerId = null;
+                this.emit(LAYER_INFO_ID_CHANGED);
+            },
+
+            getInfoBoxLayerId: function() {
+                return this.savedState.infoBoxLayerId;
+            },
+
+            infoIsDisplayed: function(layerId) {
+                return this.savedState.infoBoxLayerId === layerId;
             }
         });
     }

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.css
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.css
@@ -32,8 +32,13 @@
         border-top: 1px solid #f8f8f8;
     }
     .layer-selector2 .tree-container li:hover > a,
-    .layer-selector2 .tree-container li:hover > .layer-tools {
+    .layer-selector2 .tree-container li:hover > .layer-tools,
+    .layer-selector2 .tree-container li.leaf-node.active > a {
         background: #f5f5f5;
+    }
+    .layer-selector2 .tree-container li.leaf-node .layer-tools i:hover,
+    .layer-selector2 .tree-container li.leaf-node .layer-tools i.active {
+        color: #23618c;
     }
     .layer-selector2 .tree-container li.leaf-node.selected > a,
     .layer-selector2 .tree-container li.leaf-node.selected:hover > a,
@@ -52,7 +57,8 @@
             width: auto;
         }
         .layer-selector2 .tree-container li.leaf-node:hover > .layer-tools,
-        .layer-selector2 .tree-container li.leaf-node.selected > .layer-tools {
+        .layer-selector2 .tree-container li.leaf-node.selected > .layer-tools,
+        .layer-selector2 .tree-container li.leaf-node.active > .layer-tools {
             display: block;
         }
 

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.css
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.css
@@ -39,8 +39,7 @@
     .layer-selector2 .tree-container li.leaf-node.selected:hover > a,
     .layer-selector2 .tree-container li.leaf-node.selected > .layer-tools,
     .layer-selector2 .tree-container li.leaf-node.selected:hover > .layer-tools {
-        color: #fff;
-        background: #23618c;
+        background: #ccc;
     }
     .layer-selector2 .tree-container li > .layer-tools {
         display: none;

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -81,6 +81,7 @@ define([
                     })
                     .on('click', 'a.more', function() {
                         self.showLayerMenu(this);
+                        self.setActiveStateForLayerTools(this, '.more');
                     })
                     .on('keyup', 'input.filter', function() {
                         var $el = $(this),
@@ -155,6 +156,7 @@ define([
             destroyLayerMenu: function() {
                 $('body').find('.layer-selector2-layer-menu').remove();
                 $('body').find('.layer-selector2-layer-menu-shadow').remove();
+                this.clearActiveStateForLayerTools('.more');
             },
 
             updateMap: function() {
@@ -451,6 +453,20 @@ define([
                     top: top,
                     left: offset.left
                 };
+            },
+
+            setActiveStateForLayerTools: function(el, selector) {
+                this.clearActiveStateForLayerTools(selector);
+                $(el).find('i').addClass('active');
+                $(el).closest('[data-layer-id]').addClass('active');
+            },
+
+            clearActiveStateForLayerTools: function(selector) {
+                var completeSelector = '[data-layer-id].active ' + selector + ' i.active',
+                    $el = $(this.container).find(completeSelector);
+
+                $el.removeClass('active');
+                $el.closest('[data-layer-id]').removeClass('active');
             }
         });
     }

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -74,10 +74,10 @@ define([
                         self.state.toggleLayer(self.getClosestLayerId(this));
                     })
                     .on('click', 'a.info', function() {
-                        self.showLayerInfo(self.getClosestLayerId(this));
+                        self.state.setInfoBoxLayerId(self.getClosestLayerId(this));
                     })
                     .on('click', '.info-box .close', function() {
-                        self.hideLayerInfo();
+                        self.state.clearInfoBoxLayerId();
                     })
                     .on('click', 'a.more', function() {
                         self.showLayerMenu(this);
@@ -279,6 +279,7 @@ define([
                 $(this.container).html(this.pluginTmpl());
                 this.renderFilter();
                 this.renderTree();
+                this.showLayerInfo();
             },
 
             renderFilter: function() {
@@ -298,11 +299,15 @@ define([
 
             renderLayer: function(indent, layer) {
                 var isSelected = this.state.isSelected(layer.id()),
-                    isExpanded = this.state.isExpanded(layer.id());
+                    isExpanded = this.state.isExpanded(layer.id()),
+                    infoBoxIsDisplayed = this.state.infoIsDisplayed(layer.id());
 
                 var cssClass = [];
                 if (isSelected) {
                     cssClass.push('selected');
+                }
+                if (infoBoxIsDisplayed) {
+                    cssClass.push('active');
                 }
                 cssClass.push(layer.isFolder() ? 'parent-node' : 'leaf-node');
                 cssClass = cssClass.join(' ');
@@ -313,6 +318,7 @@ define([
                     cssClass: cssClass,
                     isSelected: isSelected,
                     isExpanded: isExpanded,
+                    infoBoxIsDisplayed: infoBoxIsDisplayed,
                     indent: indent,
                     renderLayer: _.bind(this.renderLayer, this, indent + 1)
                 });
@@ -356,6 +362,9 @@ define([
                     }),
                     this.state.on('change:opacity', function() {
                         self.updateMap();
+                    }),
+                    this.state.on('change:layerInfoId', function() {
+                        self.render();
                     })
                 ];
 
@@ -407,7 +416,10 @@ define([
                     });
             },
 
-            showLayerInfo: function(layerId) {
+            showLayerInfo: function() {
+                var layerId = this.state.getInfoBoxLayerId();
+                if (!layerId) { return; }
+
                 var self = this,
                     layer = this.state.findLayer(layerId);
 
@@ -425,6 +437,7 @@ define([
 
             hideLayerInfo: function() {
                 $(this.container).find('.info-box-container').empty();
+                this.state.clearInfoBoxState();
             },
 
             setLayerOpacity: function(layerId, opacity) {

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -70,6 +70,9 @@ define([
                     .on('click', 'a.layer-row', function() {
                         self.state.toggleLayer(self.getClosestLayerId(this));
                     })
+                    .on('click', 'a.show', function() {
+                        self.state.toggleLayer(self.getClosestLayerId(this));
+                    })
                     .on('click', 'a.info', function() {
                         self.showLayerInfo(self.getClosestLayerId(this));
                     })

--- a/src/GeositeFramework/plugins/layer_selector_v2/templates.html
+++ b/src/GeositeFramework/plugins/layer_selector_v2/templates.html
@@ -42,7 +42,7 @@
         <% if (!layer.isFolder()) { %>
         <div class="layer-tools">
             <a href="javascript:;" class="show"><i class="icon-eye<% if (!isSelected) { %>-off<% } else { %> active <% } %>"></i></a>
-            <a href="javascript:;" class="info"><i class="icon-info-circled"></i></a>
+            <a href="javascript:;" class="info"><i class="icon-info-circled <% if (infoBoxIsDisplayed) { %> active <% } %>"></i></a>
             <a href="javascript:;" class="more"><i class="icon-ellipsis"></i></a>
         </div>
         <% } %>

--- a/src/GeositeFramework/plugins/layer_selector_v2/templates.html
+++ b/src/GeositeFramework/plugins/layer_selector_v2/templates.html
@@ -41,7 +41,7 @@
 
         <% if (!layer.isFolder()) { %>
         <div class="layer-tools">
-            <a href="javascript:;" class="show"><i class="icon-eye<% if (!isSelected) { %>-off<% } %>"></i></a>
+            <a href="javascript:;" class="show"><i class="icon-eye<% if (!isSelected) { %>-off<% } else { %> active <% } %>"></i></a>
             <a href="javascript:;" class="info"><i class="icon-info-circled"></i></a>
             <a href="javascript:;" class="more"><i class="icon-ellipsis"></i></a>
         </div>


### PR DESCRIPTION
~~I still want to do a little more testing and shoring up on this.~~ Ready for testing.

Because the layer info box is independent of the layer selector window, and it persists through changes in layer selections, and because the info icon needs to stay highlighted while the info box is open even if another layer is selected, it was simplest to track the box as part of the state (as opposed to after render DOM manipulation) despite the added complexity of tracking such a simple thing.

The layer tools menu is a bit simpler since it is attached to the layer selector items and can be closed when a different layer is selected.

**Testing instructions**
- Open the layer menu for a layer and verify that the layer stays in the active/hover state until the layer menu is closed.
- Open the info box for a layer, and verify that while the info box is open, the layer element is displayed in the active/hover state, and that the "i" icon stays blue.
- Verify that clicking the eye icon toggles the visibility of a layer.

![image](https://cloud.githubusercontent.com/assets/1042475/13154363/9937b688-d646-11e5-9d43-89c51bbc5ea2.png)

![image](https://cloud.githubusercontent.com/assets/1042475/13154369/a1afd85e-d646-11e5-89e3-526a5798e320.png)

![image](https://cloud.githubusercontent.com/assets/1042475/13154380/ac6337f0-d646-11e5-8348-6fd19c1f7e64.png)
