### PR TITLE
Add map print area

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -142,6 +142,10 @@
                 "customPrintTemplatePrefix": {
                     "type": "string",
                     "required": false
+                },
+                "headerLogoPath": {
+                    "type": "string",
+                    "required": false
                 }
             },
             "additionalProperties": false

--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -64,6 +64,7 @@ namespace GeositeFramework.Models
         public String PrimaryColor { get; private set; }
         public String SecondaryColor { get; private set; }
         public String TertiaryColor { get; private set; }
+        public String PrintHeaderLogo { get; private set; }
 
         /// <summary>
         /// Create a Geosite object by loading the "region.json" file and enumerating plug-ins, using the specified paths.
@@ -148,6 +149,10 @@ namespace GeositeFramework.Models
                 TertiaryColor = ColorTranslator.ToHtml(_defaultTertiary);
             }
 
+            var printConfig = jsonObj["print"];
+            if (printConfig != null) {
+                PrintHeaderLogo = (string)printConfig["headerLogoPath"];
+            }
 
             if (jsonObj["googleAnalyticsPropertyId"] != null)
             {

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -88,10 +88,10 @@
     <link rel="stylesheet" href="//js.arcgis.com/3.10/js/dojo/dojox/layout/resources/ResizeHandle.css">
     <link rel="stylesheet" href="//js.arcgis.com/o/232546/geosite-v1.0.9/esri/css/esri.css">
 
+    <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="css/print.css">
     <link rel="stylesheet" href="css/TinyBox2.css">
     <link rel="stylesheet" href="css/pageguide.min.css"/>
-    <link rel="stylesheet" href="css/main.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto:500,900" rel="stylesheet">
 
@@ -415,7 +415,7 @@
     <script type="text/template" id="template-export-window">
         <div class="popover">
             <div class="popover-header">
-                <h2><span class="i18n" data-i18n="Map">Map</span> <span class="export-pane-number"></span> <span class="i18n" data-i18n="Export">Export</span></h2>
+                <h2><span class="i18n" data-i18n="Map Export">Map Export</span></h2>
             </div>
             <div class="popover-content">
                 <div class="row">
@@ -429,16 +429,13 @@
                          <h5 class="i18n" data-i18n="Legend">Legend</h5>
                         <label><input type="checkbox" name="export-include-legend" /><span class="i18n" data-i18n="Include Layer Legend">Include Layer Legend</span></label>
                     </div>
-                    <div class="small-4 columns">
-                        <div class="export-indicator"><img class="icon" src="img/spinner.gif" /></div>
-                    </div>
                 </div>
                 <div class="row">
                     <div class="left-col">
                         <div class="export-output-area"></div>
                     </div>
                     <div class="right-col">
-                        <a href="#" id="export-button" class="button radius i18n" data-i18n="Generate Map Export" disabled="disabled">Generate Map Export</a>
+                        <a href="#" id="export-button" class="button radius i18n" data-i18n="Generate Map Export">Generate Map Export</a>
                     </div>
                 </div>
             </div>
@@ -607,6 +604,15 @@
     <!-- Area for plugins to arrange their markup independent
         of their container -->
     <div id="plugin-print-sandbox"></div>
+
+    <!-- Area for the main map to get setup for printing. -->
+    <div id="map-print-sandbox">
+        <div class="print-sandbox-header">
+            <img src="@Model.PrintHeaderLogo" title="Header Logo" class="logo" />
+            <h1></h1>
+        </div>
+        <div id="print-map-container">Map goes here</div>
+    </div>
 
     <!-- LEFT CONTENT AREA -->
     <div id="left-pane" class="flex-container content"></div>

--- a/src/GeositeFramework/css/app-print.css
+++ b/src/GeositeFramework/css/app-print.css
@@ -1,0 +1,5 @@
+﻿@media print {
+    #map-print-sandbox {
+        visibility: visible;
+    }
+}

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -2317,6 +2317,27 @@ a.active {
     position: absolute;
     visibility: hidden;
 }
