### PR TITLE
Toggle the min/max icon for legend

### DIFF
--- a/src/GeositeFramework/js/Legend.js
+++ b/src/GeositeFramework/js/Legend.js
@@ -174,6 +174,11 @@ define(['use!Geosite',
             // height despite the above css changes.
             this.$el.find('.legend-body').hide();
 
+            // Toggle the text of the minimize button
+            this.$el.find('.legend-close')
+                .attr({title: 'Restore Legend'})
+                .text('+');
+
             // Hide the resize handle or else the user can resize the
             // minimized legend.
             this.$el.find('.dojoxResizeHandle').hide();
@@ -199,6 +204,11 @@ define(['use!Geosite',
 
             this.$el.find('.legend-body').show();
             this.$el.find('.dojoxResizeHandle').show();
+
+            // Toggle the text of the minimize button
+            this.$el.find('.legend-close')
+                .attr({title: 'Hide Legend'})
+                .text('_');
 
             this.$el.removeClass('minimized');
         },


### PR DESCRIPTION
Swap out a _ for a + when toggling the min/max for Legend.

Connects #609 

To test, minimize the legend and restore it noting the change in icon and title text.