### PR TITLE
Add ability to specify an Active App highlight color

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -156,7 +156,8 @@
             "properties": {
                 "primary": {"type": "string", "required": true},
                 "secondary": {"type": "string", "required": true},
-                "tertiary": {"type": "string", "required": true}
+                "tertiary": {"type": "string", "required": true},
+                "active": {"type": "string", "required": true}
             },
             "required": false,
             "additionalProperties": false

--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -19,6 +19,7 @@ namespace GeositeFramework.Models
         private readonly Color _defaultPrimary = ColorTranslator.FromHtml("#0f1c27");
         private readonly Color _defaultSecondary = ColorTranslator.FromHtml("#3bb3be");
         private readonly Color _defaultTertiary = ColorTranslator.FromHtml("#27343e");
+        private readonly Color _defaultActiveApp = ColorTranslator.FromHtml("#27343e");
 
         public class Link
         {
@@ -57,6 +58,7 @@ namespace GeositeFramework.Models
         public String PrimaryColor { get; private set; }
         public String SecondaryColor { get; private set; }
         public String TertiaryColor { get; private set; }
+        public String ActiveAppColor { get; private set; }
         public String PrintHeaderLogo { get; private set; }
 
         /// <summary>
@@ -133,13 +135,16 @@ namespace GeositeFramework.Models
             {
                 PrimaryColor = ExtractColorFromJson(colorConfig, "primary");
                 SecondaryColor = ExtractColorFromJson(colorConfig, "secondary");
+                ActiveAppColor = ExtractColorFromJson(colorConfig, "active");
                 TertiaryColor = ExtractColorFromJson(colorConfig, "tertiary");
             }
             else
             {
                 PrimaryColor = ColorTranslator.ToHtml(_defaultPrimary);
                 SecondaryColor = ColorTranslator.ToHtml(_defaultSecondary);
+                ActiveAppColor = ColorTranslator.ToHtml(_defaultActiveApp);
                 TertiaryColor = ColorTranslator.ToHtml(_defaultTertiary);
+
             }
 
             var printConfig = jsonObj["print"];

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -101,6 +101,10 @@
             background-color: @Model.TertiaryColor;
         }
 
+        .nav-apps-button.active.app-displayed {
+            background-color: @Model.ActiveAppColor;
+        }
+
         .color-primary,
         .button,
         .alert-primary {

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -93,7 +93,8 @@
     "colors": {
         "primary": "#29658C",
         "secondary": "#3BBDC2",
-        "tertiary": "#333"
+        "tertiary": "#333",
+        "active": "#3b91be"
     },
     "identifyBlacklist": ["OBJECTID", "OBJECTID_1"],
     "identifyEnabled": true,


### PR DESCRIPTION
This color is used on the side bar to distinguish between apps that are
"running" in the background from that which is currently open.

The color chosen here in our sample is arbitrary

![screenshot from 2016-12-22 14 10 36](https://cloud.githubusercontent.com/assets/1014341/21437223/9dba603c-c850-11e6-986a-e2dddcca15a1.png)

As a side note, I don't think the existing color names ("tertiary", etc) are very helpful, but the API is essentially released by now, so I added a more meaningful name to this new property rather than _quaternary_.


Connects #792 

#### Testing
Change the hex color provided by region.json `colors.active` and confirm it is used to style open plugins.  The region data is cached, so you'll need to bounce your app server or modify web.config