### PR TITLE
Make plugin sidebar-nav buttons clickable in IE11

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -914,7 +914,8 @@ nav {
 .sidebar-nav,
 .sidebar-with-nav-vertical {
     display: -ms-flexbox;
-    display: flex
+    display: flex;
+    z-index: 2005;
 }
 .sidebar-nav {
     width: inherit;


### PR DESCRIPTION
## Overview

This PR fixes a bug whereby the sidebar header buttons weren't clickable in IE-11. The issue was that the `.sidebar` class was rendering above the `.sidebar-nav` class, as the former had z-index 2000 and the latter didn't have a z-index value set. In Chrome the `mouseover` and `click` events seem to pass through regardless, but in IE 11 the element didn't receive any events even though it remained visible.

We fix it by adding a `z-index: 2005` rule to the `.sidebar-nav` class, which places it the header above the sidebar.

## Testing
 * rebuild this branch in VS, view it in Chrome, and when the "Getting Started" sidebar opens, verify that you can click the buttons in the sidebar nav header
 * view it in IE11 and verify that the nav header buttons work the same way
 * view in Firefox and verify that the nav header buttons also work there

Connects #807 