### PR TITLE
Initialize Launchpad by default

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -169,7 +169,7 @@
             "type": "boolean",
             "required": false
         },
-        "launchpads": {
+        "launchpad": {
             "type": "object",
             "required": false,
             "properties": {

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -153,17 +153,34 @@ require([
         function initPlugins(model, esriMap) {
             var mapModel = model.get('mapModel'),
                 regionData = model.get('regionData'),
-                savedState = model.get('stateOfPlugins');
+                savedState = model.get('stateOfPlugins'),
+                launchpadPlugin = null;
 
             model.get('plugins').each(function(pluginModel) {
+                if (checkName(pluginModel, 'launchpad')) {
+                    launchpadPlugin = pluginModel;
+                }
                 pluginModel.initPluginObject(regionData, mapModel, esriMap);
             });
 
-            // Wait a second before activating a permaline (scenario) to ensure the map
+            // Wait a second before activating a permalink (scenario) to ensure the map
             // layer is loaded.
             _.delay(function() {
                 activateScenario(model, savedState, model.get('activeSubregion'));
+
+                // If no savedState and there is a launchpad plugin, active it first.
+                // A saveCode key would indicate that another plugin should be active
+                if (Object.keys(savedState).length === 0 && launchpadPlugin) {
+                    launchpadPlugin.toggleSelected();
+                }
             }, 1000);
+        }
+
+        function checkName(pluginModel, nameToCheck) {
+            if (pluginModel.name().indexOf('/' + nameToCheck) > -1) {
+                return true;
+            }
+            return false;
         }
 
         function activateScenario(pane, stateOfPlugins, activeSubregion) {


### PR DESCRIPTION
After all plugins are created, activate the launchpad if it has been
included and if there is no other saved state that would contradict that
activation.

Does not use a timeout based approach as described in #747.

Also fixes the region.json schema to check the correct property for launchpad, and uses the presence of a `launchpad` config key as an indication to create or not create a launchpad instance.

#### Testing
* With the `region.json` configured as is (with a launchpad), verify that the launchpad is opened on app start
* Open regional planning, select some layers and position the map - generate a save 'n share link
* Open that save 'n share link and verify that the launchpad is not visible, but the regional planning plugin is.
* Rename the `launchpad` config key so as it remove it.  Restart the site such that the region.json is re-parsed and verify that the launchpad is not visible.

Connects #747 