### PR TITLE
Toggle plugin layers on eye-icon button click

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -341,7 +341,7 @@
                         </button>
                     <% } %>
 
-                    <button class="button-link"><i class="icon-eye"></i></button>
+                    <button class="button-link plugin-eye"><i class="icon-eye"></i></button>
                 </div>
             </div>
             <div class="sidebar-content">

--- a/src/GeositeFramework/css/app.css
+++ b/src/GeositeFramework/css/app.css
@@ -250,8 +250,6 @@ input.code-like, textarea.code-like {
     margin-top: 4px;
 }
 
-
-
 /* -----------------------------------------
    Content Area - Map
 ----------------------------------------- */

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -8,7 +8,6 @@ require(['use!Geosite',
          'esri/layers/ArcGISDynamicMapServiceLayer',
          'framework/Logger',
          'dojo/dom-style',
-         'framework/widgets/ConstrainedMoveable',
          'dojox/layout/ResizeHandle',
          'dijit/form/CheckBox',
          'dijit/form/Button'
@@ -18,7 +17,6 @@ require(['use!Geosite',
              ArcGISDynamicMapServiceLayer,
              Logger,
              domStyle,
-             ConstrainedMoveable,
              ResizeHandle,
              CheckBox,
              Button) {
@@ -482,11 +480,6 @@ require(['use!Geosite',
             view.$el.parents().find('.content .nav-apps').after($uiContainer);
 
             setResizable(view, pluginObject.resizable);
-
-            new ConstrainedMoveable($uiContainer[0], {
-                handle: $uiContainer.find('.sidebar-nav')[0],
-                within: true
-            });
 
             // Tell the model about $uiContainer so it can pass it to the plugin object
             model.set('$uiContainer', $uiContainer);

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -130,7 +130,9 @@ require(['use!Geosite',
             defaults: {
                 pluginObject: null,
                 active: false,
-                displayHelp: false
+                displayHelp: false,
+                pluginLayers: {},
+                pluginLayersVisible: true
             },
             initialize: function () { initialize(this); },
 
@@ -160,6 +162,21 @@ require(['use!Geosite',
                 } else {
                     this.get('pluginObject').deactivate();
                     this.trigger('plugin:deselected');
+                }
+            },
+
+            toggleLayers: function () {
+                var currentPlugin = this.get('pluginObject'),
+                    pluginLayersVisible = this.get('pluginLayersVisible');
+
+                if (pluginLayersVisible) {
+                    this.set('pluginLayers', currentPlugin.map.getMyLayers());
+                    currentPlugin.map.removeAllLayers();
+                    this.set('pluginLayersVisible', false);
+                } else {
+                    currentPlugin.map.addLayers(this.get('pluginLayers'));
+                    this.set('pluginLayers', {});
+                    this.set('pluginLayersVisible', true);
                 }
             },
 
@@ -401,6 +418,10 @@ require(['use!Geosite',
             view.$uiContainer = $uiContainer;
 
             $uiContainer
+                // Toggle plugin layers on and off when eye-icon button's clicked
+                .find('.plugin-eye').on('click', function () {
+                    model.toggleLayers();
+                }).end()
                 // Listen for events to turn the plugin completely off
                 .find('.plugin-off').on('click', function () {
                     model.turnOff();


### PR DESCRIPTION
This PR wires up the eye-icon button to show and hide a plugin's layers on clicking the eye-icon button. Per #694, the desired behavior for this button is that it toggles a plugin's layers on and off on the map and in the legend on click, but does not otherwise reset the state of the plugin. 

To handle this, I added a new `toggleLayers` method to `plugins.js`, plus some variables to store the state of the toggling and the layers to return to the map when they're toggled back on. The result currently works like this:

*After adding layers from ECA and Regional Planning plugins:*

![screen shot 2016-10-20 at 10 08 04 am](https://cloud.githubusercontent.com/assets/4165523/19563222/3cd2d0c6-96ad-11e6-8787-994af0917380.png)

*After clicking the eye-icon button in the Regional Planning plugin:*

![screen shot 2016-10-20 at 10 08 20 am](https://cloud.githubusercontent.com/assets/4165523/19563242/4e7098c2-96ad-11e6-85a7-66b5740d5f52.png)

*After clicking the Regional Planning eye-icon button again:*

![screen shot 2016-10-20 at 10 08 31 am](https://cloud.githubusercontent.com/assets/4165523/19563262/5a715ea4-96ad-11e6-8832-4f7a62145a93.png)

The second commit here removes a drag event listener from the sidebar plugins which would cause them to be banished out of the viewport if a user dragged while clicking. This functionality's no longer necessary since the sidebar plugins now occupy a fixed spot in the viewport when selected.

**Testing**
- get this branch, install the ECA and Regional Planning plugins, then build the project in Visual Studio
- view the project in Google Chrome and open the browser console
- toggle some layers on in ECA and some in Regional Planning
- click the eye-icon in Regional Planning and verify that its layers have been removed from the map and the legend but that the state of the plugin itself has not been reset and that the layers from ECA remain on the map and in the legend
- click the eye-icon button again to toggle its layers back on and confirm that they show in the map and legend
- repeat these steps with ECA
- try some additional combos of toggling on and off between plugins and verify that the app doesn't end up in a non-working state
- try to click and drag the header bar for the plugins and verify that nothing happens

Connects #694 