### PR TITLE
Update plugin list sidebar behavior on tablets

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -959,11 +959,6 @@ nav {
     padding-bottom: 27px;
     overflow: auto;
 }
-@media (max-width: 991px) {
-    .nav-apps {
-        width: 46px
-    }
-}
 .nav-apps-button {
     width: 100%;
     text-align: left;
@@ -995,18 +990,11 @@ nav {
 }
 
 @media (max-width: 991px) {
-    .nav-apps-button .button-text {
-        display: none
+    .nav-apps-narrow {
+        width: 46px;
     }
-    .nav-apps-button:hover .button-text {
-        display: block;
-        position: absolute;
-        left: 46px;
-        background-color: #0f1c27;
-        z-index: 200;
-        padding: 10px;
-        pointer-events: none;
-        color: #fff
+    .nav-apps-narrow .button-text {
+        display:none;
     }
     .nav-apps-button:hover .button-text:after {
         content: "";


### PR DESCRIPTION
## Overview

On viewports narrower than 991px (which included iPads in portrait mode), the prototype had shown only plugin icons along with a not-straightforward-to-dismiss tooltip pointing to the icon when one of the buttons had been tapped. 

This PR removes the tooltips altogether and updates the plugin list sidebar behavior for viewports < 991px:

- when a plugin is open and displaying content in its sidebar container, we now show only the icons in the plugin list sidebar
- when no plugins are displaying content in a sidebar container, we now show the icons and plugin titles in the sidebar

This works by toggling a CSS class on the `nav-app` class, which houses the plugin list. When plugin content is visible, `nav-app` now gets a `nav-app-narrow` class -- which is removed when no plugin content's visible. That class has rules within a `@media (max-width: 991px) {` CSS rule which hides the text for the plugin buttons.

## Screenshots

![img_0100](https://cloud.githubusercontent.com/assets/4165523/21509708/84d98446-cc59-11e6-9fd5-802e8f8e6e41.PNG)

![img_0106](https://cloud.githubusercontent.com/assets/4165523/21509713/9a6311b0-cc59-11e6-8c7c-5540c6e20940.PNG)

![img_0105](https://cloud.githubusercontent.com/assets/4165523/21509715/a67a0a44-cc59-11e6-82e3-13d879ff4dc0.PNG)

## Notes

To see selectable layers in regional-planning, make sure you've got the most recent commits from the plugin's `prototype` branch.

## Testing
- rebuild this branch in VS, then launch in the browser
- use the app as usual in your browser and verify that everything still works as before on a viewport > 990 px;
- use ngrok, iisexpress-proxy, or similar to make your version available to an iPad, then connect and check the site in both landscape and portrait mode
- in landscape mode, verify that everything still works as it did before and that the plugin buttons display the titles
- in portrait mode, verify that the plugin list sidebar now shows only icons when a plugin's content is visible, shows icons and titles when no plugin content is visible, and does not show any tooltips on taps
- try to get the plugin list sidebar out of sync with whether plugin content is visible. Do this by trying combinations of tapping a plugin to open it, selecting another one, selecting another one, closing/minimizing then reopening plugins in various sequences. Verify that the show/hide plugin titles behavior continues to work correctly.

Connects #771 