### PR TITLE
Add back overflow styling to sidebar

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -372,7 +372,7 @@
     </script>
 
     <script type="text/template" id="template-plugin-container">
-        <div class="sidebar <%= sizeClassName %> id="<%= id %>" style="<%= customWidth %>">
+        <div class="sidebar <%= sizeClassName %> content-scrollable" id="<%= id %>" style="<%= customWidth %>">
             <div class="sidebar-nav">
                 <h2 class="nav-title" class="i18n" data-i18n="<%- title %>">
                     <%- title %>

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -435,6 +435,10 @@ html {
     overflow: hidden;
 }
 
+.content-scrollable {
+    overflow-y: auto;
+}
+
 .container,
 .container-fluid {
     position: relative
@@ -942,6 +946,7 @@ nav {
 .sidebar-content {
     position: relative;
     height: calc(100% - 40px);
+    overflow-y: auto;
     margin-top: 40px;
     width: 100%;
 }
@@ -2336,6 +2341,7 @@ body.x-body {
 .sidebar-content > h2  {
   margin-top: 1rem;
 }
+
 #map-utils-dropdown-button > i:before {
   margin-left: 50%;
   transform: translate(-50%, 0%);


### PR DESCRIPTION
A previous PR https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/838 changed the overflow styling to make the Regional Planning info box visible. Unfortunately, it broke the scrolling on the Launchpad, so we undo that PR in this commit. 

#### Testing
* Check that you can scroll in the Launchpad and Regional Planning plugins when there is overflow, on Chrome, Firefox, and IE11.

Connects #808 