### PR TITLE
Remove inforgraphic in favor of in-app help

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -379,9 +379,9 @@
                         </button>
                     <% } %>
 
-                    <% if (isHelpButtonVisible) { %>
-                        <button class="button-link plugin-help i18n" data-i18n="[title]View the info-graphic" title="View the info-graphic">
-                            <i class="icon-info-circled-1"></i>
+                    <% if (hasHelp) { %>
+                        <button class="button-link plugin-help i18n" data-i18n="[title]Help" title="Help">
+                            <i class="icon-info-circled"></i>
                         </button>
                     <% } %>
 

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -46,7 +46,8 @@ require(['use!Geosite',
                         _unsafeMap: esriMap,
                         downloadAsCsv: requestCsvDownload,
                         downloadAsPlainText: requestTextDownload,
-                        dispatcher: N.app.dispatcher
+                        dispatcher: N.app.dispatcher,
+                        supressHelpOnStartup: _.partial(supressHelpOnStartup, model)
                     },
                     plugin: {
                         turnOff: model.turnOff.bind(model)
@@ -105,6 +106,12 @@ require(['use!Geosite',
             return model.get('pluginSrcFolder');
         }
 
+        // Allow the plugin to ask the framework to store and provide a
+        // flag for showing help when activating, across sessions
+        function supressHelpOnStartup(model, doSupress) {
+            model.setSupressHelpOnStartup(doSupress);
+        }
+
         /*
         Check that the plugin implements the minimal viable interface.
         Plugin code can just assume the plugin is valid if it has been loaded
@@ -127,9 +134,9 @@ require(['use!Geosite',
         N.models = N.models || {};
         N.models.Plugin = Backbone.Model.extend({
             defaults: {
+                startHelpKey: "-supress-help-start",
                 pluginObject: null,
                 active: false,
-                displayHelp: false,
                 pluginLayers: {},
                 pluginLayersVisible: true
             },
@@ -149,15 +156,16 @@ require(['use!Geosite',
                 return _.last(name(this).split('/'));
             },
 
+            // Instruct the plugin to display its in-app help
+            showHelp: function () { },
+
             onSelectedChanged: function () {
                 if (this.selected) {
-                    var active = this.get('active')
-                    if (!active && this.getShowHelpOnStartup()) {
-                        this.set('displayHelp', true);
-                    }
+                    var active = this.get('active'),
+                        supressHelpOnStart = !active && this.getSupressHelpOnStartup();
 
                     this.set('active', true);
-                    this.get('pluginObject').activate();
+                    this.get('pluginObject').activate(!supressHelpOnStart);
                 } else {
                     this.get('pluginObject').deactivate();
                     this.trigger('plugin:deselected');
@@ -248,19 +256,17 @@ require(['use!Geosite',
                 }
             },
 
-            getShowHelpOnStartup: function() {
+            getSupressHelpOnStartup: function() {
                 var pluginObject = this.get('pluginObject'),
-                    showValueKey = pluginObject.toolbarName + " showinfographic";
-                if (typeof localStorage[showValueKey] !== 'undefined') {
-                    return localStorage[showValueKey] === 'true';
-                } else {
-					return pluginObject.showInfographicOnStart;
-				}
+                    showValueKey = pluginObject.toolbarName + this.get('startHelpKey');
+
+                return !!localStorage[showValueKey];
             },
 
-            setShowHelpOnStartup: function(val) {
+            setSupressHelpOnStartup: function(val) {
                 var pluginObject = this.get('pluginObject'),
-                    showValueKey = pluginObject.toolbarName + " showinfographic";
+                    showValueKey = pluginObject.toolbarName + this.get('startHelpKey');
+
                 localStorage.setItem(showValueKey, val);
             }
         });
@@ -362,8 +368,6 @@ require(['use!Geosite',
             render(view);
             view.$el.appendTo($parent);
             createUiContainer(view, paneNumber);
-            createHelpScreen(view);
-            view.listenTo(model, 'change:displayHelp', onDisplayHelpChanged);
             N.views.BasePlugin.prototype.initialize.call(view);
         }
 
@@ -418,7 +422,7 @@ require(['use!Geosite',
                 bindings = {
                     title: pluginObject.toolbarName,
                     id: containerId,
-                    isHelpButtonVisible: isHelpButtonVisible(view),
+                    hasHelp: pluginObject.hasHelp,
                     hasCustomPrint: pluginObject.hasCustomPrint,
                     sizeClassName: getPluginSizeClassName(pluginObject.size),
                     customWidth: getCustomPluginWidth(pluginObject.size, pluginObject.width)
@@ -441,7 +445,7 @@ require(['use!Geosite',
                     model.deselect();
                 }).end()
                 .find('.plugin-help').on('click', function () {
-                    model.set('displayHelp', true);
+                    pluginObject.showHelp();
                 }).end()
                 .find('.plugin-print').on('click', function() {
                     var pluginDeferred = $.Deferred(),
@@ -562,20 +566,6 @@ require(['use!Geosite',
             }).appendTo('head');
         }
 
-        function createHelpScreen(view) {
-            var model = view.model,
-                pluginObject = model.get('pluginObject'),
-                pluginContainer = view.$uiContainer;
-
-            if (pluginObject.infoGraphic) {
-                view.helpScreen = new N.views.InfoGraphicView({
-                    model: model
-                });
-                pluginContainer.append(view.helpScreen.el);
-                view.helpScreen.$el.hide();
-            }
-        }
-
         function getPluginSizeClassName(size) {
             return 'sidebar-width-' + size;
         }
@@ -588,34 +578,9 @@ require(['use!Geosite',
             }
         }
 
-        function isHelpButtonVisible(view) {
-            var model = view.model,
-                pluginObject = model.get('pluginObject');
-            return typeof pluginObject.infoGraphic !== 'undefined';
-        }
-
-        function onDisplayHelpChanged() {
-            var view = this,
-                model = view.model,
-                pluginObject = model.get('pluginObject'),
-                $uiContainer = view.$uiContainer,
-                $mainPanel = $uiContainer.find('.sidebar-content'),
-                showInfoGraphic = !!model.get('displayHelp');
-
-            if (!view.helpScreen) {
-                return;
-            }
-
-            if (showInfoGraphic) {
-                view.helpScreen.$el.show();
-                $mainPanel.hide();
-            } else {
-                view.helpScreen.$el.hide();
-                $mainPanel.show();
-            }
-
-            var primaryContainerVisible = !showInfoGraphic;
-            pluginObject.onContainerVisibilityChanged(primaryContainerVisible);
+        function hasHelp(view) {
+            var pluginObj = view.model.get('pluginObject');
+            return pluginObj.hasHelp;
         }
 
         N.views = N.views || {};
@@ -632,68 +597,6 @@ require(['use!Geosite',
 
             render: function() {
                 return render(this);
-            }
-        });
-    }());
-
-    (function infoGraphicView() {
-        N.views = N.views || {};
-        N.views.InfoGraphicView = Backbone.View.extend({
-            tagName: 'div',
-            className: 'claro plugin-infographic',
-
-            initialize: function() {
-                this.render();
-            },
-
-            render: function() {
-                var pluginModel = this.model,
-                    pluginObject = pluginModel.get('pluginObject'),
-                    snippit;
-
-                if (pluginObject.infoGraphic.slice(pluginObject.infoGraphic.length - 4, pluginObject.infoGraphic.length) == ".jpg" || pluginObject.infoGraphic.slice(pluginObject.infoGraphic.length - 4, pluginObject.infoGraphic.length) == ".png") {
-                    snippit = $('<img class="graphic" />').attr('src', pluginObject.infoGraphic);
-                } else {
-                    snippit = $(pluginObject.infoGraphic);
-                }
-
-                this.$el.append(snippit);
-
-                var checkboxnode = $('<span>').get(0);
-                this.$el.append(checkboxnode);
-
-                var nscheckBox = new CheckBox({
-                    name: "checkBox",
-                    checked: !pluginModel.getShowHelpOnStartup(),
-                    onChange: function(show) {
-                        pluginModel.setShowHelpOnStartup(!show);
-                    }
-                }, checkboxnode);
-
-                var lbl = $("<label>Don't show this on start</label>")
-                    .addClass('i18n')
-                    .attr({
-                        'for': nscheckBox.id,
-                        'data-i18n': "Don't show this on start"
-                    });
-
-                this.$el.append(lbl);
-
-                var buttonnode = $('<div>').addClass('sidebar-button-bottom').get(0);
-                this.$el.append(buttonnode);
-
-                $('<button>')
-                    .text('Get started')
-                    .attr('data-i18n', 'Get started')
-                    .addClass('button button-primary radius i18n')
-                    .click(function() {
-                        pluginModel.set('displayHelp', false);
-                    })
-                    .appendTo(buttonnode);
-
-                if ($.i18n) {
-                    $(this.$el).localize();
-                }
             }
         });
     }());

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -161,11 +161,8 @@ require(['use!Geosite',
 
             onSelectedChanged: function () {
                 if (this.selected) {
-                    var active = this.get('active'),
-                        supressHelpOnStart = !active && this.getSupressHelpOnStartup();
-
                     this.set('active', true);
-                    this.get('pluginObject').activate(!supressHelpOnStart);
+                    this.get('pluginObject').activate(!this.getSuppressHelpOnStartup());
                 } else {
                     this.get('pluginObject').deactivate();
                     this.trigger('plugin:deselected');

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -47,7 +47,7 @@ require(['use!Geosite',
                         downloadAsCsv: requestCsvDownload,
                         downloadAsPlainText: requestTextDownload,
                         dispatcher: N.app.dispatcher,
-                        supressHelpOnStartup: _.partial(supressHelpOnStartup, model)
+                        suppressHelpOnStartup: _.partial(suppressHelpOnStartup, model)
                     },
                     plugin: {
                         turnOff: model.turnOff.bind(model)
@@ -108,8 +108,8 @@ require(['use!Geosite',
 
         // Allow the plugin to ask the framework to store and provide a
         // flag for showing help when activating, across sessions
-        function supressHelpOnStartup(model, doSupress) {
-            model.setSupressHelpOnStartup(doSupress);
+        function suppressHelpOnStartup(model, doSuppress) {
+            model.setSuppressHelpOnStartup(doSuppress);
         }
 
         /*
@@ -134,7 +134,7 @@ require(['use!Geosite',
         N.models = N.models || {};
         N.models.Plugin = Backbone.Model.extend({
             defaults: {
-                startHelpKey: "-supress-help-start",
+                startHelpKey: "-suppress-help-start",
                 pluginObject: null,
                 active: false,
                 pluginLayers: {},
@@ -253,14 +253,14 @@ require(['use!Geosite',
                 }
             },
 
-            getSupressHelpOnStartup: function() {
+            getSuppressHelpOnStartup: function() {
                 var pluginObject = this.get('pluginObject'),
                     showValueKey = pluginObject.toolbarName + this.get('startHelpKey');
 
                 return !!localStorage[showValueKey];
             },
 
-            setSupressHelpOnStartup: function(val) {
+            setSuppressHelpOnStartup: function(val) {
                 var pluginObject = this.get('pluginObject'),
                     showValueKey = pluginObject.toolbarName + this.get('startHelpKey');
 

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -29,7 +29,8 @@ define(["dojo/_base/declare",
             toolbarType: "sidebar",
             showServiceLayersInLegend: true,
             allowIdentifyWhenActive: false,
-            showInfographicOnStart: false,
+            hasHelp: false,
+
             // Allow the framework to put a custom print button for this plugin
             hasCustomPrint: false,
 

--- a/src/GeositeFramework/plugins/launchpad/main.js
+++ b/src/GeositeFramework/plugins/launchpad/main.js
@@ -29,7 +29,6 @@ define([
             size: overrides.size || 'small',
             width: overrides.width || 300,
             hasCustomPrint: false,
-            infoGraphic: undefined,
             toolbarType: "sidebar",
             allowIdentifyWhenActive: true,
 

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -24,12 +24,12 @@ define(["dojo/_base/declare", "framework/PluginBase"],
                 // Example of how a plugin could show help on startup, but
                 // only the first time a user opens the plugin:
 
-                // Show the help on activation, if it has not been supressed
+                // Show the help on activation, if it has not been suppressed
                 if (showHelpOnStart) {
                     this.showHelp();
 
                     // Don't show this help on startup anymore, after the first time 
-                    this.app.supressHelpOnStartup(true);
+                    this.app.suppressHelpOnStartup(true);
                 }
             },
 

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -4,15 +4,12 @@ define(["dojo/_base/declare", "framework/PluginBase"],
         return declare(PluginBase, {
             toolbarName: "Identify Point",
             fullName: "Identify point sample plugin",
-            infoGraphic: "sample_plugins/identify_point/splash.png",
+            hasHelp: true,
             allowIdentifyWhenActive: true,
-            resizable: false,
-            width: 320,
-            height: 'auto',
+            size: 'small',
             hasCustomPrint: true,
             usePrintPreviewMap: true,
             previewMapSize: [500, 350],
-            icon: 'info-2',
 
             initialize: function(args) {
                 declare.safeMixin(this, args);
@@ -21,6 +18,19 @@ define(["dojo/_base/declare", "framework/PluginBase"],
 
                 // Hide the print button until the identify feature has been used.
                 $(this.printButton).hide();
+            },
+
+            activate: function(showHelpOnStart) {
+                // Example of how a plugin could show help on startup, but
+                // only the first time a user opens the plugin:
+
+                // Show the help on activation, if it has not been supressed
+                if (showHelpOnStart) {
+                    this.showHelp();
+
+                    // Don't show this help on startup anymore, after the first time 
+                    this.app.supressHelpOnStartup(true);
+                }
             },
 
             identify: function(mapPoint, clickPoint, processResults) {
@@ -43,6 +53,27 @@ define(["dojo/_base/declare", "framework/PluginBase"],
                 $printArea.append('<img id="sample-graphic-print" src="' + this.infoGraphic + '" >');
 
                 printDeferred.resolve();
+            },
+
+            showHelp: function() {
+                // Show a generic help and dismissal button
+                var self = this;
+                if (self.$helpMsg) {
+                    self.$helpMsg.remove();
+                }
+
+                self.$helpMsg = $("<div>Help: Click the map to see the point </div>");
+
+                $("<a>", {
+                    className: "button",
+                    href: '#',
+                    text: "Got it",
+                    click: function() {
+                        self.$helpMsg.remove();
+                    }
+                }).appendTo(self.$helpMsg);
+
+                $(this.container).append(self.$helpMsg);
             }
         });
     }


### PR DESCRIPTION
#### Overview
Plugins can register with the framework to acknowledge that there is
in-app help functionality available.  The framework handles the UI of
showing the help icon in the header and for managing the state of "show on
start" via local storage.  Its intended purpose is to allow plugins to
manage their own help functionality and move away from the exising
infographic approach.

The details of the approach should match the associated issue, which is descriptive

Connects #782 

#### Testing
* Load the Itendify Point plugin, verify that help is shown.
* Dismiss the in-app help, and click the `i` info button in the header, verify help is shown again (dismiss)
* Close plugin and re-open, verify that the help is not shown
* Refresh the page and do the same.

The goal is to allow the plugin to handle some in app instruction, with a light UI mechanism from the framework and the ability to manage whether the app shows help upon activation.  It's meant to be flexible, and the above is just one workflow that could accommodate it.