### PR TITLE
Remove toggleLayer delay

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -448,6 +448,7 @@ define([
             toggleLayer: function(layer) {
                 var self = this;
                 this.state = this.state.toggleLayer(layer);
+                self.rebuildTree();
                 layer.getService().fetchMapService().then(function() {
                     self.rebuildTree();
                 });


### PR DESCRIPTION
When you expand the root folder for slow services (ex. Global Risk) the
tree is not re-rendered until the map service is fetched. This fixes
that by rendering the tree immediately.