### PR TITLE
Fix preloading of WMS layers.

### DIFF
--- a/src/GeositeFramework/plugins/layer_selector_v2/main.js
+++ b/src/GeositeFramework/plugins/layer_selector_v2/main.js
@@ -413,7 +413,13 @@ define([
                 // Fetch all map services found.
                 var promise = all(_.map(serviceUrls, function(v, serviceUrl) {
                     // Cache map service response.
-                    return ajaxUtil.fetch(serviceUrl);
+                    var options = {};
+                    if (serviceUrl.match(/WMS/i)) {
+                        options.format = 'text';
+                        options.content = '';
+                    }
+
+                    return ajaxUtil.fetch(serviceUrl, options);
                 }));
 
                 promise.always(function() {


### PR DESCRIPTION
* We need to specify that the response should be handled as text
for WMS layers.

**Testing instructions**
- There should be no errors when the layer selector is launched, and all WMS layers should be preloaded.