### PR TITLE
Implement custom colors in new design

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -107,7 +107,7 @@
             }
         },
         "basemaps": {
-            "type": "array", 
+            "type": "array",
             "required": true,
             "minItems": 1,
             "items": {

--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -154,7 +154,8 @@
             "type": "object",
             "properties": {
                 "primary": {"type": "string", "required": true},
-                "secondary": {"type": "string", "required": true}
+                "secondary": {"type": "string", "required": true},
+                "tertiary": {"type": "string", "required": true}
             },
             "required": false,
             "additionalProperties": false

--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -16,8 +16,9 @@ namespace GeositeFramework.Models
     {
         // For backwards compatibility with V1 region.json files,
         // provide defaults for the customized colors
-        private readonly Color _defaultPrimary = ColorTranslator.FromHtml("#26648E");
-        private readonly Color _defaultSecondary = ColorTranslator.FromHtml("#26648E");
+        private readonly Color _defaultPrimary = ColorTranslator.FromHtml("#0f1c27");
+        private readonly Color _defaultSecondary = ColorTranslator.FromHtml("#3bb3be");
+        private readonly Color _defaultTertiary = ColorTranslator.FromHtml("#27343e");
 
         public class Link
         {
@@ -62,6 +63,7 @@ namespace GeositeFramework.Models
         public string ConfigurationForUseJs { get; private set; }
         public String PrimaryColor { get; private set; }
         public String SecondaryColor { get; private set; }
+        public String TertiaryColor { get; private set; }
 
         /// <summary>
         /// Create a Geosite object by loading the "region.json" file and enumerating plug-ins, using the specified paths.
@@ -137,11 +139,13 @@ namespace GeositeFramework.Models
             {
                 PrimaryColor = ExtractColorFromJson(colorConfig, "primary");
                 SecondaryColor = ExtractColorFromJson(colorConfig, "secondary");
+                TertiaryColor = ExtractColorFromJson(colorConfig, "tertiary");
             }
             else
             {
                 PrimaryColor = ColorTranslator.ToHtml(_defaultPrimary);
                 SecondaryColor = ColorTranslator.ToHtml(_defaultSecondary);
+                TertiaryColor = ColorTranslator.ToHtml(_defaultTertiary);
             }
 
 

--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -14,7 +14,7 @@ namespace GeositeFramework.Models
     /// </summary>
     public class Geosite
     {
-        // For backwards compatibility with V1 region.json files, 
+        // For backwards compatibility with V1 region.json files,
         // provide defaults for the customized colors
         private readonly Color _defaultPrimary = ColorTranslator.FromHtml("#26648E");
         private readonly Color _defaultSecondary = ColorTranslator.FromHtml("#26648E");
@@ -103,7 +103,7 @@ namespace GeositeFramework.Models
         }
 
         /// <summary>
-        /// Make a Geosite object given the specified configuration info. 
+        /// Make a Geosite object given the specified configuration info.
         /// Note this is public only for testing purposes.
         /// </summary>
         /// <param name="jsonDataRegion">JSON configuration data (e.g. from a "region.json" configuration file)</param>
@@ -190,8 +190,8 @@ namespace GeositeFramework.Models
         {
             try
             {
-                // Run the values through the type system to provide meaningful 
-                // errors to syntax problems, since these values are essentially 
+                // Run the values through the type system to provide meaningful
+                // errors to syntax problems, since these values are essentially
                 // getting tossed into the web page as code
                 var color =  ColorTranslator.FromHtml(json[key].ToString());
                 return ColorTranslator.ToHtml(color);

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -100,12 +100,47 @@
 
     <!-- Simple implementation style overrides from config -->
     <style type="text/css">
-        .top-bar {
+        header {
             background: @Model.PrimaryColor;
         }
 
-        .top-bar ul > li.name h1 a {
+        .nav-apps {
+            background-color: @Model.TertiaryColor;
+        }
+
+        .color-primary,
+        .button,
+        .alert-primary {
             color: @Model.SecondaryColor;
+        }
+
+        .background-primary,
+        .button-primary,
+        .nav-apps-button.active,
+        .header-dropdown .dropdown-menu,
+        .dropdown-menu>.active>a:hover,
+        .loading.loading-pulse.loading-primary,
+        .loading.loading-blink.loading-primary>div,
+        .alert-primary {
+            background-color: @Model.SecondaryColor;
+        }
+
+        .button:focus,
+        .button-primary:focus,
+        .button-secondary:focus,
+        .button-danger:focus,
+        .button-warning:focus {
+            box-shadow: 0 1px 2px -1px @Model.SecondaryColor;
+        }
+
+        .header-dropdown .dropdown-menu:after {
+            border-bottom: 7px solid @Model.SecondaryColor;
+        }
+
+        .loading.loading-spinner.loading-primary {
+            border-left: 1.1em solid @Model.SecondaryColor;
+            border-bottom: 1.1em solid @Model.SecondaryColor;
+            border-right: 1.1em solid @Model.SecondaryColor;
         }
 
         /* Use custom colors for overlay */
@@ -132,12 +167,6 @@
         body .tlypageguide_shadow:after {
             background-color: @Model.SecondaryColor;
             opacity: 0.2;
-        }
-
-        /* Site color for header dropdown menu selection */
-        .top-bar .dropdown .dropdown-menu LI > A:hover,
-        .top-bar .dropdown .dropdown-menu LABEL:hover {
-            background-color: @Model.SecondaryColor;
         }
     </style>
 

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -103,8 +103,9 @@
         "customPrintTemplatePrefix": "Letter ANSI A GeositeFramework"
     },
     "colors": {
-        "primary": "#26648E",
-        "secondary": "#26648E"
+        "primary": "#29658C",
+        "secondary": "#3BBDC2",
+        "tertiary": "#333"
     },
     "identifyBlacklist": ["OBJECTID", "OBJECTID_1"],
     "identifyEnabled": true,


### PR DESCRIPTION
The CSS rules in the index document that use the custom colors were
updated with selectors that are used in the new design.

Also, a third color was added to the region config. This color is used
to configure the color of the sidebar.

The default colors were updated to match the new design.

Current theme:
![image](https://cloud.githubusercontent.com/assets/1042475/19664234/83c197ca-9a0d-11e6-815d-91e736897677.png)

For demonstration purposes:
![image](https://cloud.githubusercontent.com/assets/1042475/19664242/8b21ee3e-9a0d-11e6-858a-eb5b4d231175.png)

**Testing**
- Modify the colors in `region.json` and verify the app theme is updated accordingly.

**Note**
- The links in the title bar are currently being colored by Foundation, which will be removed in #691.
- Some color choices will result in a color scheme that doesn't work well.

Connects to #695 