### PR TITLE
Shutdown launchpad on plugin activation

### DIFF
--- a/src/GeositeFramework/plugins/launchpad/main.js
+++ b/src/GeositeFramework/plugins/launchpad/main.js
@@ -71,6 +71,11 @@ define([
                 this.render();
             },
 
+            deactivate: function() {
+                var self = this;
+                self.plugin.turnOff();
+            },
+
             render: function() {
                 var $el = $(this.pluginTmpl({
                     title: N.app.data.region.launchpad.title,


### PR DESCRIPTION
This adds a "deactivated" handler to the launchpad that shuts down the plugin when another plugin is launched or a subregion is activated.

To test:
* clone this branch, bring up the environment, and open the app
* click on the launchpad control in the sidebar
* either activate another plugin/subregion, or click one of the launchpad controls that does the same
* check that whenever a plugin/subregion is activated, the launchpad turns off

Connects #750 