### PR TITLE
Allow custom launchpad content

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -175,9 +175,11 @@
             "properties": {
                 "type": "object",
                 "properties": {
-                    "title": { "type": "string", "required": true },
-                    "description": { "type": "string", "required": true },
+                    "html": { "type": "bool", "required": false },
+                    "title": { "type": "string", "required": false },
+                    "description": { "type": "string", "required": false },
                     "plugins": {
+                        "required": false,
                         "type": "array",
                         "items": {
                             "type": "object",
@@ -189,6 +191,7 @@
                         }
                     },
                     "scenarios": {
+                        "required": false,
                         "type": "array",
                         "items": {
                             "type": "object",
@@ -196,6 +199,18 @@
                                 "title": { "type": "string", "required": true },
                                 "description": { "type": "string", "required": true },
                                 "saveCode": { "type": "string", "required": true },
+                            }
+                        }
+                    },
+                    "partners": {
+                        "type": "array",
+                        "required": false,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "logoPath": { "type": "string", "required": true },
+                                "link": { "type": "string", "required": true },
+                                "title": { "type": "string", "required": true }
                             }
                         }
                     }
@@ -221,18 +236,6 @@
                 },
             },
             "additionalProperties": false
-        },
-        "partners": {
-            "type": "array",
-            "required": false,
-            "items": {
-                "type": "object",
-                "properties": {
-                    "logoPath": { "type": "string", "required": true },
-                    "link": { "type": "string", "required": true },
-                    "title": { "type": "string", "required": true }
-                }
-            }
         }
     },
     "additionalProperties": false

--- a/src/GeositeFramework/GeositeFramework.csproj
+++ b/src/GeositeFramework/GeositeFramework.csproj
@@ -273,6 +273,9 @@
     <Content Include="plugins\launchpad\plugin.json" />
     <Content Include="plugins\launchpad\README.md" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Shared\CustomLaunchPadContent.cshtml" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -615,6 +615,12 @@
 
     @Html.Partial("TourInfo")
 
+    <!-- If a view is provided (overwritten via the region repo), a user can
+        change the region setting `launchpad.html = true` to use this content -->
+    <div id="custom-launchpad-content" style="display:none;">
+        @Html.Partial("CustomLaunchpadContent")
+    </div>
+
     <!-- Area for plugins to arrange their markup independent
         of their container -->
     <div id="plugin-print-sandbox"></div>

--- a/src/GeositeFramework/Views/Shared/CustomLaunchPadContent.cshtml
+++ b/src/GeositeFramework/Views/Shared/CustomLaunchPadContent.cshtml
@@ -1,0 +1,5 @@
+﻿<h2>Custom Launchpad</h2>
+<div>
+    This shows how it is possible to include custom launchpad markup.
+</div>
+<img src="http://placehold.it/300x150">

--- a/src/GeositeFramework/plugins/launchpad/main.js
+++ b/src/GeositeFramework/plugins/launchpad/main.js
@@ -87,13 +87,17 @@ define([
                 self.plugin.turnOff();
             },
 
-            render: function () {
+            render: function() {
+                var config = N.app.data.region.launchpad,
+                    snippetSelector = '#custom-launchpad-content';
+
                 var $el = $(this.pluginTmpl({
-                    title: N.app.data.region.launchpad.title,
-                    description: N.app.data.region.launchpad.description,
-                    plugins: N.app.data.region.launchpad.plugins,
-                    scenarios: N.app.data.region.launchpad.scenarios,
-                    partners: N.app.data.region.partners,
+                    htmlSnippet: config.html ? $(snippetSelector).html() : null,
+                    title: config.title,
+                    description: config.description,
+                    plugins: config.plugins,
+                    scenarios: config.scenarios,
+                    partners: config.partners,
                     uiState: this.uiState,
                 }));
 

--- a/src/GeositeFramework/plugins/launchpad/main.js
+++ b/src/GeositeFramework/plugins/launchpad/main.js
@@ -67,16 +67,16 @@ define([
                     function(p) {
                         self.uiState['plugin-' + p.pluginName] = {
                             showToggle: p.description.length > 140,
-                            textTruncated: p.description.length > 140,
-                        }
+                            textTruncated: p.description.length > 140
+                        };
                     },
                     this);
                 _.each(N.app.data.region.launchpad.scenarios,
                     function(p) {
                         self.uiState['scenario-' + p.saveCode] = {
                             showToggle: p.description.length > 140,
-                            textTruncated: p.description.length > 140,
-                        }
+                            textTruncated: p.description.length > 140
+                        };
                     },
                     this);
                 this.render();

--- a/src/GeositeFramework/plugins/launchpad/templates.html
+++ b/src/GeositeFramework/plugins/launchpad/templates.html
@@ -1,7 +1,15 @@
 <script type="text/template" id="plugin">
     <div class="launchpad-plugin">
-        <h2><%= title %></h2>
-        <p><%= description %></p>
+        <% if (htmlSnippet) { %>
+            <div>
+            <%= htmlSnippet %>
+            </div>
+        <% } else { %>
+            <h2><%= title %></h2>
+            <p><%= description %></p>
+        <% } %>
+
+        <% if (plugins) { %>
         <h3>Start exploring</h3>
         <div class="plugins">
             <ul>
@@ -26,6 +34,9 @@
             <% }); %>
             </ul>
         </div>
+        <% } %>
+
+        <% if (scenarios) { %>
         <h3>One-click maps</h3>
         <div class="scenarios">
             <ul>
@@ -50,6 +61,9 @@
             <% }); %>
             </ul>
         </div>
