### PR TITLE
Replace the hide layers button with the close button

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -343,7 +343,7 @@
                         </button>
                     <% } %>
 
-                    <button class="button-link plugin-eye"><i class="icon-eye"></i></button>
+                    <button class="button-link plugin-off"><i class="icon-cancel"></i></button>
                 </div>
             </div>
             <div class="sidebar-content">

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -343,7 +343,7 @@
                         </button>
                     <% } %>
 
-                    <button class="button-link plugin-off"><i class="icon-cancel"></i></button>
+                    <button class="button-link plugin-off i18n" data-i18n="[title]Turn off this plugin" title="Turn off this plugin"><i class="icon-cancel"></i></button>
                 </div>
             </div>
             <div class="sidebar-content">

--- a/src/GeositeFramework/locales/en.json
+++ b/src/GeositeFramework/locales/en.json
@@ -56,5 +56,6 @@
     "Don't show this on start": "Don't show this on start",
     "Continue": "Continue",
     "Get Started": "Get Started",
-    "Measure": "Measure"
+    "Measure": "Measure",
+    "Turn off this plugin": "Turn off this plugin"
 }

--- a/src/GeositeFramework/locales/es.json
+++ b/src/GeositeFramework/locales/es.json
@@ -56,5 +56,6 @@
     "Don't show this on start": "No mostrar esto al iniciar",
     "Continue": "Continuar",
     "Next": "Siguiente",
-    "Measure": "Mediciones"
+    "Measure": "Mediciones",
+    "Turn off this plugin": "Desactivar este plugin"
 }


### PR DESCRIPTION
After further consideration, we thought it made more sense to bring back
the plugin close button instead of having a button that would hide active
plugin layers. I left the layer hiding code in case we need it later.

![image](https://cloud.githubusercontent.com/assets/1042475/19741857/6bf52ff6-9b90-11e6-8ea7-76543fe3fbb4.png)

**Testing**
- Launch the app and open the Regional Planning plugin.
- Expand some of the layer trees and turn on some layers.
- Click the plugin close button.
- Verify that the layers are removed.
- Open the Regional Planning plugin again. It should be back to the initial state.

Connects to #718