### PR TITLE
Make the plugin icons smaller

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -973,6 +973,11 @@ nav {
     margin-right: 6px;
     font-size: 18px
 }
+.nav-apps-button > .button-icon img {
+    height: 20px;
+    width: 20px;
+}
+
 @media (max-width: 991px) {
     .nav-apps-button .button-text {
         display: none


### PR DESCRIPTION
This may not be the final size, but gets it closer to the prototype
version.

From
![screenshot from 2016-12-05 16 10 24](https://cloud.githubusercontent.com/assets/1014341/20902486/5f936856-bb05-11e6-8824-26404f45fd6a.png)

To
![screenshot from 2016-12-05 16 11 21](https://cloud.githubusercontent.com/assets/1014341/20902508/7976f562-bb05-11e6-8528-e12bd136ddb1.png)

Connects #757 