### PR TITLE
Print fixups

### DIFF
--- a/src/GeositeFramework/css/app-print.css
+++ b/src/GeositeFramework/css/app-print.css
@@ -5,10 +5,6 @@
         text-align: center;
     }
 
-    .esriScalebar {
-        visibility: hidden;
-    }
-
     .print-sandbox-header {
         display: flex;
         flex-direction: row;
@@ -94,14 +90,6 @@
         display: none;
     }
 
-    .esriAttributionLastItem {
-        display: none !important;
-    }
-
-    .logo-med {
-        display: none !important;
-    }
-    
     .legend-header {
         height: 15%;
         font-size: 11px;
@@ -138,6 +126,10 @@
     .print-legend-coll {
         display: flex !important;
         flex-direction: column;
+        flex-wrap: wrap;
+        height: 60px;
+        align-content: stretch;
+        justify-content: center;
     }
 
     .legend-layer img {
@@ -218,10 +210,6 @@
     height: 0.95in;
 }
 
-.esriScalebar {
-    visibility: hidden;
-}
-    
 #print-map-container {
     overflow: hidden !important;
 }

--- a/src/GeositeFramework/css/print-landscape.css
+++ b/src/GeositeFramework/css/print-landscape.css
@@ -22,6 +22,14 @@
         top: 80% !important;
         height: 20% !important;
     }
+
+    .above-legend {
+        bottom: 21% !important;
+    }
+
+    .page-bottom {
+        bottom: 1% !important;
+    }
 }
 
 #map-print-sandbox {

--- a/src/GeositeFramework/css/print-portrait.css
+++ b/src/GeositeFramework/css/print-portrait.css
@@ -22,6 +22,14 @@
         top: 75% !important;
         height: 25% !important;
     }
+
+    .above-legend {
+        bottom: 26% !important;
+    }
+
+    .page-bottom {
+        bottom: 1% !important;
+    }
 }
 
 #map-print-sandbox {


### PR DESCRIPTION
This fixes a bug that resulted in the map scalebar and the attribution elements being obscured by the legend.

To test:
* clone this branch and open the app
* print a basic, unmodified map both with and without the legend, and check that the scalebar and the attribution are at the bottom of the page
* add layers that cause the legend to appear, then print with and without legend and check that the scalebar and attribution element move appropriately
* repeat last 2 steps for landscape/portrait layouts, in targeted browsers

Connects #790 