### PR TITLE
Add partner section to Launchpad

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -221,6 +221,18 @@
                 },
             },
             "additionalProperties": false
+        },
+        "partners": {
+            "type": "array",
+            "required": false,
+            "items": {
+                "type": "object",
+                "properties": {
+                    "logoPath": { "type": "string", "required": true },
+                    "link": { "type": "string", "required": true },
+                    "title": { "type": "string", "required": true }
+                }
+            }
         }
     },
     "additionalProperties": false

--- a/src/GeositeFramework/plugins/launchpad/main.js
+++ b/src/GeositeFramework/plugins/launchpad/main.js
@@ -76,7 +76,8 @@ define([
                     title: N.app.data.region.launchpad.title,
                     description: N.app.data.region.launchpad.description,
                     plugins: N.app.data.region.launchpad.plugins,
-                    scenarios: N.app.data.region.launchpad.scenarios
+                    scenarios: N.app.data.region.launchpad.scenarios,
+                    partners: N.app.data.region.partners
                 }));
 
                 $(this.container).empty().append($el);

--- a/src/GeositeFramework/plugins/launchpad/style.css
+++ b/src/GeositeFramework/plugins/launchpad/style.css
@@ -14,3 +14,11 @@
 .launchpad-plugin .scenarios .button {
     float: right;
 }
+
+.launchpad-plugin .partners li {
+    display: inline-block;
+}
+.launchpad-plugin .partners img {
+    height: 60px;
+    margin: 5px 10px;
+}

--- a/src/GeositeFramework/plugins/launchpad/style.css
+++ b/src/GeositeFramework/plugins/launchpad/style.css
@@ -14,11 +14,15 @@
 .launchpad-plugin .scenarios .button {
     float: right;
 }
-
 .launchpad-plugin .partners li {
     display: inline-block;
 }
 .launchpad-plugin .partners img {
     height: 60px;
     margin: 5px 10px;
+}
+.launchpad-plugin ul {
+    margin: 0;
+    list-style-type: none;
+    padding: 0;
 }

--- a/src/GeositeFramework/plugins/launchpad/templates.html
+++ b/src/GeositeFramework/plugins/launchpad/templates.html
@@ -30,5 +30,17 @@
             <% }); %>
             </ul>
         </div>
+        <h3>Partners</h3>
+        <div class="partners">
+            <ul>
+            <% _.each(partners, function(partner) { %>
+                <li>
+                    <a href="<%= partner.link %>" target="_blank">
+                        <img src="<%= partner.logoPath %>" alt="<%= partner.title %>" />
+                    </a>
+                </li>
+            <% }); %>
+            </ul>
+        </div>
     </div>
 </script>

--- a/src/GeositeFramework/plugins/launchpad/templates.html
+++ b/src/GeositeFramework/plugins/launchpad/templates.html
@@ -36,7 +36,7 @@
             <% _.each(partners, function(partner) { %>
                 <li>
                     <a href="<%= partner.link %>" target="_blank">
-                        <img src="<%= partner.logoPath %>" alt="<%= partner.title %>" />
+                        <img src="<%= partner.logoPath %>" alt="<%= partner.title %>" title="<%= partner.title %>"/>
                     </a>
                 </li>
             <% }); %>

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -138,5 +138,27 @@
                 "legendType": "scale"
             }
         ]
-    }
+    },
+    "partners": [
+        {
+            "logoPath": "http://www.naturalcapitalproject.org/wp-content/uploads/2015/05/logo-ls-lined-up.jpg",
+            "link": "http://www.naturalcapitalproject.org/",
+            "title": "Natural Capital Project",
+        },
+        {
+            "logoPath": "https://coast.noaa.gov/assets/logos/noaa-badge-full-color-no-outertext.svg",
+            "link": "https://coast.noaa.gov/digitalcoast/",
+            "title": "NOAA Digital Coast",
+        },
+        {
+            "logoPath": "https://www.fws.gov/home/graphics/logo.png",
+            "link": "https://www.fws.gov/",
+            "title": "U.S. Fish and Wildlife Surface",
+        },
+        {
+            "logoPath": "https://www.usm.edu/sites/default/files/groups/office-university-communications/images/univc123pc_0.png",
+            "link": "https://www.usm.edu/",
+            "title": "University of Southern Mississippi",
+        },
+    ]
 }


### PR DESCRIPTION
## Overview

Adds a section for partner links and logos to the new launchpad. The region schema was updated as well to support configuring the partners from there.

### Demo

![image](https://cloud.githubusercontent.com/assets/1042475/20635666/1dea5308-b32e-11e6-8edc-b664a37a8a2a.png)

### Notes

This does not use the "HTML fragment" approach described in the issue because I was unclear as to exactly what that meant/what the advantages are. Happy to adjust if need be.

## Testing

- Open the launchpad.
- Verify that the partner section is visible and contains all of the partners listed out in the config.

Connects to #741