### PR TITLE
Add support for specifying plugin size 

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -323,7 +323,7 @@
     </script>
 
     <script type="text/template" id="template-plugin-container">
-        <div class="sidebar sidebar-width-small content-scrollable" id="<%= id %>">
+        <div class="sidebar <%= sizeClassName %> content-scrollable" id="<%= id %>" style="<%= customWidth %>">
             <div class="sidebar-nav">
                 <h2 class="nav-title" class="i18n" data-i18n="<%- title %>">
                     <%- title %>

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -936,6 +936,9 @@ nav {
 .sidebar.sidebar-width-small {
     width: 350px
 }
+.sidebar.sidebar-width-large {
+    width: 700px
+}
 .nav-apps {
     text-align: left;
     width: 240px;

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -8,7 +8,6 @@ require(['use!Geosite',
          'esri/layers/ArcGISDynamicMapServiceLayer',
          'framework/Logger',
          'dojo/dom-style',
-         'dojox/layout/ResizeHandle',
          'dijit/form/CheckBox',
          'dijit/form/Button'
         ],
@@ -17,7 +16,6 @@ require(['use!Geosite',
              ArcGISDynamicMapServiceLayer,
              Logger,
              domStyle,
-             ResizeHandle,
              CheckBox,
              Button) {
     "use strict";
@@ -479,8 +477,6 @@ require(['use!Geosite',
             // Attach to top pane element
             view.$el.parents().find('.content .nav-apps').after($uiContainer);
 
-            setResizable(view, pluginObject.resizable);
-
             // Tell the model about $uiContainer so it can pass it to the plugin object
             model.set('$uiContainer', $uiContainer);
         }
@@ -549,12 +545,6 @@ require(['use!Geosite',
             }).appendTo('head');
         }
 
-        function onContainerResize(view, resizeHandle, event) {
-            var dx = event.x - resizeHandle.startPoint.x,
-                dy = event.y - resizeHandle.startPoint.y;
-            view.model.get("pluginObject").resize(dx, dy);
-        }
-
         function createHelpScreen(view) {
             var model = view.model,
                 pluginObject = model.get('pluginObject'),
@@ -595,33 +585,8 @@ require(['use!Geosite',
                 $mainPanel.show();
             }
 
-            // Disable resizing when infographic is active
-            setResizable(this, pluginObject.resizable && !showInfoGraphic);
-
             var primaryContainerVisible = !showInfoGraphic;
             pluginObject.onContainerVisibilityChanged(primaryContainerVisible);
-        }
-
-        // Draw resize handle if resizable, destroy it if not resizable.
-        function setResizable(view, resizable) {
-            var handle = view.resizeHandle,
-                handleExists = typeof handle !== 'undefined' && handle != null,
-                containerId = getContainerId(view);
-            if (resizable && !handleExists) {
-                // Make the container resizable and moveable
-                handle = new ResizeHandle({
-                    targetId: containerId,
-                    activeResize: true,
-                    animateSizing: false
-                });
-                handle.placeAt(containerId)
-                handle.on('resize', function (e) { onContainerResize(view, this, e); });
-                view.resizeHandle = handle;
-            } else if (!resizable && handleExists) {
-                handle.destroy();
-                view.resizeHandle = null;
-            }
-            view.$uiContainer.toggleClass('resizable', resizable);
         }
 
         N.views = N.views || {};
@@ -695,7 +660,6 @@ require(['use!Geosite',
                     .addClass('button radius i18n')
                     .click(function() {
                         pluginModel.set('displayHelp', false);
-                        pluginObject.resize();
                     })
                     .appendTo(buttonnode);
 

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -407,7 +407,9 @@ require(['use!Geosite',
                     title: pluginObject.toolbarName,
                     id: containerId,
                     isHelpButtonVisible: isHelpButtonVisible(view),
-                    hasCustomPrint: pluginObject.hasCustomPrint
+                    hasCustomPrint: pluginObject.hasCustomPrint,
+                    sizeClassName: getPluginSizeClassName(pluginObject.size),
+                    customWidth: getCustomPluginWidth(pluginObject.size, pluginObject.width)
                 },
                 $uiContainer = $($.trim(N.app.templates['template-plugin-container'](bindings)));
 
@@ -556,6 +558,18 @@ require(['use!Geosite',
                 });
                 pluginContainer.append(view.helpScreen.el);
                 view.helpScreen.$el.hide();
+            }
+        }
+
+        function getPluginSizeClassName(size) {
+            return 'sidebar-width-' + size;
+        }
+
+        function getCustomPluginWidth(size, width) {
+            if (size === 'custom') {
+                return 'width: ' + width + 'px;';
+            } else {
+                return '';
             }
         }
 

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -45,9 +45,8 @@ define(["dojo/_base/declare",
             // will be called.
             closeOthersWhenActive: true,
 
-            resizable: true,
-            width: 300,
-            height: 400,
+            size: 'small', // small, large, or custom
+            width: 300, // only used if 'custom' is specified for size
             icon: "globe",
 
             initialize: function() {},


### PR DESCRIPTION
In the new design, plugins can be three sizes: small (default), large, or custom. Small and large use fixed widths, while the custom option requires that the developer specifies the width of the plugin in pixels.

Small (default):
![image](https://cloud.githubusercontent.com/assets/1042475/19566238/866348d8-96b7-11e6-81f0-8a02e4e52998.png)

Large:
![image](https://cloud.githubusercontent.com/assets/1042475/19566230/80bc04a6-96b7-11e6-8910-08c2aa46b0de.png)

Custom:
![image](https://cloud.githubusercontent.com/assets/1042475/19566246/90613eb2-96b7-11e6-89b4-73ca38e377c2.png)

**Testing**
- If you haven't already, add a few plugins to your local site.
- Override the size of some of the plugins (these settings are generally in the `main.js` file of the plugin). For some specify `large`, for others, specify `custom` and provide a `width` setting.
- Activate the plugins in the app, and verify that the sizes were applied correctly. Plugins which you did not override the size of should be small.

Connects to #696