### PR TITLE
Fix map plugin activation

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -306,7 +306,7 @@
     </script>
 
     <script type="text/template" id="template-topbar-plugin">
-            <a class="plugin-launcher i18n" data-i18n="[title]<%=fullName%>" href="javascript:;"></a>
+        <a class="plugin-launcher i18n" data-i18n="[title]<%=fullName%>" href="javascript:;"></a>
     </script>
 
     <script type="text/template" id="template-topbar-tools">

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -319,8 +319,8 @@ require(['use!Geosite',
             // into. Make your UI separate from the button that
             // launches it.
             events: {
-                'click button.plugin-launcher': 'handleLaunch',
-                'click button.plugin-clear': 'handleClear'
+                'click .plugin-launcher': 'handleLaunch',
+                'click .plugin-clear': 'handleClear'
             },
 
             initialize: function () { initialize(this); },


### PR DESCRIPTION
Use a less specific selector for plugin launcher event binding. The
sidebar plugins use button elements now, but the topbar/map plugins use
divs.

![image](https://cloud.githubusercontent.com/assets/1042475/19601867/ff1f75aa-9778-11e6-9216-01feea7ab3c6.png)

**Testing**
- Try activating all of the map plugins. They should now work.
- Try activating some sidebar plugins. They should still work.

Connects to #700