### PR TITLE
Configure installation dropdown menu

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -48,6 +48,17 @@
                 "additionalProperties": false
             }
         },
+        "regionLinks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "text": {"type": "string", "required": true},
+                    "url": {"type": "string", "required": true},
+                },
+                "additionalProperties": false
+            }
+        },
         "sidebarLinks": {
             "type": "array",
             "items": {

--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -53,6 +53,7 @@ namespace GeositeFramework.Models
         public Link TitleMain { get; private set; }
         public Link TitleDetail { get; private set; }
         public List<Link> HeaderLinks { get; private set; }
+        public List<Link> RegionLinks { get; private set; }
         public string RegionDataJson { get; private set; }
         public List<string> PluginFolderNames { get; private set; }
         public string PluginModuleIdentifiers { get; private set; }
@@ -152,6 +153,12 @@ namespace GeositeFramework.Models
             if (jsonObj["headerLinks"] != null)
             {
                 HeaderLinks = jsonObj["headerLinks"]
+                    .Select(ExtractLinkFromJson).ToList();
+            }
+
+            if (jsonObj["regionLinks"] != null)
+            {
+                RegionLinks = jsonObj["regionLinks"]
                     .Select(ExtractLinkFromJson).ToList();
             }
 

--- a/src/GeositeFramework/Tests/GeositeTests.cs
+++ b/src/GeositeFramework/Tests/GeositeTests.cs
@@ -70,6 +70,9 @@ namespace GeositeFramework.Tests
             Expect(geosite.HeaderLinks.Count, EqualTo(2));
             Expect(geosite.HeaderLinks[0].Url, EqualTo("http://www.azavea.com/"));
             Expect(geosite.HeaderLinks[1].Text, EqualTo("GIS"));
+            Expect(geosite.RegionLinks.Count, EqualTo(11));
+            Expect(geosite.RegionLinks[10].Text, EqualTo("Washington"));
+            Expect(geosite.RegionLinks[3].Url, EqualTo("http://maps.coastalresilience.org/gsvg/"));
             Expect(geosite.PluginModuleIdentifiers, EqualTo("'layer_selector/main', 'measure/main', 'nearshore_waves/main', 'explode/main'"));
             Expect(geosite.PluginVariableNames, EqualTo("p0, p1, p2, p3"));
             Expect(geosite.PluginCssUrls, Contains("main.css"));

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -57,6 +57,15 @@
     }
 
 }
+
+@helper RenderRegionLinks(IList<Geosite.Link> links) {
+    foreach (var link in links) {
+        <li id="@link.ElementId">
+            <a target="_blank" href="@link.Url">@link.Text</a>
+        </li>
+    }
+}
+
 <!DOCTYPE html>
 <!--[if IE 8]>          <html class="no-js lt-ie9" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!-->  <html class="no-js" lang="en"> <!--<![endif]-->
@@ -543,23 +552,14 @@
         </div>
         <div class="dropdown header-dropdown nav-locations">
             <button class="button dropdown-toggle nav-main-button" type="button" id="installation-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <span class="nav-locations-content">
-                    New York City<i class="dropdown-icon icon-angle-down"></i>
-                </span>
+                <div class="nav-locations-content">
+                    @OptionalLinkText(@Model.TitleDetail)
+                    <i class="dropdown-icon icon-angle-down"></i>
+                </div>
             </button>
 
             <ul class="dropdown-menu" aria-labelledby="installation-menu">
-                <li><a href="#">California</a></li>
-                <li><a href="#">Connecticut</a></li>
-                <li><a href="#">Gulf of Mexico</a></li>
-                <li><a href="#">Grenada, St. Vincent &amp; the Grenadines</a></li>
-                <li><a href="#">MesoAmerican Reef</a></li>
-                <li><a href="#">New York</a></li>
-                <li><a href="#">New Jersey</a></li>
-                <li><a href="#">Southeast Florida</a></li>
-                <li><a href="#">United States</a></li>
-                <li><a href="#">U.S. Virgin Islands</a></li>
-                <li><a href="#">Washington</a></li>
+                @RenderRegionLinks(Model.RegionLinks)
             </ul>
         </div>
     </header>

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -17,10 +17,23 @@
                 { "text": "Fish", "url": "https://en.wikipedia.org/wiki/Fish" },
                 { "text": "Tour Again", "url": "javascript:;", "elementId": "help-overlay-start"}
             ]
-        },
+       },
         { "text": "Azavea", "url": "http://www.azavea.com/" },
         { "text": "GIS", "popup": true, "url": "http://en.wikipedia.org/wiki/Geographic_information_system" },
         { "text": "Tour", "url": "javascript:;", "elementId": "help-overlay-start"},
+    ],
+    "regionLinks": [
+        { "text": "California", "url": "http://maps.coastalresilience.org/california/" },
+        { "text": "Connecticut", "url": "http://maps.coastalresilience.org/connecticut" },
+        { "text": "Global", "url": "http://maps.coastalresilience.org/global/" },
+        { "text": "Grenada, St. Vincent & the Grenadines", "url": "http://maps.coastalresilience.org/gsvg/" },
+        { "text": "MesoAmerican Reef", "url": "http://maps.coastalresilience.org/mar/" },
+        { "text": "New York", "url": "http://maps.coastalresilience.org/newyork" },
+        { "text": "New Jersey", "url": "http://maps.coastalresilience.org/newjersey" },
+        { "text": "Southeast Florida", "url": "http://maps.coastalresilience.org/seflorida/" },
+        { "text": "United States", "url": "http://maps.coastalresilience.org/unitedstates/" },
+        { "text": "U.S. Virgin Islands", "url": "http://maps.coastalresilience.org/usvi/" },
+        { "text": "Washington", "url": "http://maps.coastalresilience.org/pugetsound" }
     ],
     "initialExtent": [
         -98.61328125,


### PR DESCRIPTION
This PR sets up the region installation dropdown menu to configure dynamically from the links nested beneath `region.json`'s `"GO TO"` item, which is how those links seem to be initially configured in the regional sites:

![screen shot 2016-10-18 at 11 45 08 am](https://cloud.githubusercontent.com/assets/4165523/19486987/a08cdaa6-952e-11e6-85e4-8647e24c03e7.png)
 
& ->

![screen shot 2016-10-18 at 11 45 25 am](https://cloud.githubusercontent.com/assets/4165523/19486990/a67a92e6-952e-11e6-8ef5-6d5d6c629025.png)

The changes here update the parsing in `Geosite.cs` to create a `RegionLinks` component in addition to the existing `HeaderLinks` component, by filtering the objects based on whether or not they've got the name `"GO TO"`. From there, the list of `RegionLinks` gets passed through a `RenderRegionLinks` helper method which creates the links in the dropdown. 

**Testing**
- Get this branch, build the solution in Visual Studio, then view it in the web browser
- Confirm that you see the new dropdown menu with clickable links ordered in a way that matches the `region.json` file
- Confirm that the "Geosite Framework Sample" dropdown includes its own list of links and does not include any of the links under "Sample Region"

Connects #692 