### PR TITLE
Redraw legend upon map resize

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -301,6 +301,8 @@ require(['use!Geosite',
         dojo.connect(esriMap, 'onLayerAdd', redraw);
         dojo.connect(esriMap, 'onLayerRemove', redraw);
         dojo.connect(esriMap, 'onLayerSuspend', redraw);
+        // Allow plugins to trigger a legend redraw by calling map.resize()
+        dojo.connect(esriMap, 'resize', redraw);
     }
 
     N.views = N.views || {};


### PR DESCRIPTION
Allow plugins to redraw the legend by calling `map.resize()`.

This is a workaround for the fact that adding custom legend HTML does
not trigger any events we listen to for redrawing the legend.

If custom legend HTML is created while the legend is minimized, it will
stay minimized.

I decided that it would be easier for plugins to trigger an event on the
`map` instance (that each plugin already has access to) instead of
updating the API to pass in the current `Legend` instance.

This was previously not an issue because the legend container remained
open at all times, even when it was empty. Plugins that rely on this old
legend behavior, and use custom legend content, will need to be updated
to call `map.resize()` each time custom legend content is updated.

**Testing**

1. Clone and checkout https://github.com/CoastalResilienceNetwork/filterSelect/pull/1 into your `plugins` folder
2. Load the `filterSelect` plugin
3. Select a project type

    ![image](https://cloud.githubusercontent.com/assets/43062/18145029/743f6cb4-6f97-11e6-9a37-749ddc2294b1.png)
4. Verify that the custom legend appears (without needing to pan/zoom the map)

Connects #665