### PR TITLE
Add map to print preview window & print sandbox

### DIFF
--- a/src/GeositeFramework/GeositeFramework.csproj
+++ b/src/GeositeFramework/GeositeFramework.csproj
@@ -139,6 +139,7 @@
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="App_Start\WebApiConfig.cs" />
+    <Content Include="css\app-print.css" />
     <Content Include="css\print-hide-map1.css" />
     <Content Include="css\print-hide-map0.css" />
     <Content Include="css\jquery.dropdown.css" />

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -91,7 +91,6 @@
     <link rel="stylesheet" href="css/TinyBox2.css">
     <link rel="stylesheet" href="css/pageguide.min.css"/>
     <link rel="stylesheet" href="css/main.css">
-    <link rel="stylesheet" href="css/print.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto:500,900" rel="stylesheet">
 
@@ -433,6 +432,10 @@
                         <label><input type="checkbox" name="export-include-legend" /> <span class="i18n" data-i18n="Include Layer Legend">Include Layer Legend</span></label>
                     </div>
                 </div>
+                <div id="export-print-preview-container">
+                    <p class="instructions i18n" data-i18n="Zoom to the view that you want printed in your map.">Zoom to the view that you want printed in your map.</p>
+                    <div id="export-print-preview-map"></div>
+                </div>
                 <div class="row">
                     <div class="left-col">
                         <div class="export-output-area">
@@ -625,7 +628,7 @@
             <img src="@Model.PrintHeaderLogo" title="Header Logo" class="logo" />
             <h1></h1>
         </div>
-        <div id="print-map-container">Map goes here</div>
+        <div id="print-map-container"></div>
     </div>
 
     <!-- LEFT CONTENT AREA -->

--- a/src/GeositeFramework/css/app-print.css
+++ b/src/GeositeFramework/css/app-print.css
@@ -1,5 +1,109 @@
 ﻿@media print {
     #map-print-sandbox {
-        visibility: visible;
+        visibility: visible !important;
     }
+
+    #legend-container-0 {
+        display: none;
+    }
+
+    #export-print-preview-container {
+        padding-bottom: 5px !important;
+    }
+
+    #left-pane {
+        display: none;
+    }
+    
+    #right-pane {
+        display: none;
+    }
+
+    .tbox {
+        display: none !important;
+    }
+
+    .tmask {
+        display: none !important;
+    }
+
+    header {
+        display: none !important;
+    }
+
+    #export-print-preview-map.div.control-container {
+        display: none;
+    }
+
+    #export-print-preview-map {
+        width: 100% !important;
+        max-height: 750px;
+    }
+
+    #export-print-preview-map > #map-0 {
+        max-height: 750px;
+        height: 100%;
+        top: 0 !important;
+        position: relative !important;
+    }
+
+    #export-print-preview-map > #map-0 > #legend-container-0 {
+        display: none !important;
+    }
+
+    #export-print-preview-map > #map-0 > #map-0_root {
+        visibility: visible !important;
+    }
+    
+    #export-print-preview-map > #map-0 > #map-0_root img.layerTile {
+        visibility: visible !important;
+    }
+
+    #export-print-preview-map > #map-0 > #map-0_root > #map-0_zoom_slider {
+        display: none;
+    }
+
+    .plugin-launcher {
+        display: none;
+    }
+}
+
+#export-print-preview-container {
+    padding-bottom: 5px !important;
+}
+
+#export-print-preview-container.tinner > div.tcontent {
+    max-height: 100% !important;
+}
+
+#export-print-preview-container.tinner > div.tcontent > div.popover {
+    max-height: 100%;
+}
+
+#export-print-preview-container.tinner > div.tcontent > div.popover > div.popover-content {
+    max-height: 95%;
+    height: 95%;
+    padding-bottom: 5px;
+    padding-top: 10px;
+}
+
+
+#export-print-preview-map.div.control-container {
+    display: none;
+}
+
+#export-print-preview-map {
+    width: 100% !important;
+    max-height: 200px;
+}
+
+#export-print-preview-map > #map-0 {
+    max-height: 200px;
+    height: 100%;
+    top: 0 !important;
+    position: relative !important;
+}
+
+#export-print-preview-map > #map-0 > #legend-container-0 {
+    display: none !important;
 }

--- a/src/GeositeFramework/css/print.css
+++ b/src/GeositeFramework/css/print.css
@@ -1,4 +1,10 @@
 ﻿@media print {
+    #map-print-sandbox {
+        visibility: visible !important;
+    }
+    .print-sandbox-header {
+        display: none !important;
+    }
     /* Hide all body an map elements and print preview map controls */
     body,
     #plugin-print-preview-map_zoom_slider {
@@ -35,5 +41,9 @@
 
     #plugin-print-preview-map_container img {
         visibility: visible;
+    }
+
+    .esriSimpleSlider {
+        display: none;
     }
 }

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -410,13 +410,7 @@ require([
                         paneNumber: this.model.get('paneNumber')
                     }),
                     view = new N.views.ExportTool({ model: model });
-
-                TINY.box.show({
-                    html: view.render().el,
-                    fixed: true,
-                    maskopacity: 50,
-                    closejs: function() { view.remove(); }
-                });
+                view.render();
             },
 
             saveState: function() {

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -450,6 +450,9 @@ require(['use!Geosite',
                     $('.' + printCssClass).remove();
                     $printSandbox.empty();
 
+                    // add base plugin css
+                    addCss('css/print.css', 'base-plugin-print-css');
+
                     // Add the plugin css
                     addCss(pluginCssPath, printCssClass);
 


### PR DESCRIPTION
This adds a map to the print-preview window and the final printed output. By moving the DOM element directly, all the map layers and settings remain unchanged, apart from where altered by specific style rules.

To test:
* clone this branch and bring up the app
* navigate to `http://localhost:54633`
* click on the options button on the right and then on "Export Page"
* a window should appear that resembles this -->
![download1](https://cloud.githubusercontent.com/assets/18290666/20361600/2ab65caa-ac06-11e6-9be0-d3996b780ef3.png)
* you should be able to move and zoom the map, and any basemap or layers from the main page should be identical --> 
![download3](https://cloud.githubusercontent.com/assets/18290666/20361613/381dea0c-ac06-11e6-8e24-228f45a271bd.png)
* add a test title in the textbox
* click "Generate Map Export" to move to the print preview
* check that the print preview has the map, title, and correct branding
* repeat for a couple combinations of basemaps and layers
* repeat but exit without clicking "Generate Map Export", and check that the map is in the main app

Connects #725 