### PR TITLE
Create Tree and AgsService modules

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -55,6 +55,7 @@ require(['use!Geosite',
                 });
             } catch (e) {
                 // Prevent the malfunctioning plugin from stopping the rest of the code execution
+                console.error(e.stack);
                 console.error(e);
             }
         }

--- a/src/GeositeFramework/js/util/ajax.js
+++ b/src/GeositeFramework/js/util/ajax.js
@@ -22,7 +22,10 @@ define(['esri/request'],
                 }).then(function(data) {
                     cache[url] = data;
                 }, function(error) {
+                    console.debug('ajaxUtil', error);
                     cache[url] = error;
+                }).then(function() {
+                    return cache[url];
                 });
             }
             return promises[url];

--- a/src/GeositeFramework/plugins/layer_selector_v2/AgsService.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/AgsService.js
@@ -1,0 +1,95 @@
+define([
+        "dojo/_base/declare",
+        "dojo/Deferred",
+        "underscore",
+        "framework/util/ajax",
+        "./util",
+        "./LayerNode"
+    ],
+    function(declare,
+             Deferred,
+             _,
+             ajaxUtil,
+             util,
+             LayerNode) {
+        "use strict";
+
+        return declare(null, {
+            constructor: function(server) {
+                this.server = server;
+            },
+
+            getServiceUrl: function() {
+                return util.urljoin(this.server.url, this.server.name, 'MapServer');
+            },
+
+            // Return a promise containing map service data.
+            fetchMapService: function() {
+                return ajaxUtil.fetch(this.getServiceUrl());
+            },
+
+            // Return cached map service data.
+            getServiceData: function() {
+                return ajaxUtil.get(this.getServiceUrl());
+            },
+
+            // Return a promise with service layer data.
+            fetchLayerDetails: function(tree, layerId) {
+                var self = this;
+                // We need to fetch the service before we can fetch the details.
+                return this.fetchMapService()
+                    .then(function(serviceData) {
+                        var layer = tree.findLayer(layerId),
+                            serviceLayer = self.findServiceLayer(layer),
+                            url = util.urljoin(self.getServiceUrl(), serviceLayer.id);
+                        return ajaxUtil.fetch(url);
+                    });
+            },
+
+            // Return cached layer details.
+            getLayerDetails: function(serviceLayer) {
+                if (!serviceLayer) {
+                    return;
+                }
+                var url = util.urljoin(this.getServiceUrl(), serviceLayer.id);
+                return ajaxUtil.get(url);
+            },
+
+            // Find the corresponding data for `layer` in the map service.
+            findServiceLayer: function(layer) {
+                var serviceData = this.getServiceData();
+
+                if (!serviceData || !layer) {
+                    return null;
+                }
+
+                return _.find(serviceData.layers, function(serviceLayer) {
+                    if (layer.getName() === serviceLayer.name) {
+                        // Compare not only the name, but the structure as well.
+                        // Protects against an edge case where a map service
+                        // contains a parent and child layer with the same name.
+                        if (layer.hasChildren() && serviceLayer.subLayerIds) {
+                            return true;
+                        } else if (!layer.hasChildren() && !serviceLayer.subLayerIds) {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
+            },
+
+            findServiceLayerById: function(layerId) {
+                var serviceData = this.getServiceData();
+                if (serviceData) {
+                    return _.findWhere(serviceData.layers, { id: layerId });
+                }
+                return null;
+            },
+
+            supportsOpacity: function() {
+                var serviceData = this.getServiceData();
+                return serviceData && serviceData.supportsDynamicLayers;
+            }
+        });
+    }
+);

--- a/src/GeositeFramework/plugins/layer_selector_v2/Config.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/Config.js
@@ -6,21 +6,24 @@
         "./LayerNode",
         "./schema",
         "dojo/text!./layers.json",
-        "./util"
+        "./util",
+        "./Tree"
     ],
     function(declare, JSON, tv4, _,
              LayerNode,
              layerConfigSchema,
              layerSourcesJson,
-             util) {
+             util,
+             Tree) {
         "use strict";
 
         return declare(null, {
             constructor: function () {
-                var rawNodes = this.parse(layerSourcesJson);
-                this.layers = _.map(rawNodes, function(node) {
-                    return LayerNode.fromJS(node);
-                });
+                var rawNodes = this.parse(layerSourcesJson),
+                    layers = _.map(rawNodes, function(node) {
+                        return LayerNode.fromJS(node);
+                    });
+                this.tree = new Tree(layers);
             },
 
             parse: function(json) {
@@ -40,14 +43,8 @@
                 return null;
             },
 
-            getLayers: function() {
-                return this.layers;
-            },
-
-            findLayer: function(layerId) {
-                return util.find(this.layers, function(layer) {
-                    return layer.findLayer(layerId);
-                });
+            getTree: function() {
+                return this.tree;
             }
         });
     }

--- a/src/GeositeFramework/plugins/layer_selector_v2/NullService.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/NullService.js
@@ -1,0 +1,46 @@
+define([
+        "dojo/_base/declare",
+    ],
+    function(declare) {
+        "use strict";
+
+        return declare(null, {
+            getServiceUrl: function() {
+                return null;
+            },
+
+            // Return a promise containing map service data.
+            fetchMapService: function() {
+                throw new Error('Not implemented');
+            },
+
+            // Return a promise with service layer data.
+            fetchLayerDetails: function(tree, layerId) {
+                throw new Error('Not implemented');
+            },
+
+            // Return cached map service data.
+            getServiceData: function() {
+                return null;
+            },
+
+            // Return cached layer details.
+            getLayerDetails: function(serviceLayer) {
+                return null;
+            },
+
+            // Find the corresponding data for `layer` in the map service.
+            findServiceLayer: function(layer) {
+                return null;
+            },
+
+            findServiceLayerById: function(layerId) {
+                return null;
+            },
+
+            supportsOpacity: function() {
+                return false;
+            }
+        });
+    }
+);

--- a/src/GeositeFramework/plugins/layer_selector_v2/State.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/State.js
@@ -1,84 +1,21 @@
 define([
         "dojo/_base/declare",
-        "dojo/Deferred",
-        "esri/request",
-        "underscore",
-        "framework/PausableEvented",
-        "framework/util/ajax",
-        "./util",
-        "./LayerNode"
+        "underscore"
     ],
     function(declare,
-             Deferred,
-             request,
-             _,
-             PausableEvented,
-             ajaxUtil,
-             util,
-             LayerNode) {
+             _) {
         "use strict";
 
-        var LAYERS_CHANGED = 'change:layers',
-            SELECTED_LAYERS_CHANGED = 'change:selectedLayers',
-            FILTER_CHANGED = 'change:filter',
-            EVERYTHING_CHANGED = 'change:all',
-            OPACITY_CHANGED = 'change:opacity',
-            LAYER_INFO_ID_CHANGED = 'change:layerInfoId';
+        return declare(null, {
+            constructor: function(data) {
+                this.setState(data);
+            },
 
-        // Return true if layer data has been fetched.
-        function isLoaded(layer) {
-            if (layer.isFolder()) {
-                return true;
-            } else {
-                return ajaxUtil.isCached(layer.getServiceUrl());
-            }
-        }
+            getState: function() {
+                return this.savedState;
+            },
 
-        // Return map service data for the corresponding layer.
-        function getServiceData(serviceUrl) {
-            return ajaxUtil.get(serviceUrl);
-        }
-
-        // Find the corresponding data for `layer` in the map service.
-        function findServiceLayer(serviceData, layer) {
-            if (!serviceData || !layer) {
-                return null;
-            }
-            return _.find(serviceData.layers, function(serviceLayer) {
-                if (layer.getName() === serviceLayer.name) {
-                    // Compare not only the name, but the structure as well.
-                    // Protects against an edge case where a map service
-                    // contains a parent and child layer with the same name.
-                    if (layer.hasChildren() && serviceLayer.subLayerIds) {
-                        return true;
-                    } else if (!layer.hasChildren() && !serviceLayer.subLayerIds) {
-                        return true;
-                    }
-                }
-                return false;
-            });
-        }
-
-        function findServiceLayerById(serviceData, layerId) {
-            if (!serviceData) {
-                return null;
-            }
-            return _.findWhere(serviceData.layers, { id: layerId });
-        }
-
-        function getLayerDetails(layer, serviceLayer) {
-            if (!serviceLayer) {
-                return;
-            }
-            var url = util.urljoin(layer.getServiceUrl(), serviceLayer.id);
-            return ajaxUtil.get(url);
-        }
-
-        return declare([PausableEvented], {
-            constructor: function(config, data, currentRegion) {
-                this.config = config;
-                this.currentRegion = currentRegion;
-
+            setState: function(data) {
                 this.savedState = _.defaults({}, data, {
                     filterText: '',
                     // Selected layerIds (in-order).
@@ -90,139 +27,14 @@ define([
                     // Layer id that infobox is display for.
                     infoBoxLayerId: null
                 });
-
-                // Create initial working layer objects.
-                this.rebuildLayers();
-
-                // Restore saved state.
-                this.filterTree(this.savedState.filterText);
-                this.setSelectedLayers(this.savedState.selectedLayers);
-                this.setExpandedLayers(this.savedState.expandedLayers);
-            },
-
-            // Combine config layer nodes with map service data.
-            coalesceLayers: function() {
-                return _.map(this.config.getLayers(), function(layer) {
-                    return this.coalesceLayerNode(null, layer);
-                }, this);
-            },
-
-            // Combine layer node objects with service data.
-            coalesceLayerNode: function(parent, layer) {
-                var serviceData = getServiceData(layer.getServiceUrl()),
-                    serviceLayer = findServiceLayer(serviceData, layer),
-                    layerDetails = getLayerDetails(layer, serviceLayer),
-                    node = _.assign({}, serviceLayer || {}, layerDetails || {}, layer.getData()),
-                    result = new LayerNode(node, parent);
-
-                // Include layers loaded on-demand (overrides layers defined in layers.json).
-                if (layer.includeAllLayers() && serviceLayer && serviceLayer.subLayerIds) {
-                    _.each(serviceLayer.subLayerIds, function(subLayerId) {
-                        var childLayer = this.coalesceSubLayer(result, subLayerId);
-                        result.addChild(childLayer);
-                    }, this);
-                } else {
-                    _.each(layer.getChildren(), function(child) {
-                        var childLayer = this.coalesceLayerNode(result, child);
-                        result.addChild(childLayer);
-                    }, this);
-                }
-
-                return result;
-            },
-
-            // Wrap service data in layer node objects.
-            coalesceSubLayer: function(parent, subLayerId) {
-                var serviceData = getServiceData(parent.getServiceUrl()),
-                    serviceLayer = findServiceLayerById(serviceData, subLayerId),
-                    layerDetails = getLayerDetails(parent, serviceLayer),
-                    node = _.assign({}, serviceLayer || {}, layerDetails || {}),
-                    result = new LayerNode(node, parent);
-
-                if (serviceLayer.subLayerIds) {
-                    _.each(serviceLayer.subLayerIds, function(subLayerId) {
-                        var childLayer = this.coalesceSubLayer(result, subLayerId);
-                        result.addChild(childLayer);
-                    }, this);
-                }
-
-                return result;
-            },
-
-            filterByName: function(layers, filterText) {
-                if (filterText.length === 0) {
-                    return layers;
-                }
-
-                filterText = filterText.toLowerCase();
-
-                // Include all leaf nodes that partially match `filterText` and
-                // include all parent nodes that have at least one child.
-                return _.filter(layers, function filterLayer(layer) {
-                    if (!layer.isFolder()) {
-                        // TODO: Fuzzy match?
-                        return layer.getDisplayName().toLowerCase().indexOf(filterText) !== -1;
-                    } else {
-                        layer.children = _.filter(layer.children, filterLayer);
-                        return layer.getChildren().length > 0;
-                    }
-                });
-            },
-
-            filterByRegion: function(layers, currentRegion) {
-                return _.filter(layers, function filterLayer(layer) {
-                    if (!layer.isAvailableInRegion(currentRegion)) {
-                        return false;
-                    } else if (layer.isFolder()) {
-                        layer.children = _.filter(layer.children, filterLayer);
-                        return layer.getChildren().length > 0;
-                    }
-                    return true;
-                });
-            },
-
-            // Ensure that `layers` always reflects the union of configuration
-            // data with data fetched from map services.
-            rebuildLayers: function() {
-                this.layers = this.coalesceLayers();
-
-                // `coalesceLayers` needs to be executed again because the filter
-                // logic mutates the data and we don't want to alter `layers`.
-                var filteredLayers = this.coalesceLayers();
-                filteredLayers = this.filterByRegion(filteredLayers, this.currentRegion);
-                filteredLayers = this.filterByName(filteredLayers, this.getFilterText());
-                this.filteredLayers = filteredLayers;
-
-                this.emit(LAYERS_CHANGED);
-            },
-
-            getLayers: function() {
-                return this.filteredLayers;
-            },
-
-            findLayer: function(layerId) {
-                return util.find(this.layers, function(layer) {
-                    return layer.findLayer(layerId);
-                });
-            },
-
-            getSelectedLayers: function() {
-                return _.map(this.savedState.selectedLayers, this.findLayer, this);
             },
 
             clearAll: function() {
-                this.filterTree('');
-                this.setSelectedLayers([]);
-                this.setExpandedLayers([]);
-                this.emit(EVERYTHING_CHANGED);
+                this.setState(null);
             },
 
-            isSelected: function(layerId) {
-                return _.contains(this.savedState.selectedLayers, layerId);
-            },
-
-            toggleLayer: function(layerId) {
-                var layer = this.findLayer(layerId);
+            toggleLayer: function(layer) {
+                var layerId = layer.id();
                 if (layer.isFolder()) {
                     if (this.isExpanded(layerId)) {
                         this.collapseLayer(layerId);
@@ -238,18 +50,20 @@ define([
                 }
             },
 
+            getSelectedLayers: function() {
+                return this.savedState.selectedLayers;
+            },
+
+            isSelected: function(layerId) {
+                return _.contains(this.savedState.selectedLayers, layerId);
+            },
+
             selectLayer: function(layerId) {
-                this.setSelectedLayers(this.savedState.selectedLayers.concat(layerId));
+                this.savedState.selectedLayers.push(layerId);
             },
 
             deselectLayer: function(layerId) {
-                this.setSelectedLayers(_.without(this.savedState.selectedLayers, layerId));
-            },
-
-            setSelectedLayers: function(selectedLayers) {
-                this.savedState.selectedLayers = selectedLayers;
-                _.each(selectedLayers, _.bind(this.fetchMapService, this));
-                this.emit(SELECTED_LAYERS_CHANGED);
+                this.savedState.selectedLayers = _.without(this.savedState.selectedLayers, layerId);
             },
 
             isExpanded: function(layerId) {
@@ -257,105 +71,28 @@ define([
             },
 
             expandLayer: function(layerId) {
-                this.setExpandedLayers(this.savedState.expandedLayers.concat(layerId));
+                this.savedState.expandedLayers.push(layerId);
             },
 
             collapseLayer: function(layerId) {
-                this.setExpandedLayers(_.without(this.savedState.expandedLayers, layerId));
+                this.savedState.expandedLayers = _.without(this.savedState.expandedLayers, layerId);
             },
 
-            setExpandedLayers: function(expandedLayers) {
-                this.savedState.expandedLayers = expandedLayers;
-                this.emit(LAYERS_CHANGED);
-            },
-
-            fetchMapService: function(layerId) {
-                var self = this,
-                    layer = this.config.findLayer(layerId),
-                    done = function() {
-                        return self.findLayer(layerId);
-                    };
-
-                // Only fetch map service data for layers defined in the
-                // layers.json config and only if it hasn't already been fetched.
-                // Otherwise, `rebuildLayers` will get called more often
-                // than it needs to be.
-                if (layer && ajaxUtil.shouldFetch(layer.getServiceUrl())) {
-                    return ajaxUtil.fetch(layer.getServiceUrl())
-                            .then(_.bind(this.rebuildLayers, this))
-                            .then(done);
-                }
-
-                return new Deferred().resolve(done());
-            },
-
-            // Gets details for one layer. Returns a promise with
-            // the provided layer and details.
-            fetchLayerDetails: function(layer) {
-                var self = this;
-
-                // We need to fetch the service before we can fetch
-                // the details.
-                return this.fetchMapService(layer.id())
-                        .then(function(newLayer) {
-                            var layerId = newLayer.getServiceId(),
-                                url = util.urljoin(newLayer.getServiceUrl(), layerId);
-                            return ajaxUtil.fetch(url);
-                        })
-                        .then(_.bind(this.rebuildLayers, this))
-                        .then(function() {
-                            return self.findLayer(layer.id());
-                        });
+            collapseAllLayers: function() {
+                this.savedState.expandedLayers = [];
             },
 
             getFilterText: function() {
                 return this.savedState.filterText.trim();
             },
 
-            filterTree: function(filterText) {
-                var self = this;
-
-                if (filterText === this.savedState.filterText) {
-                    return;
-                }
-
+            setFilterText: function(filterText) {
                 this.savedState.filterText = filterText;
-                this.pauseEvents();
-
-                // Apply filter.
-                this.rebuildLayers();
-
-                // Expand all layers that passed the filter.
-                this.setExpandedLayers([]);
-                _.each(this.filteredLayers, function(rootLayer) {
-                    rootLayer.walk(function(layer) {
-                        self.expandLayer(layer.id());
-                    });
-                });
-
-                this.resumeEvents();
-                this.emit(FILTER_CHANGED);
-            },
-
-            serialize: function() {
-                return this.savedState;
             },
 
             getLayerOpacity: function(layerId) {
                 var savedLayerOpacity = _.findWhere(this.savedState.layerOpacity, { layerId: layerId });
-
-                if (savedLayerOpacity) {
-                    return savedLayerOpacity.opacity;
-                } else {
-                    var layer = this.findLayer(layerId),
-                        configOpacity = layer.getOpacity();
-
-                    if (configOpacity) {
-                        return configOpacity;
-                    }
-                }
-
-                return 1;
+                return savedLayerOpacity && savedLayerOpacity.opacity;
             },
 
             setLayerOpacity: function(layerId, opacity) {
@@ -369,23 +106,14 @@ define([
                         opacity: opacity
                     });
                 }
-
-                this.emit(OPACITY_CHANGED);
-            },
-
-            serviceSupportsOpacity: function(serviceUrl) {
-                var serviceData = getServiceData(serviceUrl);
-                return serviceData && serviceData.supportsDynamicLayers;
             },
 
             setInfoBoxLayerId: function(layerId) {
                 this.savedState.infoBoxLayerId = layerId;
-                this.emit(LAYER_INFO_ID_CHANGED);
             },
 
             clearInfoBoxLayerId: function() {
                 this.savedState.infoBoxLayerId = null;
-                this.emit(LAYER_INFO_ID_CHANGED);
             },
 
             getInfoBoxLayerId: function() {
@@ -394,6 +122,14 @@ define([
 
             infoIsDisplayed: function(layerId) {
                 return this.savedState.infoBoxLayerId === layerId;
+            },
+
+            setCurrentRegion: function(currentRegion) {
+                this.currentRegion = currentRegion;
+            },
+
+            getCurrentRegion: function() {
+                return this.currentRegion || 'main';
             }
         });
     }

--- a/src/GeositeFramework/plugins/layer_selector_v2/Tree.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/Tree.js
@@ -1,0 +1,163 @@
+define([
+        "dojo/_base/declare",
+        "underscore",
+        "./util",
+        "./LayerNode"
+    ],
+    function(declare,
+             _,
+             util,
+             LayerNode) {
+        "use strict";
+
+        return declare(null, {
+            constructor: function(config, state) {
+                this.config = config;
+                this.state = state;
+                this.rebuildLayers();
+            },
+
+            rebuildLayers: function() {
+                this.layers = this.coalesceLayers();
+                this.layers = this.filterByRegion(this.layers, this.state.getCurrentRegion());
+                this.layers = this.filterByName(this.layers, this.state.getFilterText());
+            },
+
+            // Combine config layer nodes with map service data.
+            coalesceLayers: function() {
+                return _.map(this.config.getLayers(), function(layer) {
+                    return this.coalesceLayerNode(null, layer);
+                }, this);
+            },
+
+            // Combine layer node objects with service data.
+            coalesceLayerNode: function(parent, layer) {
+                var service = layer.getService(),
+                    serviceLayer = service.findServiceLayer(layer),
+                    layerDetails = service.getLayerDetails(serviceLayer),
+                    layerData = _.assign({}, serviceLayer || {}, layerDetails || {}, layer.getData()),
+                    layerId = this.createLayerId(parent, layerData),
+                    opacity = this.state.getLayerOpacity(layerId),
+                    node = _.assign(layerData, {
+                        uid: layerId,
+                        isSelected: this.state.isSelected(layerId),
+                        isExpanded: this.state.isExpanded(layerId),
+                        infoIsDisplayed: this.state.infoIsDisplayed(layerId),
+                        opacity: _.isNumber(opacity) ? opacity : layer.getOpacity()
+                    }),
+                    result = new LayerNode(node, parent);
+
+                // Include layers loaded on-demand (overrides layers defined in layers.json).
+                if (layer.includeAllLayers() && serviceLayer && serviceLayer.subLayerIds) {
+                    _.each(serviceLayer.subLayerIds, function(subLayerId) {
+                        var childLayer = this.coalesceSubLayer(result, subLayerId);
+                        result.addChild(childLayer);
+                    }, this);
+                } else {
+                    _.each(layer.getChildren(), function(child) {
+                        var childLayer = this.coalesceLayerNode(result, child);
+                        result.addChild(childLayer);
+                    }, this);
+                }
+
+                return result;
+            },
+
+            // Wrap service data in layer node objects.
+            coalesceSubLayer: function(parent, subLayerId) {
+                var service = parent.getService(),
+                    serviceLayer = service.findServiceLayerById(subLayerId),
+                    layerDetails = service.getLayerDetails(serviceLayer),
+                    layerData = _.assign({}, serviceLayer || {}, layerDetails || {}),
+                    layerId = this.createLayerId(parent, layerData),
+                    node = _.assign(layerData, {
+                        uid: layerId,
+                        isSelected: this.state.isSelected(layerId),
+                        isExpanded: this.state.isExpanded(layerId),
+                        infoIsDisplayed: this.state.infoIsDisplayed(layerId),
+                        opacity: this.state.getLayerOpacity(layerId)
+                    }),
+                    result = new LayerNode(node, parent);
+
+                if (serviceLayer.subLayerIds) {
+                    _.each(serviceLayer.subLayerIds, function(subLayerId) {
+                        var childLayer = this.coalesceSubLayer(result, subLayerId);
+                        result.addChild(childLayer);
+                    }, this);
+                }
+
+                return result;
+            },
+
+            // `node` should contain the minimum amount of information needed
+            // to generate a unique layer ID (name & optionally displayName).
+            createLayerId: function(parent, node) {
+                // Default to `displayName` instead of `name` because not all layers
+                // have names (ex. folder nodes).
+                var displayName = node.displayName || node.name;
+                if (parent) {
+                    return parent.id() + '/' + displayName;
+                }
+               return displayName;
+            },
+
+            filterByRegion: function(layers, currentRegion) {
+                return _.filter(_.map(layers, function(layer) {
+                    if (!layer.isAvailableInRegion(currentRegion)) {
+                        return null;
+                    } else if (layer.isFolder()) {
+                        var children = this.filterByRegion(layer.getChildren(), currentRegion);
+                        if (children.length > 0) {
+                            var result = new LayerNode(layer.node, layer.parent);
+                            result.addChildren(children);
+                            return result;
+                        }
+                        return null;
+                    }
+                    return layer;
+                }, this));
+            },
+
+            filterByName: function(layers, filterText) {
+                if (filterText.length === 0) {
+                    return layers;
+                }
+
+                filterText = filterText.toLowerCase();
+
+                return _.filter(_.map(layers, function(layer) {
+                    if (!layer.isFolder()) {
+                        return layer.getDisplayName().toLowerCase().indexOf(filterText) !== -1 ?
+                            layer : null;
+                    } else {
+                        var children = this.filterByName(layer.getChildren(), filterText);
+                        if (children.length > 0) {
+                            var result = new LayerNode(layer.node, layer.parent);
+                            result.addChildren(children);
+                            return result;
+                        }
+                        return null;
+                    }
+                }, this));
+            },
+
+            getLayers: function() {
+                return this.layers;
+            },
+
+            findLayer: function(layerId) {
+                return util.find(this.layers, function(layer) {
+                    return layer.findLayer(layerId);
+                });
+            },
+
+            findLayers: function(layerIds) {
+                return _.filter(_.map(layerIds, this.findLayer, this));
+            },
+
+            walk: function(callback) {
+                _.invoke(this.layers, 'walk', callback);
+            }
+        });
+    }
+);

--- a/src/GeositeFramework/plugins/layer_selector_v2/layers.json
+++ b/src/GeositeFramework/plugins/layer_selector_v2/layers.json
@@ -23,7 +23,7 @@
                     },
                     {
                         "name": "Congressional Districts",
-                        "description": "This polygon layer delineates the US Congressional District boundaries in New Jersey, 2012 - 2022."
+                        "description": "(Custom) This polygon layer delineates the US Congressional District boundaries in New Jersey, 2012 - 2022."
                     },
                     {
                         "name": "Town,city, village",

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -63,7 +63,7 @@ define([
 
                 this.state = new State();
                 this.config = new Config();
-                this.tree = new Tree(this.config, this.state);
+                this.rebuildTree();
 
                 this.bindEvents();
             },
@@ -310,7 +310,7 @@ define([
 
             renderTree: _.debounce(function() {
                 var html = this.treeTmpl({
-                    tree: this.tree,
+                    tree: this.filteredTree,
                     renderLayer: _.bind(this.renderLayer, this, 0)
                 });
                 $(this.container).find('.tree-container').html(html);
@@ -519,8 +519,14 @@ define([
                 this.rebuildTree();
             },
 
+            // Rebuild tree from scratch.
             rebuildTree: function() {
-                this.tree.rebuildLayers();
+                this.tree = this.config.getTree().update(this.state);
+                // Need to maintain a separate filtered tree so that map
+                // layers remain visible even after applying a filter.
+                this.filteredTree = this.tree
+                    .filterByRegion(this.state.getCurrentRegion())
+                    .filterByName(this.state.getFilterText());
                 this.renderTree();
                 this.updateMap();
             }

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -66,18 +66,22 @@ define([
 
             bindEvents: function() {
                 var self = this;
+
+                function toggleLayer() {
+                    var layerId = self.getClosestLayerId(this),
+                        layer = self.tree.findLayer(layerId);
+                    self.toggleLayer(layer);
+                }
+
                 $(this.container)
-                    .on('click', 'a.layer-row', function() {
-                        self.state.toggleLayer(self.getClosestLayerId(this));
-                    })
-                    .on('click', 'a.show', function() {
-                        self.state.toggleLayer(self.getClosestLayerId(this));
-                    })
+                    .on('click', 'a.layer-row', toggleLayer)
+                    .on('click', 'a.show', toggleLayer)
                     .on('click', 'a.info', function() {
                         self.state.setInfoBoxLayerId(self.getClosestLayerId(this));
+                        self.showLayerInfo();
                     })
                     .on('click', '.info-box .close', function() {
-                        self.state.clearInfoBoxLayerId();
+                        self.hideLayerInfo();
                     })
                     .on('click', 'a.more', function() {
                         self.showLayerMenu(this);
@@ -437,7 +441,7 @@ define([
 
             hideLayerInfo: function() {
                 $(this.container).find('.info-box-container').empty();
-                this.state.clearInfoBoxState();
+                this.state.clearInfoBoxLayerId();
             },
 
             setLayerOpacity: function(layerId, opacity) {

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -81,7 +81,7 @@ define([
                     .on('click', 'a.layer-row', toggleLayer)
                     .on('click', 'a.show', toggleLayer)
                     .on('click', 'a.info', function() {
-                        self.state.setInfoBoxLayerId(self.getClosestLayerId(this));
+                        self.state = self.state.setInfoBoxLayerId(self.getClosestLayerId(this));
                         self.showLayerInfo();
                     })
                     .on('click', '.info-box .close', function() {
@@ -355,7 +355,7 @@ define([
             setState: function(data) {
                 var self = this;
 
-                this.state.setState(data);
+                this.state = new State(data);
                 this.rebuildTree();
                 this.render();
 
@@ -393,11 +393,11 @@ define([
             },
 
             subregionActivated: function(currentRegion) {
-                this.state.setCurrentRegion(currentRegion.id);
+                this.state = this.state.setCurrentRegion(currentRegion.id);
             },
 
             subregionDeactivated: function(currentRegion) {
-                this.state.setCurrentRegion(null);
+                this.state = this.state.setCurrentRegion(null);
             },
 
             zoomToLayerExtent: function(layerId) {
@@ -442,12 +442,12 @@ define([
 
             hideLayerInfo: function() {
                 $(this.container).find('.info-box-container').empty();
-                this.state.clearInfoBoxLayerId();
+                this.state = this.state.clearInfoBoxLayerId();
             },
 
             toggleLayer: function(layer) {
                 var self = this;
-                this.state.toggleLayer(layer);
+                this.state = this.state.toggleLayer(layer);
                 layer.getService().fetchMapService().then(function() {
                     self.rebuildTree();
                 });
@@ -456,25 +456,24 @@ define([
             applyFilter: function(filterText) {
                 var self = this;
 
-                this.state.setFilterText(filterText);
+                this.state = this.state.setFilterText(filterText).collapseAllLayers();
                 this.rebuildTree();
 
                 // Expand all layers that passed the filter.
-                this.state.collapseAllLayers();
                 this.tree.walk(function(layer) {
-                    self.state.expandLayer(layer.id());
+                    self.state = self.state.expandLayer(layer.id());
                 });
                 this.rebuildTree();
             },
 
             clearAll: function() {
-                this.state.clearAll();
+                this.state = new State();
                 this.rebuildTree();
                 this.render();
             },
 
             setLayerOpacity: function(layerId, opacity) {
-                this.state.setLayerOpacity(layerId, opacity);
+                this.state = this.state.setLayerOpacity(layerId, opacity);
                 this.rebuildTree();
             },
 

--- a/src/GeositeFramework/plugins/layer_selector_v2/templates.html
+++ b/src/GeositeFramework/plugins/layer_selector_v2/templates.html
@@ -13,7 +13,7 @@
 </script>
 
 <script type="text/template" id="tree">
-    <ul><%= _.map(layers, renderLayer).join('') %></ul>
+    <ul><%= _.map(tree.getLayers(), renderLayer).join('') %></ul>
 </script>
 
 <script type="text/template" id="layer">

--- a/src/GeositeFramework/plugins/layer_selector_v2/tests.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/tests.js
@@ -71,7 +71,7 @@ define([
                     ]
                 });
                 var child = parent.findLayer('foo/bar');
-                assertTrue(child.getServiceUrl() === 'http://service/xyz/MapServer');
+                assertTrue(child.getService().getServiceUrl() === 'http://service/xyz/MapServer');
             }
         ]);
     }


### PR DESCRIPTION
Refactors the State module by splitting it up into 3 distinct modules:

* State - Represents plugin saved state; contains simple getter/setters

* Tree - Collection of layers; has filter/find functions as well as all
the data necessary to render the tree in the UI

* AgsService - Responsible for all ajax requests

The purpose of this change is to create several smaller units of code that
can be easily tested.

Other changes:

* LayerNode should now be the single source of truth for all layer data.
As a consequence, the tree must be recreated every time there is a state
change or map service data is fetched.

* Events have been removed. These didn't seem necessary anymore and
should make unit testing simpler.