### PR TITLE
Ensure layerId is always an int in getVisibleLayers

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -232,7 +232,8 @@ require(['use!Geosite',
                     service.visibleLayers.sort(function(a, b) { return a - b; });
                     _.each(service.visibleLayers, function(layerId) {
                         var layer,
-                            legend;
+                            legend,
+                            layerId = parseInt(layerId);
 
                         if (isWms(service)) {
                             layer = _getWMSLayer(service, layerId);


### PR DESCRIPTION
Convert layerId to an int when assembling visible layers. In most cases, it was already in int. In some cases, it was a string, which caused look-ups further down in the getVisibleLayers function to fail.

**Testing**
- Add the [restoration explorer](https://github.com/CoastalResilienceNetwork/restoration-explorer) plugin to your local development framework installation.
- Visit the site, and activate the plugin.
- Select some of options from the plugin to add layers.
- Ensure those layers show up in the legend.
- Ensure layers added in the Regional Planning plugin still get added to the legend.
- [Risk explorer](https://github.com/CoastalResilienceNetwork/explorer) also experienced the same problem, so you may want to test that it works now too.

![image](https://cloud.githubusercontent.com/assets/1042475/17252975/c4491050-557c-11e6-950a-8cadbac7fc46.png)

Connects to #661 
