### PR TITLE
Hold language translations in memory

### DIFF
--- a/src/GeositeFramework/App_Start/RouteConfig.cs
+++ b/src/GeositeFramework/App_Start/RouteConfig.cs
@@ -24,6 +24,12 @@ namespace GeositeFramework
             );
 
             routes.MapRoute(
+                name: "Language",
+                url: "languages/{locale}",
+                defaults: new { controller = "Language", action = "GetLocale"}
+            );
+
+            routes.MapRoute(
                 name: "Default",
                 url: "{controller}/{action}/{id}",
                 defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }

--- a/src/GeositeFramework/Controllers/LanguageController.cs
+++ b/src/GeositeFramework/Controllers/LanguageController.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Web;
+using System.Web.Mvc;
+using log4net;
+
+namespace GeositeFramework.Controllers
+{
+    public class LanguageController : Controller
+    {
+        private static readonly ILog _log =
+            LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>
+        /// Returns the translation JSON representation for a particular locale
+        /// </summary>
+        /// <returns></returns>
+        public ActionResult GetLocale(string locale)
+        {
+            try {
+                return Json(MvcApplication.Languages[locale], JsonRequestBehavior.AllowGet);
+            } catch(Exception ex) {
+                _log.Error(ex);
+                throw new HttpException(500, String.Format("Invalid locale setting: {0}", locale));
+            }
+        }
+    }
+}

--- a/src/GeositeFramework/GeositeFramework.csproj
+++ b/src/GeositeFramework/GeositeFramework.csproj
@@ -118,6 +118,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Controllers\LanguageController.cs" />
     <Compile Include="Controllers\LogController.cs" />
     <Compile Include="Controllers\DownloadController.cs" />
     <Compile Include="Global.asax.cs">

--- a/src/GeositeFramework/Global.asax.cs
+++ b/src/GeositeFramework/Global.asax.cs
@@ -22,6 +22,7 @@ namespace GeositeFramework
     public class MvcApplication : System.Web.HttpApplication
     {
         public static Geosite GeositeData { get; private set; }
+        public static Translations Languages { get; private set; }
 
         private static readonly string _geositeFrameworkVersion = "0.1.0";
         private static readonly ILog _log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
@@ -40,7 +41,7 @@ namespace GeositeFramework
 
             // Load geosite configuration data (which loads and validates all config files)
             GeositeData = LoadGeositeData();
-            
+
             // Create a logger for each plugin
             foreach (string pluginName in GeositeData.PluginFolderNames)
             {
@@ -48,7 +49,7 @@ namespace GeositeFramework
             }
 
             // Prepare Languages for Internationalization
-            PrepareLanguages(GeositeData);
+            Languages = PrepareLanguages(GeositeData);
         }
 
         private Geosite LoadGeositeData()
@@ -108,7 +109,7 @@ namespace GeositeFramework
             }
         }
 
-        private void PrepareLanguages(Geosite data)
+        private Translations PrepareLanguages(Geosite data)
         {
             var translations = new Translations();
 
@@ -135,22 +136,7 @@ namespace GeositeFramework
 
             translations = mergeTranslations(coreTranslations, translations);
 
-            // Create final languages folder, deleting old one if exists
-            var finalLocalesPath = HostingEnvironment.MapPath("~/languages");
-            if (Directory.Exists(finalLocalesPath))
-            {
-                Directory.Delete(finalLocalesPath, true);
-            }
-            Directory.CreateDirectory(finalLocalesPath);
-
-            // Write combined translations to disk
-            translations.ToList().ForEach(t =>
-            {
-                var lang = t.Key;
-                var json = JsonConvert.SerializeObject(t.Value);
-
-                File.WriteAllText(String.Format("{0}/{1}.json", finalLocalesPath, lang), json);
-            });
+            return translations;
         }
 
         /// <summary>

--- a/src/GeositeFramework/js/App.js
+++ b/src/GeositeFramework/js/App.js
@@ -69,7 +69,7 @@
 
             initResizeHandler();
 
-            // Setup a manager for synced maps.  As maps are created, 
+            // Setup a manager for synced maps.  As maps are created,
             // they will be added to it.
             N.app.syncedMapManager = new N.SyncedMapManager(N.app.models.screen);
 
@@ -90,7 +90,7 @@
             // function, then clear it. This is done instead of the
             // typical behavior of HashModels which is to continue
             // listening for changes in the location.hash
-            
+
             // IE8 will throw a syntax error if the hash contains a single
             // # character before entering hashmodels
             handleHashChangedFn(location.hash === '#' ? '' : location.hash);
@@ -104,7 +104,7 @@
             var bottomHeight         = $('.side-nav.bottom:visible').height(),
                 sidebarHeight        = $('.sidebar:visible').height(),
                 rightBottomHeight    = $('#right-pane:visible .side-nav.bottom').height();
-            
+
             $('.side-nav.top:visible').height(sidebarHeight - bottomHeight);
             $('#right-pane .side-nav.top').height(sidebarHeight - rightBottomHeight);
             $(N).trigger('resize');
@@ -151,7 +151,7 @@
                 overloadTranslationOptionHandler: i18nextSprintfPostProcessor.overloadTranslationOptionHandler,
                 // Path to load translations from
                 backend: {
-                    loadPath: 'languages/{{lng}}.json'
+                    loadPath: 'languages/{{lng}}'
                 }
             },
             callback = function() {


### PR DESCRIPTION
To avoid having to write/delete files on disk during App_Start, hold the
translation results as a global static and expose it as a route to the
front end app.

_sorry for the whitespace noise in the commit, new editor_

Connects #610 
Connects #620 
Connects #621 

#### Test
* Ensure you have no `/languages/` directory (delete if necessary)
* Load app and ensure `en` xhr request succeeds (`/languages/en`)
* Change your region language setting to `es`
* Check that translation `es` request succeeds and the app is translated
* Check that a bogus language file logs the error in `/logs/GeositeFramework.log` (ex: http://localhost:54633/languages/ghostwolfe)