### PR TITLE
Add `underscore` import for use in map-utils

### DIFF
--- a/src/GeositeFramework/plugins/map_utils/main.js
+++ b/src/GeositeFramework/plugins/map_utils/main.js
@@ -4,6 +4,11 @@
             name: 'jquery',
             location: '//ajax.googleapis.com/ajax/libs/jquery/1.9.0',
             main: 'jquery.min'
+        },
+        {
+            name: 'underscore',
+            location: '//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3',
+            main: 'underscore-min'
         }
     ]
 });

--- a/src/GeositeFramework/plugins/map_utils/plugin.json
+++ b/src/GeositeFramework/plugins/map_utils/plugin.json
@@ -2,5 +2,8 @@
     "css": [
         "plugins/map_utils/style.css",
         "plugins/map_utils/measure/style.css"
-    ]
+    ],
+    "use": {
+        "underscore": { "attach": "_" }
+    }
 }


### PR DESCRIPTION
This PR fixes a bug whereby `underscore` wasn't available in the measure plugin. The changes here add `underscore` to the `main.js` file for the map-utils plugins, and call `use` on the import to make it available.

**Testing**
- get this branch and launch it without any additional plugins installed
- build the project in Visual Studio
- view the site in the web browser and verify that it loads as it should and that you don't see the 

```
Uncaught TypeError: Module 'underscore' is undefined or does not have a 'use' config. ...
```

error in the console.
- verify that the rest of the app works as it should