### PR TITLE
Allow features to be identified based on Geometry

### DIFF
--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -142,6 +142,7 @@ define(["dojo/_base/declare",
                         identifyParams.height = map.height;
                         identifyParams.geometry = mapPoint;
                         identifyParams.mapExtent = map.extent;
+                        identifyParams.returnGeometry = true;
 
                         var identifyTask = new dIdentifyTask(service.url),
                             deferred = identifyTask.execute(identifyParams);
@@ -337,7 +338,10 @@ define(["dojo/_base/declare",
                     return identifiedFeatures;
                 }
 
-                function isThinFeature(feature) { return _.contains(['Point', 'Line', 'Polyline'], feature.attributes.Shape); }
+                function isThinFeature(feature) {
+                    return _.contains(['point', 'line', 'polyline'], feature.geometry.type);
+                }
+
                 function isAreaFeature(feature) { return !isThinFeature(feature); }
             }
 


### PR DESCRIPTION
#### Overview
To account for small and large feature types (polygon vs else), two
identify requests are made at different tolerances.  For lines, the code
assumed there is a `Shape` attribute to make the decision about which
group of feature a particular result belonged to.  This was only the case
for geodatabase types that include that attribute automatically, and in
some cases it didn't exist. By including the geometry type in the returned
results, this check can be made consistent.

Connects #662 

#### Testing
* Make sure you `region.json` has the setting `"identifyEnabled": true`
* Clone the "map-tree" plugin into your `/js/plugins` directory as `layer_selector`
* Overwrite the `layers.json` file with the one located here: http://maps.naturalresourcenavigator.org/plugins/layer_selector/layers.json
* Add any layer from the `Streams` folder and click on one to identify (layer is present in upstate NY). You should get results where on `develop` you will not (even though the network request will show one identify request returning results).

![screenshot from 2016-09-15 11 44 57](https://cloud.githubusercontent.com/assets/1014341/18556600/d81a9a94-7b39-11e6-8aad-c884ce8669a5.png)
