### PR TITLE
Store only data key in service response cache

### DIFF
--- a/src/GeositeFramework/js/util/ajax.js
+++ b/src/GeositeFramework/js/util/ajax.js
@@ -25,7 +25,7 @@ define(['esri/request'],
                     callbackParamName: 'callback',
                     timeout: 20000
                 }).then(function(data) {
-                    cache[url] = data;
+                    cache[url] = data.data;
                 }, function(error) {
                     cache[url] = error;
                 }).then(function() {


### PR DESCRIPTION
In the new version of the ESRI JS API, the service data is now stored under the data key in the map service info response.

**Testing**
- Test with https://github.com/CoastalResilienceNetwork/regional-planning/pull/78

Refs #845