+        <% } %>
+
+        <% if (partners) { %>
         <h3>Partners</h3>
         <div class="partners">
             <ul>
@@ -62,5 +76,6 @@
             <% }); %>
             </ul>
         </div>
+        <% } %>
     </div>
 </script>

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -98,6 +98,7 @@
     "identifyBlacklist": ["OBJECTID", "OBJECTID_1"],
     "identifyEnabled": true,
     "launchpad": {
+        "html": false,
         "title": "Explore coastal resilience issues",
         "description": "Coastal resilience is Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed urna diam, sodales et nibh at, aliquet bibendum erat. Nunc mattis in erat id luctus. Mauris aliquam scelerisque dui.",
         "plugins": [
@@ -118,6 +119,28 @@
                 "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                 "saveCode": "eyJtYXAwIjrEgGV4dGVudMSGxIB0eXBlxIYixInEi8SNIiwieG1pbsSGLTEwMjA0OTU0Ljc3MjI5NzEyxJt5xJ7EoDozMTEzNTM5LsSyMTQ0NjUxOcSbxJ1heMShOTIzxKU2xKoyNzYyODPFgzXEtMSCxYzEuDYzNsSwxL84OcS6NDMzN8SwxJtzcGF0aWFsUmVmZXLEjGPElMSHIndraWTEhsSjMsSjMMSbbMWwZXN0V8aAxoLEuDg1N33Em1/Fr3J0c8SGW8SIxIrEjMSOxb3EkcSTxJXEl8agxJrEnMS2xKHGhMSmxKjEqsSsxK7EsMSyxZzEn8SGxLnEu8S9xL/FgcWDxYXFh8WJxZ3FjcWPxZHFk8WVxZfFmTTFmyLEtcWLxrbFoMWixasuxaXFp8Wpxas3xa3Fr8WxxbPFtcW3xbluxbvEj8W+xo/Gg8SkxobGiMaKxozGjsaBxrbGksaUxpUiZnJhbWVJZMabOlswXX3Hu8WtZWxlY8SLZEJhc2XEgnBJbmTEicSGNMeuxa9uZcSFxb3IkmVOdW1ixbjEhsaHIsaMxopPZlBsdWfEn8e3xIDIh8iAyIJlZMilyKfGtToicMimyKhucy/GiXnFuF/IrMiBdG9yxqhhyIJpdmVTdWLFuciob8S3xIDHqsi0dGhlLW/Fu2HEoMSbZGnFrsi8xJVTb8ezd8mWxbkgxJ8gyZVlIMmZZcmbxqjIjXRhaWzHtyJNb8aMbHkgd8aKyYTFrWjEg8W8W1stODguxZc2xLvFl8SyxZvFlC7Fg8WjMMWQxLA4NMaFNF0syog4Ni7EvDLGuTDFlsqSyoswxLE5OMqXMDHErMqtNsqeyqA1yozKpsqoLMqTxK0yxag1xabFpTfFmTPKtcqJyrfGuTU1yqs4ypHKu8qiyq7GvMqrNsWFxYQxyrTKn8qJN8qUxKjEusSxODfKksqiMDnKqMSnyqfLpcaSy4XLmcqKxKs0y6E1xpI5xarLosqMy7M0McuLxKYyxYXErMuGy63KjcqPy43Kpcq7y5vKlcWrypfErzfKmsqcXcqeIm5vRsm2bMSGdHJ1ZcSbb3V0bMSfZUNvbMmDxJUjMMyoMEZGIsiRyLfIqcegyLbIssi5yLthyL1yyL/Hv8mBzKXFvXJvb3QvR8WzyYnGjMmQIEzJmcWzL0HGiWLHsmExx6Bvxa9jacSRyJ7Eq8SbY8mWY2vIr8SGZsWzyIfHrsmJcnNpyZDElTHFgMaozL7NgC9UyZYgT8mabs2IzYpsICYgTcm1bs2MzY7NkM2Sxb3NlMmGzZd5zZnHliLNnMiBzZ/GkM2iybdlx67Nr82BzY1hzY/Egs6BzpjOg82TzZXOiM6KzZvNnc6PzaHNo86TxJvOlc6bzplhzqrNkMWZNTbMi86ezofNmDowzZrOjM6jzaA6zpHNpM6ozL/Ols6CzprOl86rxKPOs82WzrXOt86Lzo3Nns67zJfMmcSbdsmfaWLIgEzMtsW4x7XHt1vEo8e9Is6pz4TNkM6txILFgTPPh86gzrbOuM+MzqQ6z4/MmiLPks2oz5Vlz5fMt8+axpzEu8+ez6DPgs6sz6HPpMWGNs+nz4nPqs66zpDOps6Uz4DPo8+9z7wxy43FjsekxK7HgjTQgs6Jz6nPi9CFzqXOkn3Qm8euyYbFscmJyYvJjWXJj8mRIsmTIsmsyZjNtsmyyZ/Itsy2yaLJpGXJpsW4ya3Jqsmsya7Qq8mdZcm0ybbJuMm6ybzJvsqAxIvKgsigyoTGpMe4yqDKi8yBxZDMg8qSzIbEp8yIypjMi8qbxYLLv8qiyqTKucyExZcuyqvFh8quM8qwyrLKocu/yrfKpcS+yqfRmsubyr3Kv8uBxLDLhNGkLsuJy4vMi8uOy7zHkcSmxYTLk8uVyo7LmMqgzIbLncqx0I3LocuP0ZzLpcqly6fFojbLqsu/yos3y6/Lisuyy7TShMSvxZnLucyoypvLvTfSjMqMyqHMgtG10Y/KltGSzIzRlcyPzJHMk2zMlc+tzJjPr8yczJ7MoMyizKTJhMi0zKfMqcyrzK3Qmw==",
             }
+        ],
+        "partners": [
+            {
+                "logoPath": "http://www.naturalcapitalproject.org/wp-content/uploads/2015/05/logo-ls-lined-up.jpg",
+                "link": "http://www.naturalcapitalproject.org/",
+                "title": "Natural Capital Project",
+            },
+            {
+                "logoPath": "https://coast.noaa.gov/assets/logos/noaa-badge-full-color-no-outertext.svg",
+                "link": "https://coast.noaa.gov/digitalcoast/",
+                "title": "NOAA Digital Coast",
+            },
+            {
+                "logoPath": "https://www.fws.gov/home/graphics/logo.png",
+                "link": "https://www.fws.gov/",
+                "title": "U.S. Fish and Wildlife Surface",
+            },
+            {
+                "logoPath": "https://www.usm.edu/sites/default/files/groups/office-university-communications/images/univc123pc_0.png",
+                "link": "https://www.usm.edu/",
+                "title": "University of Southern Mississippi",
+            }
         ]
     },
     "legend": {
@@ -129,26 +152,4 @@
             }
         ]
     },
