### PR TITLE
Fix legend order

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -223,7 +223,7 @@ require(['use!Geosite',
             _.each(services, function (service) {
                 var serviceInfo = view.model.serviceInfos[service.id];
                 if (serviceInfo && service.visible && serviceInfo.pluginObject.showServiceLayersInLegend) {
-                    service.visibleLayers.sort();
+                    service.visibleLayers.sort(function(a, b) { return a - b; });
                     _.each(service.visibleLayers, function(layerId) {
                         var layer = _.findWhere(service.layerInfos, {id: layerId});
                         if (!layer) {


### PR DESCRIPTION
* By default, JavaScript sorts numbers as strings, so we need to pass a comparator to correctly sort numbers in ascending order.

**Testing instructions**
- Verify that layers are added to the legend in the order by their id (which should match the z-index of the layers on the map), and that the services are ordered according to the order that their layers were added to the map. This means that if you add a layer from the New Jersey service, then the Alabama service, the New Jersey layer will be on top in the legend. If all of the layers are removed, the JS API still remembers the initial order services were added. So, if these same layers are turned back on in the opposite order, the new legend order will match the initial legend order.

Connects to #495

