### PR TITLE
All infoGraphic to be an HTML snippit or an img...

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -668,8 +668,13 @@ require(['use!Geosite',
                 var pluginModel = this.model,
                     pluginObject = pluginModel.get('pluginObject');
 
-                var img = $('<img class="graphic" />').attr('src', pluginObject.infoGraphic);
-                this.$el.append(img);
+	       if (pluginObject.infoGraphic.slice(pluginObject.infoGraphic.length - 4, pluginObject.infoGraphic.length) == ".jpg" || pluginObject.infoGraphic.slice(pluginObject.infoGraphic.length - 4, pluginObject.infoGraphic.length) == ".png") {
+		var snippit = $('<img class="graphic" />').attr('src', pluginObject.infoGraphic);
+	       } else {
+		var snippit = $(pluginObject.infoGraphic);
+	       }				
+				
+                this.$el.append(snippit);
 
                 var checkboxnode = $('<span>').get(0);
                 this.$el.append(checkboxnode);


### PR DESCRIPTION
The snippit allows the code to detect if the infoGraphic is specified as an image (.png or .jpg).  If not it assumes that it is a an html snippit and inserts into the same location.  Done at the request of Zach, should not impact current plugins that specify an image.