### PR TITLE
Override styles for tables in legend

### DIFF
--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -668,6 +668,16 @@ input.code-like, textarea.code-like {
         margin-bottom: 5px;
     }
 
+/* ESRI dijit content is put in the legend from some plugins */
+.esriLegendService table {
+    margin: 0;
+    border: none;
+}
+
+.esriLegendService td {
+    padding: 0;
+}
+
 .mCSB_container {
     margin-right: 0 !important;
 }


### PR DESCRIPTION
Plugins which use the ESRI Legend Dijit internally may place table markup
in the custom legend container.  These have excessive borders and
paddings.  This commit removes those styles so that legend items appear
uniform.

Partially connects #657 

#### Testing
Testing is difficult since one cannot clone HydroFlow into a dev framework and have it work, it needs special configuration.  Easiest test is to apply the css rule provided here to developer tools on http://54.241.26.242/mississippi-dev/ and ensure the legend styling is enhanced.