### PR TITLE
Make layer info box visible

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -372,7 +372,7 @@
     </script>
 
     <script type="text/template" id="template-plugin-container">
-        <div class="sidebar <%= sizeClassName %> content-scrollable" id="<%= id %>" style="<%= customWidth %>">
+        <div class="sidebar <%= sizeClassName %> id="<%= id %>" style="<%= customWidth %>">
             <div class="sidebar-nav">
                 <h2 class="nav-title" class="i18n" data-i18n="<%- title %>">
                     <%- title %>

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -434,9 +434,7 @@ html {
     left: 0;
     overflow: hidden;
 }
-.content-scrollable {
-    overflow-y: auto
-}
+
 .container,
 .container-fluid {
     position: relative
@@ -944,7 +942,6 @@ nav {
 .sidebar-content {
     position: relative;
     height: calc(100% - 40px);
-    overflow-y: auto;
     margin-top: 40px;
     width: 100%;
 }


### PR DESCRIPTION
This PR makes the layer info box visible.

![untitled](https://cloud.githubusercontent.com/assets/1896461/21860956/e99aeb88-d800-11e6-8ea0-2d6dbd5acc9e.png)
#### Testing
* In the app, select the Region Planning plugin, and then expand elements in the layer selector until it causes a vertical scrollbar to appear. Check that the vertical scrolling behavior is the same as before, and that no horizontal scrollbar appears.
* Click the info icon on a layer and check that the info box displays and can be closed by clicking the X.

Connects #63
