### PR TITLE
Set height for launchpad plugin to enable scrolling in IE and Firefox

### DIFF
--- a/src/GeositeFramework/plugins/launchpad/style.css
+++ b/src/GeositeFramework/plugins/launchpad/style.css
@@ -1,5 +1,6 @@
 .launchpad-plugin {
     padding: 10px;
+    height: calc(90vh - 60px);
 }
 .launchpad-plugin .plugins div,
 .launchpad-plugin .scenarios div {


### PR DESCRIPTION
## Overview

This PR adds a computed `height` rule to the launchpad plugin -- and makes it so that it's scrollable in Firefox and IE11.

Previously the plugin's content div was missing a `height` rule, and without it the plugin seemed to expand to fit the height of the content, which meant that the bottom of the map was also pushed off the screen while users were still unable to scroll. (Tapping the spacebar would scroll the plugin content and the entire map down, and on initially loading you wouldn't be able to see the map attributions.)

## Notes

Adding `height: calc(90vh - 60px);` to the `launchpad-plugin` class reduces the div's size such that the existing `overflow: auto` rule takes effect and compels it to scroll within the div. `60px` accounts for the `40px` margin set on the `sidebar-content` div along with the `20px` total of padding above and beneath the `launchpad-plugin`. `90vh` was picked based on what looked best in a variety of browsers.

## Testing
 * rebuild this branch in VS, then view it in the browser
 * check Chrome, IE, and Firefox at a variety of screen heights to verify that the plugin's scrollable when it should be and renders fully when the viewport's tall enough to accommodate it
 * also check that it remains scrollable on closing it, then reopening it. On initially loading, the `launchpad-plugin`'s `sidebar` div does not get the `style="display: block;"` rule used when toggling plugins visible and not, so a test should ensure that it scrolls with and without that

Connects #808 