### PR TITLE
WMS service support

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -15,7 +15,7 @@
     {
         @link.Text
     }
-        
+
 }
 
 
@@ -52,7 +52,7 @@
             {
                 <a target="_blank" href="@link.Url">@link.Text</a>
             }
-                                
+
         </li>
     }
 
@@ -71,7 +71,7 @@
         <link rel="stylesheet" href="@url">
     }
 
-    <link rel="stylesheet" href="//js.arcgis.com/3.11/dijit/themes/claro/claro.css"> 
+    <link rel="stylesheet" href="//js.arcgis.com/3.11/dijit/themes/claro/claro.css">
     <link rel="stylesheet" href="//js.arcgis.com/3.10/js/dojo/dojox/layout/resources/ResizeHandle.css">
     <link rel="stylesheet" href="//js.arcgis.com/o/232546/geosite-v1.0.8/esri/css/esri.css">
 
@@ -83,12 +83,12 @@
     <link rel="stylesheet" href="css/app.css">
     <link rel="stylesheet" href="css/jquery.dropdown.css"/>
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    
+
     <!-- Simple implementation style overrides from config -->
     <style type="text/css">
         .top-bar {
             background: @Model.PrimaryColor;
-        } 
+        }
 
         .top-bar ul > li.name h1 a {
             color: @Model.SecondaryColor;
@@ -102,11 +102,11 @@
         {
             background: @Model.SecondaryColor;
         }
-        body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide-active.tlypageguide_right:after, 
-        body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide-active.tlypageguide_left:after, 
+        body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide-active.tlypageguide_right:after,
+        body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide-active.tlypageguide_left:after,
         body #tlyPageGuideWrapper #tlyPageGuide li.tlypageguide-active.tlypageguide_top:after,
-        body #tlyPageGuideWrapper #tlyPageGuide li:hover.tlypageguide_right:after, 
-        body #tlyPageGuideWrapper #tlyPageGuide li:hover.tlypageguide_left:after, 
+        body #tlyPageGuideWrapper #tlyPageGuide li:hover.tlypageguide_right:after,
+        body #tlyPageGuideWrapper #tlyPageGuide li:hover.tlypageguide_left:after,
         body #tlyPageGuideWrapper #tlyPageGuide li:hover.tlypageguide_top:after {
             border-top: 15px solid @Model.SecondaryColor;
         }
@@ -284,7 +284,7 @@
     <script type="text/template" id="template-topbar-plugin">
             <a class="plugin-launcher" title="<%=fullName%>" href="javascript:;"></a>
     </script>
-    
+
     <script type="text/template" id="template-topbar-tools">
         <span class="topbar-tools">
             <a class="plugin-clear" href="javascript:;">&#10006;</a>
@@ -388,7 +388,7 @@
                 </div>
             </div>
         </div>
-      
+
     </script>
 
     <script type="text/template" id="template-export-url">
@@ -398,7 +398,7 @@
     <!-- Adding any white space between the textarea and the iframe
         will result in whitespace within the rendered textarea, which looks strange. -->
     <script type="text/template" id="embed-iframe">
-       <textarea class="code-like"><iframe width="<%= width %>" height="<%= height %>" src="<%= shortUrl %>"></iframe>        
+       <textarea class="code-like"><iframe width="<%= width %>" height="<%= height %>" src="<%= shortUrl %>"></iframe>
        </textarea>
     </script>
 
@@ -453,10 +453,10 @@
                             </ul>
 
                         </div>
-                    </div> 
+                    </div>
                 </div>
                 <% } %>
