### PR TITLE
Restore launchpad header bar

### DIFF
--- a/src/GeositeFramework/plugins/launchpad/main.js
+++ b/src/GeositeFramework/plugins/launchpad/main.js
@@ -38,7 +38,6 @@ define([
 
                 this.pluginTmpl = _.template(this.getTemplateById('plugin'));
                 this.bindEvents();
-                this.removeTitleBar();
             },
 
             bindEvents: function() {
@@ -55,14 +54,6 @@ define([
                         self.plugin.turnOff();
                         self.triggerEvent('launchpad:activate-scenario', saveCode);
                     });
-            },
-
-            removeTitleBar: function() {
-                // The launchpad is a special plugin that doesn't get to be
-                // closed like other plugins.
-                $(this.container)
-                    .css({ 'padding-top': 0 })
-                    .siblings('.sidebar-nav').remove();
             },
 
             activate: function() {


### PR DESCRIPTION
This restores the header bar to the launchpad.

To test:
* clone this branch, bring up the environment, and open the app
* check that the launchpad is open on startup, and that the header bar is visible
![screenshot-localhost 54633-2016-12-14-10-09-31](https://cloud.githubusercontent.com/assets/18290666/21187835/5ed31b4e-c1e7-11e6-809c-7b9f8ce6b62f.png)
* check that clicking the "x" button and the sidebar entry close the plugin
![screenshot-localhost 54633-2016-12-14-10-10-44](https://cloud.githubusercontent.com/assets/18290666/21187852/6dfc728c-c1e7-11e6-9761-527b08346e76.png)
* perform the following sequence: activate another plugin --> change plugin state --> activate launchpad --> close launchpad --> reopen other plugin. Check that the other plugin state is persisted and that the sidebar elements highlight as expected
![screenshot-localhost 54633-2016-12-14-10-11-35](https://cloud.githubusercontent.com/assets/18290666/21187874/7c1320d2-c1e7-11e6-9d99-da31893e8d43.png)
![screenshot-localhost 54633-2016-12-14-10-11-56](https://cloud.githubusercontent.com/assets/18290666/21187875/7c143fbc-c1e7-11e6-83a8-66ff9968a019.png)
![screenshot-localhost 54633-2016-12-14-10-12-30](https://cloud.githubusercontent.com/assets/18290666/21187873/7c0f3bc0-c1e7-11e6-880d-3f8392e16529.png)


Connects #773 