### PR TITLE
Make search bar visible on IE 11

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1654,6 +1654,7 @@ header .nav-main {
     position: absolute;
     right: 10px;
     top: 12px;
+    z-index: 2800;
 }
 /* -----------------------------------------
    Content Area - Map


### PR DESCRIPTION
The z-index of the search bar needed to be elevated to the same level as the header that it is part of
to be visible on IE 11.

To test, check that the search bar is visible on Chrome, Firefox, and IE.

Connects #834 