+#map-print-sandbox {
+    position: absolute;
+    visibility: hidden;
+    width: 100%;
+}
+#map-print-sandbox .print-sandbox-header {
+    background-color: #ccc;
+    border: 1px solid #ccc;
+    padding: 5px;
+}
+#map-print-sandbox h1 {
+    display: inline;
+}
+#map-print-sandbox img.logo {
+    height: 80px;
+}
+#print-map-container {
+    border: 1px solid #ccc;
+    padding: 5px;
+    height: 850px;
+}
 .print-preview-container {
     padding: 10px;
 }

--- a/src/GeositeFramework/css/print.css
+++ b/src/GeositeFramework/css/print.css
@@ -33,7 +33,7 @@
         visibility: visible;
     }
 
-    #plugin-print-preview-map_container img { 
+    #plugin-print-preview-map_container img {
         visibility: visible;
     }
 }

--- a/src/GeositeFramework/css/print.css
+++ b/src/GeositeFramework/css/print.css
@@ -12,7 +12,7 @@
     /* An issue in Chrome for Windows would display the borders of this
        element in print media, despite it being selected by the clause above.*/
     .plugin-launcher {
-        display: none; 
+        display: none;
     }
 
     /* Override the map tiles which have inline styles.

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -1,18 +1,8 @@
-// on view submit button click, set exportMap to be the current map
-
 require(['use!Geosite',
-         'esri/tasks/PrintTask',
-         'esri/tasks/PrintParameters',
-         'esri/tasks/PrintTemplate',
-         'esri/tasks/LegendLayer',
          'dojo/Deferred',
          'dojo/request',
          'framework/Logger'],
     function(N,
-             PrintTask,
-             PrintParameters,
-             PrintTemplate,
-             LegendLayer,
              Deferred,
              request,
              Logger) {
@@ -23,217 +13,22 @@ require(['use!Geosite',
     ////////////////////////////////
 
     N.models.ExportTool = Backbone.Model.extend({
-
         defaults: {
             // set by view, listened internally
             exportTitle: "",
             exportOrientation: null,
-            // Default ArcGIS print template is Letter ANSI A {Portrait|Landscape}
-            // but the framework provides custom templates that can be installed on
-            // the AGS to achieve better export results.  Check the region.json to
-            // enable the custom template.
-            printLayoutTemplatePrefix: 'Letter ANSI A',
-            // By default, the ESRI print task reserves space in the
-            // template for the legend, which doesn't resize.  To reclaim
-            // the space we use a different template for Legend/No Legend
-            // but this won't work if you are not using a custom layout
-            useDifferentTemplateWithLegend: false,
             exportIncludeLegend: false,
-            // set internally, listened by view
-            submitEnabled: true,
-            outputText: "",
-            // Pane number of map to export
-            paneNumber: 0
-        },
-
-        initialize: function () {
-            var model = this;
-            model.setupDependencies();
+            outputText: ""
         },
 
         submitExport: function() {
-            if (this.submissionIsValid()) {
-                this.set('submitEnabled', false);
-                this.createPDF();
-            } else {
+            if (!this.submissionIsValid()) {
                 this.set('outputText', i18next.t("Please enter all required fields."));
             }
         },
 
         submissionIsValid: function () {
             return _.contains(["Portrait", "Landscape"], this.get('exportOrientation'));
-        },
-
-        setupDependencies: function () {
-            /*
-              Creates an interface for the rest of the model to interact
-              with the esri javascript api, only if an export setting has
-              been specified in the region.json
-            */
-            var model = this,
-                url = N.app.data.region.print.printServerUrl;
-
-            // If there is a custom template scheme for export, override the
-            // default settings.  If no custom template is provided, the export
-            // will work with the out-of-the-box ArcGIS Print Task settings
-            if (N.app.data.region.print.customPrintTemplatePrefix) {
-                this.set('printLayoutTemplatePrefix',
-                    N.app.data.region.print.customPrintTemplatePrefix);
-                this.set('useDifferentTemplateWithLegend', true);
-            }
-
-            model.set('submitEnabled', false);
-            model.fetchServiceConfig(url).then(function(config) {
-                var printTask = new PrintTask(url, {async: config.async});
-                var taskParams = model.getExportParams();
-                model.pdfManager = model.createPdfManager(taskParams, printTask);
-                model.set('submitEnabled', true);
-            });
-        },
-
-        // Fetch task settings from REST API
-        fetchServiceConfig: function(url) {
-            var defer = new Deferred(),
-                jsonUrl = 'proxy.ashx?' + url + '?f=json',
-                config = {
-                    async: false
-                },
-                onSuccess = function(data) {
-                    if (data) {
-                        config.async = data.executionType == 'esriExecutionTypeAsynchronous';
-                    }
-                },
-                onFailure = function() {
-                    new Logger('export').warn(null, i18next.t('Failed to load service config'));
-                },
-                onFinish = function() {
-                    defer.resolve(config);
-                };
-            request(jsonUrl, {handleAs: 'json'})
-                .then(onSuccess, onFailure)
-                .then(onFinish);
-            return defer.promise;
-        },
-
-        getExportParams: function() {
-            var params = new PrintParameters();
-            params.map = this.get('esriMap');
-            params.template = new PrintTemplate();
-            params.template.format = "PDF";
-            params.template.preserveScale = false;
-            params.template.showAttribution = false;
-            return params;
-        },
-
-        createPdfManager: function(taskParams, printTask) {
-            var model = this,
-                pdfManager = {};
-            pdfManager.params = this.getExportParams();
-            pdfManager.printTask = printTask;
-            pdfManager.run = function (layout, title, includeLegend, success, failure) {
-                // Populate the dynamic parameters and create the pdf
-                this.params.template.layout = layout;
-                this.params.template.layoutOptions = {};
-                this.params.template.layoutOptions.titleText = title;
-                this.params.template.layoutOptions.legendLayers = includeLegend ?
-                    model.getLegendLayers(taskParams.map) : [];
-                this.printTask.execute(this.params, success, failure);
-            };
-            return pdfManager;
-        },
-
-        // Return list of all visible layers on map.
-        // Issue #269.
-        // We no longer add group nodes to the list of visible map ids.
-        // However, it seems like the PrintTask cannot render the map legend
-        // without all parent layer ids present.
-        getLegendLayers: function(map) {
-            var model = this,
-                result = [];
-            _.each(map.getLayersVisibleAtScale(), function(layer) {
-                if (layer.visibleLayers && layer.visibleLayers.length > 0 && layer.visibleLayers[0] !== -1) {
-                    var legendLayer = new LegendLayer();
-                    legendLayer.layerId = layer.id;
-                    legendLayer.subLayerIds = model.getLayerParents(layer, layer.visibleLayers);
-                    result.push(legendLayer);
-                }
-            });
-            return result;
-        },
-
-        // Return union of layerIds and related parent layer ids.
-        getLayerParents: function(layer, layerIds) {
-            var result = _.clone(layerIds),
-                // Build lookup table.
-                layerId_to_parentLayerId = _.object(_.zip(
-                    _.pluck(layer.layerInfos, 'id'),
-                    _.pluck(layer.layerInfos, 'parentLayerId')
-                )),
-                layerId = null,
-                i = 0;
-            // Loop through each visible layer and append its direct parent.
-            // This is an iterative node traversal process that will queue the
-            // next node to process at each iteration. Once we reach the root layer
-            // node there is no parent node to queue and the loop terminates.
-            while ((layerId = result[i++]) != null) {
-                var parentLayerId = layerId_to_parentLayerId[layerId];
-                if (parentLayerId != null && parentLayerId > -1 && !_.contains(result, parentLayerId)) {
-                    result.push(parentLayerId);
-                }
-            }
-            return result;
-        },
-
-        createPDF: function () {
-            var model = this,
-                resultTemplate = N.app.templates['template-export-url'],
-                attempts = 3,
-                onSuccess = function(result) {
-                    model.set('outputText', resultTemplate({ url: result.url }));
-                    onFinish();
-                },
-                onFailure = _.debounce(function() {
-                    var result = [];
-                    result.push(i18next.t('There was an error processing your request.'));
-                    if (attempts > 0) {
-                        var s = attempts == 1 ? '' : 's';
-                        result.push('Trying again ' + attempts + ' more time' + s + '...');
-                    }
-                    model.set('outputText', result.join('<br />'));
-                    tryCreatePdf();
-                }, 1000),
-                onFinish = function() {
-                    model.set('submitEnabled', true);
-                },
-                tryCreatePdf = function() {
-                    if (attempts <= 0) {
-                        onFinish();
-                        return;
-                    }
-                    model.pdfManager.run(
-                        model.getPrintTemplateName(),
-                        model.get('exportTitle'),
-                        model.get('exportIncludeLegend'),
-                        onSuccess,
-                        onFailure
-                    );
-                    attempts--;
-                };
-            tryCreatePdf();
-        },
-
-        getPrintTemplateName: function() {
-            // Print templates are MXDs on an AGS Server with the following
-            // naming convention: <<TemplatePrefix>> <<Orientation>> <<""|Legend>>.mxd
-            // This is an ESRI convention and includes whitespace, but the template
-            // name should not include the file extension.
-            var model = this,
-                includeLegend = model.get('exportIncludeLegend') && model.get('useDifferentTemplateWithLegend'),
-                legendSuffix = includeLegend ? 'Legend' : '',
-                prefix = model.get('printLayoutTemplatePrefix'),
-                orientation = model.get('exportOrientation');
-
-            return $.trim(prefix + " " + orientation + " " + legendSuffix);
         }
     });
 
