### PR TITLE
Center map-utils wrench icon on iOS Safari

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -2341,3 +2341,7 @@ body.x-body {
 .sidebar-content > h2  {
   margin-top: 1rem;
 }
+#map-utils-dropdown-button > i:before {
+  margin-left: 50%;
+  transform: translate(-50%, 0%);
+}


### PR DESCRIPTION
## Overview

This PR adds a CSS rule to center the wrench icon used on the button for the map-utils tool. Previously, the icon had appeared centered on desktop browsers, but it was off center in iOS Safari. The changes here add rules to position it 50% of the way horizontally across its parent div.

## Screenshots

*IE 11 on Windows:*
![screen shot 2016-12-28 at 10 54 22 am](https://cloud.githubusercontent.com/assets/4165523/21525593/491498b8-ccec-11e6-9994-0895330e70f0.png)

*Chrome on OS X:*
<img width="803" alt="screen shot 2016-12-28 at 10 54 34 am" src="https://cloud.githubusercontent.com/assets/4165523/21525594/4d3ca156-ccec-11e6-9b2a-2852920d8bb2.png">

*Safari on iPad:*
![img_0107](https://cloud.githubusercontent.com/assets/4165523/21525609/6e083de6-ccec-11e6-9a45-b4f538114c26.PNG)

*Safari on OS X:*
<img width="1274" alt="screen shot 2016-12-28 at 10 58 54 am" src="https://cloud.githubusercontent.com/assets/4165523/21525647/aa198aba-ccec-11e6-81c1-74796f3952eb.png">


## Notes

In addition to the browsers with screenshots above, I also checked this out in Firefox on Windows 7 -- and it worked.

## Testing
 * rebuild this branch in VS, then serve and view it in a few desktop browsers to ensure the icon's centered
 * use ngrok or iisexpress-proxy or similar to make the app available to an iPad, then visit the site and confirm that the icon's centered there, too

Connects #771 