### PR TITLE
Add class to plugin icon when it is displayed

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -320,7 +320,7 @@
     </script>
 
     <script type="text/template" id="template-sidebar-plugin">
-        <button class="nav-apps-button plugin-launcher i18n <%= selected ? 'active' : ''%>" data-i18n="[title]<%=fullName%>">
+        <button class="nav-apps-button plugin-launcher i18n <%= selected ? 'active' : ''%> <%= displayed ? 'app-displayed' : ''%>" data-i18n="[title]<%=fullName%>">
             <span class="button-icon"><img src="<%- pluginSrcFolder %>/icon_sm.png"></span>
             <span class="button-text i18n" data-i18n="<%- pluginObject.toolbarName %>"><%- pluginObject.toolbarName %></span>
         </button

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -371,9 +371,11 @@ require(['use!Geosite',
             var model = view.model,
                 pluginTemplate = N.app.templates['template-sidebar-plugin'],
                 // The plugin icon looks active if the plugin is selected or
-                // active (aka, running but not focused)
+                // active (aka, running but not focused).  It is displayed if
+                // it is currently displaying its UI.
                 html = pluginTemplate(_.extend(model.toJSON(), {
                     selected: model.selected || model.get('active'),
+                    displayed: model.selected,
                     fullName: model.get('pluginObject').fullName
                 }));
 


### PR DESCRIPTION
This is a preliminary step to allow discreet styling for the plugin icon
area for apps which are the not only "active", but open.

This will allow @jfrankl to finish some styling in this area.

Connects #755 

#### Testing
Open several apps, noting that they acquire the `active` class as usual.  The app which is displaying its UI will also have the new `displayed` class on `button` element, as well.  It's removed when a different app is opened.

![screenshot from 2016-12-07 09 57 34](https://cloud.githubusercontent.com/assets/1014341/20972660/95e91324-bc63-11e6-988b-6b93214b37bf.png)
