### PR TITLE
Add layer legend to printed map

### DIFF
--- a/src/GeositeFramework/css/app-print.css
+++ b/src/GeositeFramework/css/app-print.css
@@ -4,7 +4,14 @@
     }
 
     #legend-container-0 {
-        display: none;
+        display: block !important;
+        visibility: hidden;
+        position: fixed;
+        margin-left: 610px;
+    }
+
+    .control-container {
+        display: none !important;
     }
 
     #export-print-preview-container {
@@ -31,35 +38,42 @@
         display: none !important;
     }
 
-    #export-print-preview-map.div.control-container {
+    #print-map-container > #export-print-preview-map.div.control-container {
         display: none;
     }
 
-    #export-print-preview-map {
+    #print-map-container > #export-print-preview-map {
         width: 100% !important;
         max-height: 750px;
+        height: 100%;
     }
 
-    #export-print-preview-map > #map-0 {
+    #print-map-container > #export-print-preview-map > #map-0 {
         max-height: 750px;
         height: 100%;
         top: 0 !important;
         position: relative !important;
     }
 
-    #export-print-preview-map > #map-0 > #legend-container-0 {
-        display: none !important;
+    #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 {
+        display: block !important;
+        position: fixed;
+        margin-left: 610px;
     }
 
-    #export-print-preview-map > #map-0 > #map-0_root {
+    #print-map-container > #export-print-preview-map > #map-0 > #map-0_root {
         visibility: visible !important;
+        max-height: 750px;
+        height: 100%;
+        max-width: 720px;
+        width: 100%;
     }
     
-    #export-print-preview-map > #map-0 > #map-0_root img.layerTile {
+    #print-map-container > #export-print-preview-map > #map-0 > #map-0_root img.layerTile {
         visibility: visible !important;
     }
 
-    #export-print-preview-map > #map-0 > #map-0_root > #map-0_zoom_slider {
+    #print-map-container > #export-print-preview-map > #map-0 > #map-0_root > #map-0_zoom_slider {
         display: none;
     }
 

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -64,11 +64,28 @@ require(['use!Geosite'],
 
                         mapReadyDeferred.then(function () {
                             $("#export-print-preview-map").detach().appendTo($("#print-map-container"));
+
+                            if ($("[name='export-include-legend']").is(":checked")) {
+                                // show & expand all legend items
+                                $("#legend-container-0").css({ visibility: "visible" });
+                                _.each(
+                                    $(".item.expand>.expand-legend"),
+                                    function (el) {
+                                        el.click();
+                                    });
+                                $(".item.extra.collapse").hide();
+                            } else {
+                                // if the style rule is changed via jquery, that state seems to
+                                // "stick", regardless of what's in the stylesheet
+                                $("#legend-container-0").css({ visibility: "hidden" });
+                            }
+
                             window.print();
                             previewDeferred.resolve();
                         });
 
                         previewDeferred.then(function () {
+                            $(".item.extra.collapse").show();
                             TINY.box.hide();
                             $printPreview.hide();
                         });
@@ -81,6 +98,7 @@ require(['use!Geosite'],
                     mapNodeParent.append(mapNode);
                     $("#export-print-preview-map").detach().appendTo($("#export-print-preview-container"));
                     $('.app-print-css').remove();
+                    $("#legend-container-0").css({ visibility: "visible" });
                 }
             });
             


### PR DESCRIPTION
This adds the legend to the printed map, per the users option. The legend style is manipulated directly since it's a child of the map node that gets moved around.

To test:
* clone this branch and bring up the app
* select a layer, then click "Export"
* check the "Include Layer Legend" box and then click "Generate" -->
![download](https://cloud.githubusercontent.com/assets/18290666/20400321/39eb3a62-acc2-11e6-80d4-6b88c8bb4d02.png)
* the printed output should resemble the attached PDF-->
[Geosite Framework Sample _ Sample Region2.pdf](https://github.com/CoastalResilienceNetwork/GeositeFramework/files/598060/Geosite.Framework.Sample._.Sample.Region2.pdf)
* go through the same steps but without checking the box, there should be no legend

Connects #726 