@@ -242,7 +37,6 @@ require(['use!Geosite',
     ////////////////////////////////
 
     N.views.ExportTool = Backbone.View.extend({
-
         className: 'export-ui',
 
         events: {
@@ -256,38 +50,33 @@ require(['use!Geosite',
         },
 
         handleSubmit: function () {
-            if (this.model.get('submitEnabled') === true) {
-                this.model.set({
-                    exportTitle: this.$("#export-title").val(),
-                    exportOrientation: this.$("input:radio[name=export-orientation]:checked").val(),
-                    exportIncludeLegend: this.$('input[name=export-include-legend]').is(':checked')
-                });
-                this.model.submitExport();
-            }
-        },
+            $('.print-sandbox-header h1').text(this.$("#export-title").val());
 
-        enableSubmit: function () {
-            this.$("#export-button").removeAttr('disabled');
-            this.$("div.export-indicator").hide();
-        },
+            // Any plugin-prints may have left specific print css
+            // or sandbox elements. Clear all so that this new print routine
+            // has no conflicts with other plugins.
+            $('#plugin-print-sandbox').empty();
+            $('.plugin-print-css').remove();
 
-        waitForPrintRequest: function () {
-            this.$("#export-button").attr('disabled', 'disabled');
-            this.$("div.export-indicator").show();
-            this.$(".export-output-area").empty();
+            // Add the print stylesheet for the app
+            // Reuse the print plugin class so that this CSS file
+            // will be removed when a plugin print is triggered
+            $('<link>', {
+                rel: 'stylesheet',
+                href: 'css/app-print.css',
+                'class': 'plugin-print-css'
+            }).appendTo('head');
+
+            // This needs to be delayed to give the browser time to parse the
+            // new print stylesheet.
+            window.setTimeout(function() {
+                window.print();
+            }, 200);
         },
 
         initialize: function () {
             var view = this;
 
-            // show/hide indicator when search is in progress
-            view.listenTo(view.model, "change:submitEnabled", function () {
-                if (view.model.get("submitEnabled") === true) {
-                    view.enableSubmit();
-                } else {
-                    view.waitForPrintRequest();
-                }
-            });
             view.listenTo(view.model, "change:outputText", function () {
                 view.$(".export-output-area").html(view.model.get('outputText'));
             });
@@ -298,8 +87,6 @@ require(['use!Geosite',
             this.$el
                 .empty()
                 .append(body);
-            var paneNumber = (+this.model.get('paneNumber')) + 1;
-            this.$('.export-pane-number').text(paneNumber);
 
             if ($.i18n) {
                 $(this.$el).localize();

--- a/src/GeositeFramework/locales/en.json
+++ b/src/GeositeFramework/locales/en.json
@@ -42,7 +42,7 @@
     "Currently viewing Map 2, switch to view Map 1": "Currently viewing Map 2, switch to view Map 1",
     "Map": "Map",
     "Map Utilities": "Map Utilities",
-    "Export": "Export",
+    "Map Export": "Map Export",
     "Embed Width (px)": "Embed Width (px)",
     "Embed Height (px)": "Embed Height (px)",
     "You are currently in": "You are currently in",

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -97,7 +97,8 @@
     ],
     "print": {
         "printServerUrl": "http://lr13:6080/arcgis/rest/services/Utilities/PrintingTools/GPServer/Export%20Web%20Map%20Task",
-        "customPrintTemplatePrefix": "Letter ANSI A GeositeFramework"
+        "customPrintTemplatePrefix": "Letter ANSI A GeositeFramework",
+        "headerLogoPath": "http://maps.coastalresilience.org/network/img/TNCLogoPrimary_RGB2.jpg",
     },
     "colors": {
         "primary": "#29658C",

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -10,17 +10,17 @@
         "url": "http://www.azavea.com/"
     },
     "headerLinks": [
-       { "text": "Getting started", "launchpadId": "get-started", "url": "" },
-       { "text": "Menu", "url":"#", "items": [
+        { "text": "Getting started", "launchpadId": "get-started", "url": "" },
+        { "text": "Menu", "url":"#", "items": [
                 { "text": "Cat", "url": "https://en.wikipedia.org/wiki/Cat" },
                 { "text": "Dog", "popup": true, "url": "https://en.wikipedia.org/wiki/Dog" },
                 { "text": "Fish", "url": "https://en.wikipedia.org/wiki/Fish" },
                 { "text": "Tour Again", "url": "javascript:;", "elementId": "help-overlay-start"}
             ]
-       },
+        },
         { "text": "Azavea", "url": "http://www.azavea.com/" },
         { "text": "GIS", "popup": true, "url": "http://en.wikipedia.org/wiki/Geographic_information_system" },
-        { "text": "Tour", "url": "javascript:;", "elementId": "help-overlay-start"},
+        { "text": "Tour", "url": "javascript:;", "elementId": "help-overlay-start"}
     ],
     "regionLinks": [
         { "text": "California", "url": "http://maps.coastalresilience.org/california/" },


### PR DESCRIPTION
## Overview

This PR setups a print sandbox for the main map, wires it up to the the export functionality, and removes code related to the ArcGIS print service.

### Demo

![image](https://cloud.githubusercontent.com/assets/1042475/20219786/f6e4d4e4-a7f8-11e6-99f8-4d9f79d108f3.png)

### Notes

The print workflow is a naive implementation that lays the groundwork for #725. It will probably need to be reworked to more closely match the plugin print workflow.

## Testing Instructions

- Click the map utils plugin, and select "Export Page".
- Type a title into the title box.
- Click "Generate map export".
- Verify that the print preview has a header with the TNC logo and the title you entered.
- Activate the "Identify point" plugin, click a point on the map, then click the plugin print button.
- Click print, and verify that the print preview page does not have the map header that was added from the previous steps.
- Activate the "Export page" option again, and verify the print preview header is back and that the plugin print map is gone.

Connects #724 