### PR TITLE
Add `float: left` to plugin list navbar button icons

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -986,6 +986,7 @@ nav {
     font-size: 18px;
     position: relative;
     top: 1px;
+    float: left;
 }
 .nav-apps-button > .button-icon img {
     height: 20px;


### PR DESCRIPTION
## Overview

This PR adds a `float: left` rule to `.nav-apps-button>.button-icon` so that the span will render to the left of the plugin title text on the same line in Firefox.

## Screenshot

*Firefox on OS X*
<img width="729" alt="screen shot 2016-12-28 at 2 02 17 pm" src="https://cloud.githubusercontent.com/assets/4165523/21529330/9a921016-cd06-11e6-99cb-f121d46c0056.png">

## Notes

Checked this in OS X Safari, Windows IE11, and OS X Chrome -- where the icon and text were already horizontally aligned -- and they plugin icons and text remain horizontally aligned.

## Testing
 * rebuild this branch in VS, open the project in the browser and verify that the plugin icon and text are horizontally aligned
 * check in Firefox, Chrome, Safari, and IE11

Connects #809 