### PR TITLE
Fix minor style issues

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -88,10 +88,10 @@
     <link rel="stylesheet" href="//js.arcgis.com/3.10/js/dojo/dojox/layout/resources/ResizeHandle.css">
     <link rel="stylesheet" href="//js.arcgis.com/o/232546/geosite-v1.0.9/esri/css/esri.css">
 
-    <link rel="stylesheet" href="css/main.css">
-    <link rel="stylesheet" href="css/print.css">
     <link rel="stylesheet" href="css/TinyBox2.css">
     <link rel="stylesheet" href="css/pageguide.min.css"/>
+    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="css/print.css">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
     <link href="https://fonts.googleapis.com/css?family=Roboto:500,900" rel="stylesheet">
 

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -2341,7 +2341,7 @@ a.active {
 #print-map-container {
     border: 1px solid #ccc;
     padding: 5px;
-    height: 850px;
+    height: 500px;
 }
 .print-preview-container {
     padding: 10px;


### PR DESCRIPTION
This PR fixes two minor style issues:

1. It removes the vertical scroll bar from the app. This was being caused by the oversized map print sandbox.

Before:
![image](https://cloud.githubusercontent.com/assets/1042475/20367676/8722fa3a-ac1e-11e6-8f82-e37d83e0d23e.png)

After:
![image](https://cloud.githubusercontent.com/assets/1042475/20367641/669dfb84-ac1e-11e6-8cb2-93363c1d1240.png)

2. It fixes the modal close button by giving our stylesheets precedent over vendor stylesheets (specifically, the TinyBox stylesheet).

Before:
![image](https://cloud.githubusercontent.com/assets/1042475/20367691/93f1d6dc-ac1e-11e6-8ac1-e0f643a2f140.png)

After:
![image](https://cloud.githubusercontent.com/assets/1042475/20367634/5d4cae36-ac1e-11e6-9e3a-dc54c81ecd22.png)