### PR TITLE
Add resize method to plugin

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -32,7 +32,36 @@ require(['use!Geosite',
                 pluginName = model.get('pluginSrcFolder'),
                 $uiContainer = model.get('$uiContainer'),
                 $legendContainer = model.get('$legendContainer'),
-                logger = new Logger(pluginName);
+                logger = new Logger(pluginName),
+                resizers = {
+                    setWidth: function(val) {
+                        var d = $.Deferred(),
+                            setter = function(w) {
+                                return function() {
+                                    $uiContainer.css({ width: "" });
+                                    $uiContainer.removeClass(function() {
+                                        var classes = this.className.split(" ");
+                                        return _.filter(classes, function(c) {
+                                            return /sidebar-width-.*/.test(c);
+                                        }).join(" ");
+                                    });
+                                    $uiContainer.addClass("sidebar-width-" + w);
+                                };
+                            };
+                        _.delay(function() {
+                            if (typeof val === "string") {
+                                d.then(setter(val));
+                            } else if (typeof val === "number") {
+                                d.then(function() {
+                                    $uiContainer.css({ width: val });
+                                });
+                            }
+                            d.resolve();
+                            esriMap.resize(true);
+                        }, 100);
+                        return d.promise();
+                    }
+                };
 
             try {
                 pluginObject.initialize({
@@ -47,7 +76,8 @@ require(['use!Geosite',
                         downloadAsCsv: requestCsvDownload,
                         downloadAsPlainText: requestTextDownload,
                         dispatcher: N.app.dispatcher,
-                        suppressHelpOnStartup: _.partial(suppressHelpOnStartup, model)
+                        suppressHelpOnStartup: _.partial(suppressHelpOnStartup, model),
+                        resize: resizers
                     },
                     plugin: {
                         turnOff: model.turnOff.bind(model)

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -16,6 +16,13 @@ define(["dojo/_base/declare", "framework/PluginBase"],
                 $(this.container).append(
                     '<h4 style="padding: 5px;">' + i18next.t('Click any point on the map to display Latitude and Longitude') + '</h4>');
 
+                // add buttons to bind resize events to
+                $(this.container).append('<p>The buttons below demonstrate how to use a plugins "resize" method</p>')
+                    .append('<button class="resize-btn" data-ui-key="resize-ctl-identify-set450">Set to 450</button>')
+                    .append('<button class="resize-btn" data-ui-key="resize-ctl-identify-small">Small</button>')
+                    .append('<button class="resize-btn" data-ui-key="resize-ctl-identify-large">Large</button>')
+                    .append('<p class="width-textbox"></p>');
+
                 // Hide the print button until the identify feature has been used.
                 $(this.printButton).hide();
             },
@@ -31,6 +38,28 @@ define(["dojo/_base/declare", "framework/PluginBase"],
                     // Don't show this help on startup anymore, after the first time 
                     this.app.suppressHelpOnStartup(true);
                 }
+
+                // attach resize events to sample controls, attach actions to jQuery deferred
+                var self = this;
+                _.each($(self.container).find("button.resize-btn"), function (el) {
+                    switch ($(el).data("ui-key")) {
+                        case "resize-ctl-identify-set450":
+                            $(el).on("click", function() {
+                                self.app.resize.setWidth(450).then($(".width-textbox").text("Width is now 450"));
+                            });
+                            break;
+                        case "resize-ctl-identify-large":
+                            $(el).on("click", function() {
+                                self.app.resize.setWidth("large").then($(".width-textbox").text("Width is now large"));
+                            });
+                            break;
+                        case "resize-ctl-identify-small":
+                            $(el).on("click", function() {
+                                self.app.resize.setWidth("small").then($(".width-textbox").text("Width is now small"));
+                            });
+                            break;
+                    }
+                });
             },
 
             identify: function(mapPoint, clickPoint, processResults) {


### PR DESCRIPTION
This adds a couple resize methods to the plugin object. As mentioned in the original issue, these return `Deferred` objects.

To test:
* clone this branch
* try invoking the resize methods on plugins, checking that the sidebar width changes as expected,  persists when the plugin is closed or asleep, and that other actions can be chained to the deferred object.

I did the following to test this locally -->
* add the following to `main.js` of the sample identifiy plugin starting after line 34:
``` javascript
var self = this;
var d = this.app.resize.setWidth("large");
d.then(function() { $(self.container).css({ color: "white", background: "black" }); });
d.resolve();
```
That should execute an action when you click on a point on the map to identify it, that will make the plugin sidebar wider and change its colors.

Connects #788