### PR TITLE
Show infographic on start

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -236,8 +236,7 @@ require(['use!Geosite',
                 if (typeof localStorage[showValueKey] !== 'undefined') {
                     return localStorage[showValueKey] === 'true';
                 } else {
-					localStorage.setItem(showValueKey,pluginObject.showInfographicOnStart);
-					return localStorage[showValueKey] === 'true';
+					return pluginObject.showInfographicOnStart;
 				}
             },
 

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -1,4 +1,4 @@
-﻿/*jslint nomen:true, devel:true */
+/*jslint nomen:true, devel:true */
 /*global Backbone, _, $ */
 
 // A plugin wraps around a plugin object and manages it in backbone
@@ -235,8 +235,10 @@ require(['use!Geosite',
                     showValueKey = pluginObject.toolbarName + " showinfographic";
                 if (typeof localStorage[showValueKey] !== 'undefined') {
                     return localStorage[showValueKey] === 'true';
-                }
-                return true;
+                } else {
+					localStorage.setItem(showValueKey,pluginObject.showInfographicOnStart);
+					return localStorage[showValueKey] === 'true';
+				}
             },
 
             setShowHelpOnStartup: function(val) {

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -29,6 +29,7 @@ define(["dojo/_base/declare",
             toolbarType: "sidebar",
             showServiceLayersInLegend: true,
             allowIdentifyWhenActive: false,
+            showInfographicOnStart: false,
             // Allow the framework to put a custom print button for this plugin
             hasCustomPrint: false,
 


### PR DESCRIPTION
This pull request adds code and a default parameter to Plugin Framework that will change the default so that plugins do no show their infographic by default unless the user clicks the help "?" button.  Per Zachs requests this request also allows the plugin developer to override this behavior by setting showInfographicOnStart: true in the plugin code.