### PR TITLE
Call plugin `hibernate` method on eye icon click

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -341,7 +341,7 @@
                         </button>
                     <% } %>
 
-                    <button class="button-link"><i class="icon-eye"></i></button>
+                    <button class="button-link plugin-eye"><i class="icon-eye"></i></button>
                 </div>
             </div>
             <div class="sidebar-content">

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -8,7 +8,6 @@ require(['use!Geosite',
          'esri/layers/ArcGISDynamicMapServiceLayer',
          'framework/Logger',
          'dojo/dom-style',
-         'framework/widgets/ConstrainedMoveable',
          'dojox/layout/ResizeHandle',
          'dijit/form/CheckBox',
          'dijit/form/Button'
@@ -18,7 +17,6 @@ require(['use!Geosite',
              ArcGISDynamicMapServiceLayer,
              Logger,
              domStyle,
-             ConstrainedMoveable,
              ResizeHandle,
              CheckBox,
              Button) {
@@ -469,11 +467,6 @@ require(['use!Geosite',
             view.$el.parents().find('.content .nav-apps').after($uiContainer);
 
             setResizable(view, pluginObject.resizable);
-
-            new ConstrainedMoveable($uiContainer[0], {
-                handle: $uiContainer.find('.sidebar-nav')[0],
-                within: true
-            });
 
             // Tell the model about $uiContainer so it can pass it to the plugin object
             model.set('$uiContainer', $uiContainer);

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -163,6 +163,10 @@ require(['use!Geosite',
                 }
             },
 
+            hibernate: function () {
+                this.get('pluginObject').hibernate();
+            },
+
             turnOff: function (callback) {
                 var self = this,
                     initiallySelected = this.selected,
@@ -401,6 +405,10 @@ require(['use!Geosite',
             view.$uiContainer = $uiContainer;
 
             $uiContainer
+                // Call `hibernate` method on plugin when the eye icon is clicked
+                .find('.plugin-eye').on('click', function () {
+                    model.hibernate();
+                }).end()
                 // Listen for events to turn the plugin completely off
                 .find('.plugin-off').on('click', function () {
                     model.turnOff();


### PR DESCRIPTION
This PR wires up the eye-icon button in the plugin navbar so that it will call the plugin's `hibernate` method. I've tested it against the master branch of `regional-planning`, and it calling that method will clear the layers the plugin has added while keeping the plugin's sidebar open.

The second commit here removes some drag-to-move functionality which was added to the sidebar in the prior interface for the app. In the `prototype` branch, that feature had the effect of banishing the sidebar out of the viewport altogether, and it would interfere with clicking the navbar header buttons in the case that a click on one of the icons happened in tandem with some motion of the mouse or touchpad.

**Testing**
- get this branch, install the `regional-planning` plugin, then build the app in Visual Studio and view it in Chrome
- click the regional planning plugin to bring up the sidebar
- add some of the Alabama layers to see them highlighted in the plugin, the legend, and on the map (other layers will work, too, but those are directly in the viewport)
- click the eye icon to clear all the layers, and verify that they're removed from the map, the legend, and the layer selector
- repeat a few times to verify that it doesn't end up in a non-working state
- try to drag the header to move the sidebar and verify that it won't move
- try dragging the legend to confirm that it's still movable 

Connects #694 