### PR TITLE
Translate `Next` for infographics

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -672,8 +672,8 @@ require(['use!Geosite',
 		var snippit = $('<img class="graphic" />').attr('src', pluginObject.infoGraphic);
 	       } else {
 		var snippit = $(pluginObject.infoGraphic);
-	       }				
-				
+	       }
+
                 this.$el.append(snippit);
 
                 var checkboxnode = $('<span>').get(0);
@@ -701,7 +701,7 @@ require(['use!Geosite',
 
                 $('<a>')
                     .text('Next')
-                    .attr('data-i18n', 'Continue')
+                    .attr('data-i18n', 'Next')
                     .attr('style', 'background:#F5EB75;color:#000')
                     .addClass('button radius i18n')
                     .click(function() {

--- a/src/GeositeFramework/locales/en.json
+++ b/src/GeositeFramework/locales/en.json
@@ -53,5 +53,6 @@
     "No information is available for this location": "No information is available for this location",
     "Permalink:": "Permalink:",
     "Don't show this on start": "Don't show this on start",
-    "Continue": "Continue"
+    "Continue": "Continue",
+    "Next": "Next"
 }

--- a/src/GeositeFramework/locales/es.json
+++ b/src/GeositeFramework/locales/es.json
@@ -53,5 +53,6 @@
     "No information is available for this location": "No hay información disponible para esta ubicación",
     "Permalink:": "Enlace Permanente:",
     "Don't show this on start": "No mostrar esto al iniciar",
-    "Continue": "Continuar"
+    "Continue": "Continuar",
+    "Next": "Siguiente"
 }


### PR DESCRIPTION
"Next" replaced "Continue" and needs to be translated.

Test that infographics on `es` are translated.

![screenshot from 2016-05-13 17 49 00](https://cloud.githubusercontent.com/assets/1014341/15262936/a38530c2-1933-11e6-8de7-68297844ebc0.png)
![screenshot from 2016-05-13 17 47 44](https://cloud.githubusercontent.com/assets/1014341/15262937/a3949864-1933-11e6-8bf5-08a6cea04275.png)
