### PR TITLE
Add scalebar to map

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -5,6 +5,7 @@ require(['use!Geosite',
          'framework/Legend',
          'framework/util/ajax',
          'esri/map',
+         'esri/dijit/Scalebar',
          'esri/layers/ArcGISTiledMapServiceLayer',
          'esri/geometry/Extent',
          'esri/SpatialReference',
@@ -14,6 +15,7 @@ require(['use!Geosite',
              Legend,
              ajaxUtil,
              Map,
+             ScaleBar,
              ArcGISTiledMapServiceLayer,
              Extent,
              SpatialReference,
@@ -123,6 +125,11 @@ require(['use!Geosite',
         loadExtent(view);
         selectBasemap(view);
         initSearch(view);
+
+        var scalebar = new ScaleBar({
+            map: view.esriMap,
+            scalebarUnit: 'dual'
+        });
 
         var throttledSet = _.debounce(function() { view.model.set('extent', view.esriMap.extent) }, 1000);
         dojo.connect(view.esriMap, 'onExtentChange', function(newExtent) {


### PR DESCRIPTION
This adds a scale bar to the base map.

To test:
* clone this branch, bring up the environment, and open the app
* check that the scale bar is present on the lower left, that it functions correctly, and that the expanding sidebar pushes it out such that it is always visible

Connects #776 