### PR TITLE
Translate additional plugins

### DIFF
--- a/src/GeositeFramework/plugins/full_extent/locales/es.json
+++ b/src/GeositeFramework/plugins/full_extent/locales/es.json
@@ -1,0 +1,4 @@
+{
+    "Full Extent": "Toda su Extensión",
+    "Zoom out to the default map extent": "Alejar el zoom para el mapa predeterminado medida"
+}

--- a/src/GeositeFramework/plugins/subregion_toggle/locales/es.json
+++ b/src/GeositeFramework/plugins/subregion_toggle/locales/es.json
@@ -1,0 +1,4 @@
+{
+    "Subregion Toggle": "Subregión de Palanca",
+    "Show and hide subregion areas on the map": "Mostrar y ocultar áreas subregión en el mapa"
+}

--- a/src/GeositeFramework/plugins/zoom_to/locales/es.json
+++ b/src/GeositeFramework/plugins/zoom_to/locales/es.json
@@ -1,0 +1,6 @@
+{
+    "Zoom To": "Zoom para",
+    "Zoom to a specific address.": "Enfocar a una dirección específica.",
+    "There was an error completing your request.": "Hubo un error de completar su solicitud.",
+    "Search by Address": "Buscar por dirección"
+}


### PR DESCRIPTION
* Adds sample Spanish language files for the full_extent, zoom_to, and subregion_toggle
plugins.

**Testing**
- Set the language of the region to `es` and verify that the plugins are translated.

![image](https://cloud.githubusercontent.com/assets/1042475/14833201/110a0bec-0bcc-11e6-8a3e-a19df618de14.png)

![image](https://cloud.githubusercontent.com/assets/1042475/14833206/17cb4d2e-0bcc-11e6-804c-4def2fdc4387.png)

![image](https://cloud.githubusercontent.com/assets/1042475/14833330/b4f5293a-0bcc-11e6-917b-dae537b030b6.png)


Connects to #637