### PR TITLE
Map Export UI fixes & browser-specific print process

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -443,10 +443,11 @@
                         <h3 class="i18n" data-i18n="Orientation">Orientation</h3>
                         <label><input type="radio" name="export-orientation" value="Landscape" checked="checked"/><span class="i18n" data-i18n="Landscape">Landscape</label>
                         <label><input type="radio" name="export-orientation" value="Portrait"/><span class="i18n" data-i18n="Portrait">Portrait</label>
+                        <p class="font-italic small i18n" data-i18n="Browser Print">* You may need to alter your browser print settings</p>
                     </div>
                     <div class="popover-section">
                          <h3 class="i18n" data-i18n="Legend">Legend</h3>
-                        <label><input type="checkbox" name="export-include-legend" /> <span class="i18n" data-i18n="Include Layer Legend">Include Layer Legend</span></label>
+                        <label><input type="checkbox" name="export-include-legend" checked/> <span class="i18n" data-i18n="Include Layer Legend">Include Layer Legend</span></label>
                     </div>
                 </div>
                 <div id="export-print-preview-container">

--- a/src/GeositeFramework/css/app-print.css
+++ b/src/GeositeFramework/css/app-print.css
@@ -1,4 +1,24 @@
 ﻿@media print {
+    .print-sandbox-header h1 {
+        width: 100%;
+        padding-top: 0.3in;
+        text-align: center;
+    }
+
+    .esriScalebar {
+        visibility: hidden;
+    }
+
+    .print-sandbox-header {
+        display: flex;
+        flex-direction: row;
+        height: 0.95in;
+    }
+
+    #print-map-container {
+        overflow: hidden !important;
+    }
+
     #map-print-sandbox {
         visibility: visible !important;
     }
@@ -10,6 +30,32 @@
     #export-print-preview-container {
         padding-bottom: 5px !important;
         visibility: visible;
+    }
+
+    #legend-container-0 {
+        background-color: #fff !important;
+    }
+
+    .legend-close {
+        visibility: hidden;
+    }
+    
+    #print-map-container > #export-print-preview-map > #map-0 {
+        height: 100% !important;
+        width: 100% !important;
+        position: relative;
+    }
+    
+    #legend-container-0 {
+        margin-left: 0px !important;
+        left: 0px !important;
+        width: 100% !important;
+        position: absolute !important;
+        z-index: 10;
+    }
+    
+    .dojoResizeHandle {
+        visibility: hidden !important;
     }
 
     #left-pane {
@@ -55,6 +101,49 @@
     .logo-med {
         display: none !important;
     }
+    
+    .legend-header {
+        height: 15%;
+        font-size: 11px;
+    }
+
+    .legend-body {
+        display: flex;
+        flex-wrap: wrap;
+        width: 100% !important;
+        height: 85% !important;
+    }
+
+    .layer-legends {
+        height: 100% !important;
+        width: 100% !important;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: wrap;
+    }
+
+    .legend-layer {
+        width: auto !important;
+        font-size: 8px;
+        height: auto !important;
+        display: flex;
+        flex-direction: column;
+        flex-shrink: 1;
+    }
+
+    .legend-title {
+        max-width: 75%;
+    }
+
+    .print-legend-coll {
+        display: flex !important;
+        flex-direction: column;
+    }
+
+    .legend-layer img {
+        width: 10px;
+        height: 10px;
+    }
 }
 
 #export-print-preview-container {
@@ -95,4 +184,44 @@
 
 .instructions {
     display: none;
+}
+
+.legend-close {
+    visibility: hidden;
+}
+
+.dojoResizeHandle {
+    visibility: hidden !important;
+}
+
+#export-title {
+    width: 100%;
+}
+.print-sandbox-header .hdr-container {
+    position: fixed;
+    height: 0.85in;
+    text-align: center;
+    padding-left: 160px;
+    display: flex;
+    flex-direction: row;
+}
+
+.print-sandbox-header h1 {
+    width: 100%;
+    padding-top: 0.3in;
+    text-align: center;
+}
+
+.print-sandbox-header {
+    display: flex;
+    flex-direction: row;
+    height: 0.95in;
+}
+
+.esriScalebar {
+    visibility: hidden;
+}
+    
+#print-map-container {
+    overflow: hidden !important;
 }

--- a/src/GeositeFramework/css/print-landscape.css
+++ b/src/GeositeFramework/css/print-landscape.css
@@ -8,12 +8,7 @@
         height: 6in !important;
     }
 
-    .print-sandbox-header {
-        height: 0.95in !important;
-    }
-
     #print-map-container {
-        overflow: hidden !important;
         width: 10in !important;
         height: 6in !important;
     }
@@ -23,64 +18,9 @@
         width: 9.9in !important;
     }
 
-    #print-map-container > #export-print-preview-map > #map-0 {
-        height: 100% !important;
-        width: 100% !important;
-        position: relative;
-    }
-    
     #legend-container-0 {
-        margin-left: 0px !important;
         top: 80% !important;
