### PR TITLE
Replace print function name with "Create Map"

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -314,7 +314,7 @@
             </li>
         <% } %>
         <% if (showExportButton) { %>
-            <li><a href="javascript:;" class="export-button hide-for-tablet i18n" data-i18n="[title]Receive a printable copy of the current map"><img class="icon" src="img/icons/icon_print_up.png"/><span class="i18n" data-i18n="Export Page">Export Page</span></a></li>
+            <li><a href="javascript:;" class="export-button hide-for-tablet i18n" data-i18n="[title]Receive a printable copy of the current map"><img class="icon" src="img/icons/icon_print_up.png"/><span class="i18n" data-i18n="Create Map">Create Map</span></a></li>
         <% } %>
 
     </script>
@@ -410,7 +410,7 @@
     <script type="text/template" id="template-export-window">
         <div class="popover">
             <div class="popover-header">
-                <h2><span class="i18n" data-i18n="Map Export">Map Export</span></h2>
+                <h2><span class="i18n" data-i18n="Map Export">Create Map</span></h2>
             </div>
             <div class="popover-content">
                 <div class="row">

--- a/src/GeositeFramework/locales/en.json
+++ b/src/GeositeFramework/locales/en.json
@@ -15,7 +15,7 @@
     "Force maps to show the same extent": "Force maps to show the same extent",
     "Link Maps": "Link Maps",
     "Receive a printable copy of the current map": "Receive a printable copy of the current map",
-    "Export Page": "Export Page",
+    "Create Map": "Create Map",
     "Print Contents": "Print Contents",
     "View the info-graphic": "View the info-graphic",
     "Title (Optional):": "Title (Optional):",

--- a/src/GeositeFramework/locales/es.json
+++ b/src/GeositeFramework/locales/es.json
@@ -15,7 +15,7 @@
     "Force maps to show the same extent": "Ver la misma zona en ambos mapas",
     "Link Maps": "Vincular mapas 1 y 2",
     "Receive a printable copy of the current map": "Recibir mapa para impresión de la vista actual",
-    "Export Page": "Exportar página",
+    "Create Map": "Exportar página",
     "Print Contents": "Imprimir Contenidos",
     "View the info-graphic": "Ver la infografía",
     "Title (Optional):": "Título (opcional):",

--- a/src/GeositeFramework/plugins/map_utils/templates.html
+++ b/src/GeositeFramework/plugins/map_utils/templates.html
@@ -7,7 +7,7 @@
         <ul>
             <li><a href="#" data-command="measure" data-i18n="Measure">Measure</a></li>
             <li><a href="#" data-command="zoom" data-i18n="Zoom to Extent">Zoom to Extent</a></li>
-            <li><a href="#" data-command="export" data-i18n="Export Page">Export Page</a></li>
+            <li><a href="#" data-command="export" data-i18n="Create Map">Create Map</a></li>
             <li><a href="#" data-command="share" data-i18n="Save &amp; Share">Save &amp; Share</a></li>
         </ul>
     </div>


### PR DESCRIPTION
This replaces all instances of "Export Page" and "Map Export" with "Create Map", on the overflow list on the main page, and on the print modal.

To test:
* clone this branch, bring up the environment & open the app
* check anywhere the old text would be, ensure that it has been replaced with "Create Map"
* check that no functionality has been affected, the change should be superficial

Connects #745 