-    "partners": [
-        {
-            "logoPath": "http://www.naturalcapitalproject.org/wp-content/uploads/2015/05/logo-ls-lined-up.jpg",
-            "link": "http://www.naturalcapitalproject.org/",
-            "title": "Natural Capital Project",
-        },
-        {
-            "logoPath": "https://coast.noaa.gov/assets/logos/noaa-badge-full-color-no-outertext.svg",
-            "link": "https://coast.noaa.gov/digitalcoast/",
-            "title": "NOAA Digital Coast",
-        },
-        {
-            "logoPath": "https://www.fws.gov/home/graphics/logo.png",
-            "link": "https://www.fws.gov/",
-            "title": "U.S. Fish and Wildlife Surface",
-        },
-        {
-            "logoPath": "https://www.usm.edu/sites/default/files/groups/office-university-communications/images/univc123pc_0.png",
-            "link": "https://www.usm.edu/",
-            "title": "University of Southern Mississippi",
-        },
-    ]
 }


### PR DESCRIPTION
#### Overview
Makes region.json configurable items optional and unrendered if not present.  If `html` is set to true, it will load the content from a shared View file, which can be replaced in an instance of a region repo.

The intended workflow is described in detail in the connected issue.

Connects #781 

#### Testing
** When modifying the the region.json file, it is necessary to kill the web server process which has cached the contents.  This can be accomplished by altering and saving the web.config file, or by terminating and relaunching the process

* Launchpad in its default state is unchanged
* Enabling `html: true` in region config loads the custom HTML content and does not render title/desc.
* Removing partners, scenarios or plugins keys results in no errors and those sections not loaded