### PR TITLE
Always show framework region name

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -554,20 +554,22 @@
                 @RenderLinks(Model.HeaderLinks)
             </ul>
         </div>
-        @if(Model.RegionLinks != null) {
         <div class="dropdown header-dropdown nav-locations">
             <button class="button dropdown-toggle nav-main-button" type="button" id="installation-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <div class="nav-locations-content">
                     @Model.TitleDetail.Text
-                    <i class="dropdown-icon icon-angle-down"></i>
+                    @if(Model.RegionLinks != null) {
+                        <i class="dropdown-icon icon-angle-down"></i>
+                    }
                 </div>
             </button>
 
-            <ul class="dropdown-menu" aria-labelledby="installation-menu">
-                @RenderRegionLinks(Model.RegionLinks)
-            </ul>
+            @if(Model.RegionLinks != null) {
+                <ul class="dropdown-menu" aria-labelledby="installation-menu">
+                    @RenderRegionLinks(Model.RegionLinks)
+                </ul>
+            }
         </div>
-        }
         <div id="search"></div>
     </header>
 


### PR DESCRIPTION
In the event that no region links have been added to the site's region.json file, still show the region name, but don't render the region link list.

![image](https://cloud.githubusercontent.com/assets/1042475/19740005/0ab4355c-9b8b-11e6-9f1d-41d2e687a6df.png)
*No region links provided*

**Testing**
- Load the app. Verify the region menu is present.
- Edit `region.json`, and remove the `regionLink` section.
- Kill and restart the VS debug server.
- Reload the app. The region name should still be there ("Sample Region"), but the dropdown menu, including the arrow that indicates there is a menu, should be gone.

Connects to #717