-        left: 0px !important;
         height: 20% !important;
-        width: 100% !important;
-        position: absolute !important;
-        z-index: 10;
-        background-color: white;
-    }
-
-    .legend-header {
-        height: 15%;
-        font-size: 11px;
-    }
-
-    .legend-body {
-        display: flex;
-        flex-wrap: wrap;
-        width: 100% !important;
-        height: 85% !important;
-    }
-
-    .layer-legends {
-        height: 100% !important;
-        width: 100% !important;
-        display: flex;
-        flex-direction: column;
-        flex-wrap: wrap;
-    }
-
-    .legend-layer {
-        width: auto !important;
-        font-size: 8px;
-        height: auto !important;
-        display: flex;
-        flex-direction: column;
-        flex-shrink: 1;
-    }
-
-    .legend-title {
-        max-width: 75%;
-    }
-
-    .print-legend-coll {
-        display: flex !important;
-        flex-direction: column;
-    }
-
-    .legend-layer img {
-        width: 10px;
-        height: 10px;
     }
 }
 
@@ -89,12 +29,7 @@
     height: 6in !important;
 }
 
-.print-sandbox-header {
-    height: 0.95in !important;
-}
-
 #print-map-container {
-    overflow: hidden !important;
     width: 10in !important;
     height: 6in !important;
 }

--- a/src/GeositeFramework/css/print-portrait.css
+++ b/src/GeositeFramework/css/print-portrait.css
@@ -8,12 +8,7 @@
         height: 9in !important;
     }
 
-    .print-sandbox-header {
-        height: 0.95in !important;
-    }
-
     #print-map-container {
-        overflow: hidden !important;
         width: 8in !important;
         height: 8.65in !important;
     }
@@ -23,64 +18,9 @@
         width: 7.9in !important;
     }
 
-    #print-map-container > #export-print-preview-map > #map-0 {
-        height: 100% !important;
-        width: 100% !important;
-        position: relative;
-    }
-
     #legend-container-0 {
-        margin-left: 0px !important;
         top: 75% !important;
-        left: 0px !important;
         height: 25% !important;
-        width: 100% !important;
-        position: absolute !important;
-        z-index: 10;
-        background-color: white;
-    }
-
-    .legend-header {
-        height: 15%;
-        font-size: 11px;
-    }
-
-    .legend-body {
-        display: flex;
-        flex-wrap: wrap;
-        width: 100% !important;
-        height: 85% !important;
-    }
-
-    .layer-legends {
-        height: 100% !important;
-        width: 100% !important;
-        display: flex;
-        flex-direction: column;
-        flex-wrap: wrap;
-    }
-
-    .legend-layer {
-        width: auto !important;
-        font-size: 8px;
-        height: auto !important;
-        display: flex;
-        flex-direction: column;
-        flex-shrink: 1;
-    }
-
-    .legend-title {
-        max-width: 75%;
-    }
-
-    .print-legend-coll {
-        display: flex !important;
-        flex-direction: column;
-    }
-    
-    .legend-layer img {
-        width: 10px;
-        height: 10px;
     }
 }
 
@@ -89,12 +29,7 @@
     height: 9in !important;
 }
 
-.print-sandbox-header {
-    height: 0.95in !important;
-}
-
 #print-map-container {
-    overflow: hidden !important;
     width: 8in !important;
     height: 8.65in !important;
 }

--- a/src/GeositeFramework/locales/en.json
+++ b/src/GeositeFramework/locales/en.json
@@ -16,6 +16,7 @@
     "Link Maps": "Link Maps",
     "Receive a printable copy of the current map": "Receive a printable copy of the current map",
     "Create Map": "Create Map",
+    "Browser Print": "You may need to alter your browsers print settings",
     "Print Contents": "Print Contents",
     "View the info-graphic": "View the info-graphic",
     "Title (Optional):": "Title (Optional):",

--- a/src/GeositeFramework/locales/es.json
+++ b/src/GeositeFramework/locales/es.json
@@ -16,6 +16,7 @@
     "Link Maps": "Vincular mapas 1 y 2",
     "Receive a printable copy of the current map": "Recibir mapa para impresión de la vista actual",
     "Create Map": "Exportar página",
+    "Browser Print": "Es posible que deba modificar la configuracion de impresion de su navegador.",
     "Print Contents": "Imprimir Contenidos",
     "View the info-graphic": "Ver la infografía",
     "Title (Optional):": "Título (opcional):",


### PR DESCRIPTION
This fixes some UI issues that are part of the map export process, and addresses differences in print process between browsers.

To test:
* clone this branch, bring up the environment, and open the app
* select some combination of layers so that the legend pops up
* export the map, and check that: the textbox for the title is wider; the "Export Legend" checkbox is checked by default; in non-Chrome browsers, a message pops up to remind users about printing differences
* check that the exported map looks correct with respect to the given settings, e.g.  the legend should be printed, the page orientation should be correct, etc.

Connects #767 