-                
+
                 <% _.each(categories, function(category) { %>
                 <div class="row">
                     <div class="well">
@@ -468,7 +468,7 @@
                             <ul>
                                 <% _.each(category.issues, function(issue) { %>
                                     <li class="lp-issue-btn" data-issue-id="<%= issue.id %>">
-                                        <i class="<%= issue.faIcon %>" 
+                                        <i class="<%= issue.faIcon %>"
                                             <% if (issue.faSize) { %>
                                                 style="font-size:<%= issue.faSize %>px"
                                             <% } %>
@@ -531,24 +531,24 @@
             </section>
         </nav>
     </div>
-    
+
     @Html.Partial("TourInfo")
-    
+
     <!-- Area for plugins to arrange their markup independent
         of their container -->
     <div id="plugin-print-sandbox"></div>
 
     <!-- LEFT CONTENT AREA -->
     <div id="left-pane" class="content"></div>
-    
+
     <!-- RIGHT CONTENT AREA -->
     <div id="right-pane" class="content"></div>
-    
+
     <script src="js/polyfill.js"></script>
-    
+
     <script src="//apis.google.com/js/client.js"></script>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
-    
+
     <!-- Scripts that will change their behavior in undesirable ways if they find an AMD
          environment should be loaded before the jsapi -->
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
@@ -568,11 +568,11 @@
     <script src="js/lib/pageguide.min.js"></script>
 
     <script type="text/javascript">
-            // Configure the Dojo module loader so that module identifiers starting with "plugins/" 
+            // Configure the Dojo module loader so that module identifiers starting with "plugins/"
             // will be loaded from the site's root "plugins" folder.
             // (This usage of require() is mentioned in http://dojotoolkit.org/documentation/tutorials/1.7/modules)
             //
-            // The calls to location.pathname.replace() below prepend the app's root path to library locations. 
+            // The calls to location.pathname.replace() below prepend the app's root path to library locations.
             // Otherwise, since Dojo is loaded from a CDN it will prepend the CDN server path, and fail.
             // (See https://dojotoolkit.org/documentation/tutorials/1.7/cdn)
 
@@ -626,7 +626,7 @@
     <script src="js/Screen.js"></script>
     <script src="js/SyncedMapManager.js"></script>
     <script src="js/App.js"></script>
-    
+
     <script type="text/javascript">
 
         require(['use!Azavea'], function(Azavea) {
@@ -637,7 +637,7 @@
         // Our require() call below for loading plugins shouldn't fail, since:
         //     * Server-side code verifies that each plugin folder exists and contains a main.js file.
         //     * require() succeeds even if main.js has errors. (It passes an empty object for that module.)
-        // 
+        //
         // However, plugins can trigger a Dojo module loading error by mis-configuring their define() calls.
         // Do our best to report a useful message.
 
@@ -653,7 +653,7 @@
 
         // Load the plugins and launch the app.
         // We're using server-generated data to build this JavaScript block. Example result:
-        // 
+        //
         //     require(['plugins/layer_selector/main', 'plugins/measure/main'], function(p0, p1) {
         //         $(document).ready(function() {
         //             var regionData = {

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -243,6 +243,14 @@
         </div>
     </script>
 
+    <script type="text/template" id="template-legend-item-image">
+        <div class="legend-layer single">
+            <div class="item">
+                <img src="<%- legend %>" alt="<%- layer.title %>" />
+            </div>
+        </div>
+    </script>
+
     <script type="text/template" id="template-sidebar">
         <li class="divider"></li>
         <% if (isMain) { %>

--- a/src/GeositeFramework/js/Legend.js
+++ b/src/GeositeFramework/js/Legend.js
@@ -39,6 +39,7 @@ define(['use!Geosite',
             this.tmplLegendItemSingle = _.template($('#template-legend-item-single').html());
             this.tmplLegendItemMultiple = _.template($('#template-legend-item-multiple').html());
             this.tmplLegendItemScale = _.template($('#template-legend-item-scale').html());
+            this.tmplLegendItemImage = _.template($('#template-legend-item-image').html());
 
             // Make the legend resizeable and moveable
             var handle = new ResizeHandle({
@@ -75,10 +76,16 @@ define(['use!Geosite',
                     return this.tmplLegendItemMultiple;
                 } else if (layerSettings.legendType === 'scale') {
                     return this.tmplLegendItemScale;
+                } else if (layerSettings.legendType === 'image') {
+                    return this.tmplLegendItemImage;
                 }
             }
 
-            if (legend.legend.length === 1) {
+            // A string indicates we have a legend URL that returns an image
+            // instead of a JSON representation
+            if (typeof legend === 'string') {
+                return this.tmplLegendItemImage;
+            } else if (legend.legend.length === 1) {
                 return this.tmplLegendItemSingle;
             }
 
@@ -110,7 +117,11 @@ define(['use!Geosite',
                     tmpl = self.getLayerTemplate(legend, service, layer);
 
                 if (tmpl) {
-                    $container.append(tmpl(legend));
+                    if (typeof legend === 'string') {
+                        $container.append(tmpl({ legend: legend, layer: layer }));
+                    } else {
+                        $container.append(tmpl(legend));
+                    }
                 }
             });
 

--- a/src/GeositeFramework/js/MapWrapper.js
+++ b/src/GeositeFramework/js/MapWrapper.js
@@ -110,7 +110,7 @@
         _wrapper.centerAndZoom = function() {
             esriMap.centerAndZoom.apply(esriMap, arguments);
         };
-        
+
         // ------------------------------------------------------------------------
         // Event overrides
 

--- a/src/GeositeFramework/js/MapWrapper.js
+++ b/src/GeositeFramework/js/MapWrapper.js
@@ -28,7 +28,7 @@
         function rememberLayer(layer) {
             if (!isMyLayer(layer)) {
                 _myLayers.push(layer);
-                if (_.contains(["esri.layers.ArcGISDynamicMapServiceLayer", "esri.layers.ArcGISTiledMapServiceLayer"], layer.declaredClass)) {
+                if (_.contains(["esri.layers.ArcGISDynamicMapServiceLayer", "esri.layers.ArcGISTiledMapServiceLayer", "esri.layers.WMSLayer"], layer.declaredClass)) {
                     mapModel.addService(layer, pluginObject);
                 }
             }
@@ -38,7 +38,7 @@
             _myLayers = _.reject(_myLayers, function (l) {
                 return l.id === layer.id;
             });
-            if (_.contains(["esri.layers.ArcGISDynamicMapServiceLayer", "esri.layers.ArcGISTiledMapServiceLayer"], layer.declaredClass)) {
+            if (_.contains(["esri.layers.ArcGISDynamicMapServiceLayer", "esri.layers.ArcGISTiledMapServiceLayer", "esri.layers.WMSLayer"], layer.declaredClass)) {
                 mapModel.removeService(layer);
             }
         }

--- a/src/GeositeFramework/js/util/ajax.js
+++ b/src/GeositeFramework/js/util/ajax.js
@@ -11,14 +11,20 @@ define(['esri/request'],
         }
 
         // Fetch data from `url` and store the result in `cache` (memoized).
-        var fetch = function(url) {
+        var fetch = function(url, options) {
+            var options = options || {},
+                settings = _.defaults(options, {
+                    format: 'json',
+                    content: {f: 'json'}
+                });
+
             if (typeof promises[url] === 'undefined') {
                 promises[url] = request({
                     url: url,
-                    content: {f: 'json'},
-                    handleAs: 'json',
+                    content: settings.content,
+                    handleAs: settings.format,
                     callbackParamName: 'callback',
-                    timeout: 7000
+                    timeout: 20000
                 }).then(function(data) {
                     cache[url] = data;
                 }, function(error) {

--- a/src/GeositeFramework/plugins/layer_selector_v2/AgsService.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/AgsService.js
@@ -1,13 +1,11 @@
 define([
         "dojo/_base/declare",
-        "dojo/Deferred",
         "underscore",
         "framework/util/ajax",
         "./util",
         "./LayerNode"
     ],
     function(declare,
-             Deferred,
              _,
              ajaxUtil,
              util,

--- a/src/GeositeFramework/plugins/layer_selector_v2/LayerNode.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/LayerNode.js
@@ -4,6 +4,7 @@ define([
         "esri/geometry/Extent",
         "./util",
         "./AgsService",
+        "./WmsService",
         "./NullService"
     ],
     function(declare,
@@ -11,6 +12,7 @@ define([
              Extent,
              util,
              AgsService,
+             WmsService,
              NullService) {
         "use strict";
 
@@ -85,8 +87,10 @@ define([
 
             getService: function() {
                 var server = this.getServer();
-                if (server) {
+                if (server.type === "ags") {
                     return new AgsService(server);
+                } else if (server.type === "wms") {
+                    return new WmsService(server);
                 }
                 return new NullService();
             },

--- a/src/GeositeFramework/plugins/layer_selector_v2/WmsService.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/WmsService.js
@@ -1,0 +1,156 @@
+define([
+        "dojo/_base/declare",
+        "dojo/Deferred",
+        "underscore",
+        "./lib/xmlToJson",
+        "framework/util/ajax",
+        "./util",
+        "./LayerNode",
+    ],
+    function(declare,
+             Deferred,
+             _,
+             xmlToJson,
+             ajaxUtil,
+             util,
+             LayerNode) {
+        "use strict";
+
+        var jsonResponseCache = {};
+
+        function get(url) {
+            return jsonResponseCache[url];
+        }
+
+        return declare(null, {
+            constructor: function(server) {
+                this.server = server;
+                this.defaultAjaxOptions = {
+                    format: 'text',
+                    content: ''
+                };
+            },
+
+            getServiceUrl: function() {
+                return util.urljoin(this._getBaseServiceUrl() + '?request=GetCapabilities&service=WMS');
+            },
+
+            _getBaseServiceUrl: function() {
+                // If name exists, this is likely an AGS WMS service,
+                // as opposed to GeoServer.
+                if (this.server.name) {
+                    return util.urljoin(this.server.url, this.server.name, 'MapServer/WMSServer');
+                } else {
+                    return this.server.url;
+                }
+            },
+
+            // Return a promise containing map service data.
+            fetchMapService: function() {
+                var self = this;
+                return ajaxUtil.fetch(this.getServiceUrl(), this.defaultAjaxOptions).
+                        then(function(response) {
+                            var responseJSON = self._transformServiceData(response);
+                            jsonResponseCache[self.getServiceUrl()] = responseJSON;
+                            return responseJSON;
+                        });
+            },
+
+            // Return cached map service data.
+            getServiceData: function() {
+                return get(this.getServiceUrl());
+            },
+
+            // Return a promise with service layer data.
+            fetchLayerDetails: function(tree, layerId) {
+                // There are no layer details for a
+                // WMS layer.
+                return new Deferred().resolve({});
+            },
+
+            // Return cached layer details.
+            getLayerDetails: function(serviceLayer) {
+                // There are no layer details for a
+                // WMS layer.
+                return {};
+            },
+
+            // Find the corresponding data for `layer` in the map service.
+            findServiceLayer: function(layer) {
+                var serviceData = this.getServiceData();
+
+                if (!serviceData || !layer) {
+                    return null;
+                }
+
+                return _.find(serviceData.layers, function(serviceLayer) {
+                    if (layer.getName() === serviceLayer.name) {
+                        // Compare not only the name, but the structure as well.
+                        // Protects against an edge case where a map service
+                        // contains a parent and child layer with the same name.
+                        if (layer.hasChildren() && serviceLayer.subLayerIds) {
+                            return true;
+                        } else if (!layer.hasChildren() && !serviceLayer.subLayerIds) {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
+            },
+
+            findServiceLayerById: function(layerId) {
+                var serviceData = this.getServiceData();
+                if (serviceData) {
+                    return _.findWhere(serviceData.layers, { id: layerId });
+                }
+                return null;
+            },
+
+            supportsOpacity: function() {
+                return false;
+            },
+
+            // Maps the WMS XML service data to JSON that closely
+            // matches the JSON returned by the ESRI JS API.
+            _transformServiceData: function(serviceData) {
+                var output = {
+                        layers: []
+                    },
+                    jsonServiceData = xmlToJSON.parseString(serviceData, {
+                        childrenAsArray: false
+                    }).WMS_Capabilities;
+
+                output.currentVersion = jsonServiceData._attr.version._value;
+
+                // Add layers
+                _.each(jsonServiceData.Capability.Layer.Layer, function(layer) {
+                    var jsonLayer = {
+                        id: layer.Name._text,
+                        name: layer.Title._text,
+                        parentLayerId: null,
+                        subLayerIds: null
+                    };
+
+                    // Set Extent
+                    var boundingBox = _.isArray(layer.BoundingBox) ? layer.BoundingBox[0] : layer.BoundingBox;
+                    if (boundingBox) {
+                        jsonLayer.extent = {
+                            spatialReference: {
+                                latestWkid: boundingBox._attr.CRS._value.split(':')[1],
+                                wkid: boundingBox._attr.CRS._value.split(':')[1]
+                            },
+                            xmax: boundingBox._attr.maxx._value,
+                            xmin: boundingBox._attr.minx._value,
+                            ymax: boundingBox._attr.maxy._value,
+                            ymin: boundingBox._attr.miny._value,
+                        };
+                    }
+
+                    output.layers.push(jsonLayer);
+                });
+
+                return output;
+            },
+        });
+    }
+);

--- a/src/GeositeFramework/plugins/layer_selector_v2/layers.json
+++ b/src/GeositeFramework/plugins/layer_selector_v2/layers.json
@@ -150,5 +150,43 @@
                 "downloadUrl": "http://www.tceq.texas.gov/assets/public/gis/exports/au_oysterwaters.zip"
             }
         ]
+    },
+    {
+        "displayName": "WMS Example Layers",
+        "server": {
+            "type": "wms",
+            "layerType": "dynamic",
+            "url": "http://sampleserver1.arcgisonline.com/ArcGIS/services/Specialty/",
+            "name": "ESRI_StatesCitiesRivers_USA"
+        },
+        "includeLayers": [
+            {
+                "name": "States"
+            },
+            {
+                "name": "Cities"
+            },
+            {
+                "name": "Rivers"
+            }
+        ]
+    },
+    {
+        "displayName": "Global Risk Data Platform",
+        "server": {
+            "type": "wms",
+            "layerType": "dynamic",
+            "url": "http://preview.grid.unep.ch:8080/geoserver/wms"
+        },
+        "includeLayers": [
+            {
+                "name": "Cities_esri",
+                "displayName": "Cities"
+            },
+            {
+                "name": "Lakes_glwd1",
+                "displayName": "Lakes"
+            }
+        ]
     }
 ]

--- a/src/GeositeFramework/plugins/layer_selector_v2/lib/xmlToJSON.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/lib/xmlToJSON.js
@@ -1,0 +1,242 @@
+/* Copyright 2015 William Summers, MetaTribal LLC
+ * adapted from https://developer.mozilla.org/en-US/docs/JXON
+ *
+ * Licensed under the MIT License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/MIT
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author William Summers
+ *
+ */
+
+var xmlToJSON = (function () {
+
+    this.version = "1.3";
+
+    var options = { // set up the default options
+        mergeCDATA: true, // extract cdata and merge with text
+        grokAttr: true, // convert truthy attributes to boolean, etc
+        grokText: true, // convert truthy text/attr to boolean, etc
+        normalize: true, // collapse multiple spaces to single space
+        xmlns: true, // include namespaces as attribute in output
+        namespaceKey: '_ns', // tag name for namespace objects
+        textKey: '_text', // tag name for text nodes
+        valueKey: '_value', // tag name for attribute values
+        attrKey: '_attr', // tag for attr groups
+        cdataKey: '_cdata', // tag for cdata nodes (ignored if mergeCDATA is true)
+        attrsAsObject: true, // if false, key is used as prefix to name, set prefix to '' to merge children and attrs.
+        stripAttrPrefix: true, // remove namespace prefixes from attributes
+        stripElemPrefix: true, // for elements of same name in diff namespaces, you can enable namespaces and access the nskey property
+        childrenAsArray: true // force children into arrays
+    };
+
+    var prefixMatch = new RegExp(/(?!xmlns)^.*:/);
+    var trimMatch = new RegExp(/^\s+|\s+$/g);
+
+    this.grokType = function (sValue) {
+        if (/^\s*$/.test(sValue)) {
+            return null;
+        }
+        if (/^(?:true|false)$/i.test(sValue)) {
+            return sValue.toLowerCase() === "true";
+        }
+        if (isFinite(sValue)) {
+            return parseFloat(sValue);
+        }
+        return sValue;
+    };
+
+    this.parseString = function (xmlString, opt) {
+        return this.parseXML(this.stringToXML(xmlString), opt);
+    }
+
+    this.parseXML = function (oXMLParent, opt) {
+
+        // initialize options
+        for (var key in opt) {
+            options[key] = opt[key];
+        }
+
+        var vResult = {},
+            nLength = 0,
+            sCollectedTxt = "";
+
+        // parse namespace information
+        if (options.xmlns && oXMLParent.namespaceURI) {
+            vResult[options.namespaceKey] = oXMLParent.namespaceURI;
+        }
+
+        // parse attributes
+        // using attributes property instead of hasAttributes method to support older browsers
+        if (oXMLParent.attributes && oXMLParent.attributes.length > 0) {
+            var vAttribs = {};
+
+            for (nLength; nLength < oXMLParent.attributes.length; nLength++) {
+                var oAttrib = oXMLParent.attributes.item(nLength);
+                vContent = {};
+                var attribName = '';
+
+                if (options.stripAttrPrefix) {
+                    attribName = oAttrib.name.replace(prefixMatch, '');
+
+                } else {
+                    attribName = oAttrib.name;
+                }
+
+                if (options.grokAttr) {
+                    vContent[options.valueKey] = this.grokType(oAttrib.value.replace(trimMatch, ''));
+                } else {
+                    vContent[options.valueKey] = oAttrib.value.replace(trimMatch, '');
+                }
+
+                if (options.xmlns && oAttrib.namespaceURI) {
+                    vContent[options.namespaceKey] = oAttrib.namespaceURI;
+                }
+
+                if (options.attrsAsObject) { // attributes with same local name must enable prefixes
+                    vAttribs[attribName] = vContent;
+                } else {
+                    vResult[options.attrKey + attribName] = vContent;
+                }
+            }
+
+            if (options.attrsAsObject) {
+                vResult[options.attrKey] = vAttribs;
+            } else {}
+        }
+
+        // iterate over the children
+        if (oXMLParent.hasChildNodes()) {
+            for (var oNode, sProp, vContent, nItem = 0; nItem < oXMLParent.childNodes.length; nItem++) {
+                oNode = oXMLParent.childNodes.item(nItem);
+
+                if (oNode.nodeType === 4) {
+                    if (options.mergeCDATA) {
+                        sCollectedTxt += oNode.nodeValue;
+                    } else {
+                        if (vResult.hasOwnProperty(options.cdataKey)) {
+                            if (vResult[options.cdataKey].constructor !== Array) {
+                                vResult[options.cdataKey] = [vResult[options.cdataKey]];
+                            }
+                            vResult[options.cdataKey].push(oNode.nodeValue);
+
+                        } else {
+                            if (options.childrenAsArray) {
+                                vResult[options.cdataKey] = [];
+                                vResult[options.cdataKey].push(oNode.nodeValue);
+                            } else {
+                                vResult[options.cdataKey] = oNode.nodeValue;
+                            }
+                        }
+                    }
+                } /* nodeType is "CDATASection" (4) */
+                else if (oNode.nodeType === 3) {
+                    sCollectedTxt += oNode.nodeValue;
+                } /* nodeType is "Text" (3) */
+                else if (oNode.nodeType === 1) { /* nodeType is "Element" (1) */
+
+                    if (nLength === 0) {
+                        vResult = {};
+                    }
+
+                    // using nodeName to support browser (IE) implementation with no 'localName' property
+                    if (options.stripElemPrefix) {
+                        sProp = oNode.nodeName.replace(prefixMatch, '');
+                    } else {
+                        sProp = oNode.nodeName;
+                    }
+
+                    vContent = xmlToJSON.parseXML(oNode);
+
+                    if (vResult.hasOwnProperty(sProp)) {
+                        if (vResult[sProp].constructor !== Array) {
+                            vResult[sProp] = [vResult[sProp]];
+                        }
+                        vResult[sProp].push(vContent);
+
+                    } else {
+                        if (options.childrenAsArray) {
+                            vResult[sProp] = [];
+                            vResult[sProp].push(vContent);
+                        } else {
+                            vResult[sProp] = vContent;
+                        }
+                        nLength++;
+                    }
+                }
+            }
+        } else if (!sCollectedTxt) { // no children and no text, return null
+            if (options.childrenAsArray) {
+                vResult[options.textKey] = [];
+                vResult[options.textKey].push(null);
+            } else {
+                vResult[options.textKey] = null;
+            }
+        }
+
+        if (sCollectedTxt) {
+            if (options.grokText) {
+                var value = this.grokType(sCollectedTxt.replace(trimMatch, ''));
+                if (value !== null && value !== undefined) {
+                    vResult[options.textKey] = value;
+                }
+            } else if (options.normalize) {
+                vResult[options.textKey] = sCollectedTxt.replace(trimMatch, '').replace(/\s+/g, " ");
+            } else {
+                vResult[options.textKey] = sCollectedTxt.replace(trimMatch, '');
+            }
+        }
+
+        return vResult;
+    }
+
+
+    // Convert xmlDocument to a string
+    // Returns null on failure
+    this.xmlToString = function (xmlDoc) {
+        try {
+            var xmlString = xmlDoc.xml ? xmlDoc.xml : (new XMLSerializer()).serializeToString(xmlDoc);
+            return xmlString;
+        } catch (err) {
+            return null;
+        }
+    }
+
+    // Convert a string to XML Node Structure
+    // Returns null on failure
+    this.stringToXML = function (xmlString) {
+        try {
+            var xmlDoc = null;
+
+            if (window.DOMParser) {
+
+                var parser = new DOMParser();
+                xmlDoc = parser.parseFromString(xmlString, "text/xml");
+
+                return xmlDoc;
+            } else {
+                xmlDoc = new ActiveXObject("Microsoft.XMLDOM");
+                xmlDoc.async = false;
+                xmlDoc.loadXML(xmlString);
+
+                return xmlDoc;
+            }
+        } catch (e) {
+            return null;
+        }
+    }
+
+    return this;
+}).call({});
+
+if (typeof module != "undefined" && module !== null && module.exports) module.exports = xmlToJSON;
+else if (typeof define === "function" && define.amd) define(function() {return xmlToJSON});

--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -21,6 +21,7 @@ define([
         "esri/layers/FeatureLayer",
         "esri/layers/ArcGISDynamicMapServiceLayer",
         "esri/layers/ArcGISTiledMapServiceLayer",
+        "esri/layers/WMSLayer",
         "esri/layers/LayerDrawingOptions",
         "framework/PluginBase",
         //"./tests",
@@ -35,6 +36,7 @@ define([
              FeatureLayer,
              ArcGISDynamicMapServiceLayer,
              ArcGISTiledMapServiceLayer,
+             WMSLayer,
              LayerDrawingOptions,
              PluginBase,
              //unitTests,
@@ -175,7 +177,7 @@ define([
                 _.each(visibleLayerIds, function(layerServiceIds, serviceUrl) {
                     var mapLayer = this.map.getLayer(serviceUrl);
                     if (layerServiceIds.length === 0) {
-                        mapLayer.setVisibleLayers([-1]);
+                        mapLayer.setVisibleLayers([]);
                     } else {
                         mapLayer.setVisibleLayers(layerServiceIds);
                     }
@@ -288,7 +290,7 @@ define([
                         throw new Error('AGS service layer type is not supported: ' + server.layerType);
                     }
                 } else if (server.type === 'wms') {
-                    throw new Error('WMS server type is not implemented yet');
+                    return new WMSLayer(serviceUrl);
                 } else {
                     throw new Error('Service type not supported: ' + server.type);
                 }

--- a/src/GeositeFramework/proxy.config
+++ b/src/GeositeFramework/proxy.config
@@ -18,8 +18,8 @@
     <serverUrl matchAll="true" url="http://services.coastalresilience.org:6080/"></serverUrl>
     <serverUrl matchAll="true" url="http://dev.services2.coastalresilience.org/"></serverUrl>
     <serverUrl matchAll="true" url="http://services.coastalresilience.org/"></serverUrl>
-    <serverUrl matchAll="true" url="http://50.18.215.52/"></serverUrl>  
-    <serverUrl matchAll="true" url="http://lr13:6080/"></serverUrl>  
+    <serverUrl matchAll="true" url="http://50.18.215.52/"></serverUrl>
+    <serverUrl matchAll="true" url="http://lr13:6080/"></serverUrl>
   </serverUrls>
-  
+
 </ProxyConfig>

--- a/src/GeositeFramework/proxy.config
+++ b/src/GeositeFramework/proxy.config
@@ -20,6 +20,8 @@
     <serverUrl matchAll="true" url="http://services.coastalresilience.org/"></serverUrl>
     <serverUrl matchAll="true" url="http://50.18.215.52/"></serverUrl>
     <serverUrl matchAll="true" url="http://lr13:6080/"></serverUrl>
+    <serverUrl matchAll="true" url="http://sampleserver1.arcgisonline.com"></serverUrl>
+    <serverUrl matchAll="true" url="http://preview.grid.unep.ch:8080"></serverUrl>
   </serverUrls>
 
 </ProxyConfig>


### PR DESCRIPTION
Adds support for WMS layers. See commit messages for details.

TODO

- [X] Map XML to JSON
- [X] Add layers to legend
- [ ] ~~Zoom to extent~~
- [ ] ~~Opacity~~

Known issues:

- In the example [WMS service](http://www.arcgis.com/home/item.html?id=1f80433204814a16964c0bcd3fcefaf8) provided by TNC, there are some layers that aren't found when matching up the layers specified in the config to the layers available in the service. It may have something to do with the fact that many of the names have `:` in them. For example, specifying `preview:Lakes_glwd1` in the config doesn't work, but `Lakes_glwd1` even though the name in the service is `preview:Lakes_glwd1`. Also, lots of layers won't match up with our without the suffix. For example `GAR2015:PGA_1500_yrp` doesn't work as `GAR2015:PGA_1500_yrp` or `PGA_1500_yrp`.
- Zoom to extent does not work: https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/578
- Setting opacity is not currently supported: https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/579

Also, for future consideration, https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/580.

Ready for testing

**Testing instructions**
- Try adding layers from the two sample WMS services and verify that they show up on the map and the legend. The "Global Risk Data Platform" service is very slow.

Connects to #519 