### PR TITLE
Fix undefined function

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -49,7 +49,7 @@ require(['use!Geosite',
                         dispatcher: N.app.dispatcher
                     },
                     plugin: {
-                        turnOff: model.turnOff.bind(model)
+                        turnOff: _.bind(model.turnOff, model)
                     },
                     map: N.createMapWrapper(esriMap, mapModel, pluginObject),
                     container: ($uiContainer ? $uiContainer.find('.sidebar-content')[0] : undefined),


### PR DESCRIPTION
`Function.prototype.bind` is undefined on Chrome and Safari on iPad.

Connects #771 