### PR TITLE
Turn off an active plugin on selecting a new plugin

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -502,10 +502,6 @@ require(['use!Geosite',
                 .find('.plugin-off').on('click', function () {
                     model.turnOff();
                 }).end()
-                // Unselect the plugin, but keep active
-                .find('.plugin-close').on('click', function () {
-                    model.deselect();
-                }).end()
                 .find('.plugin-help').on('click', function () {
                     pluginObject.showHelp();
                 }).end()

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -199,11 +199,15 @@ require(['use!Geosite',
                     this.get('pluginObject').deactivate();
                     this.set('visible', false);
                     this.trigger('plugin:deselected');
-                    // Remove the `.nav-apps-narow` class if the
-                    // de-selecting the plugin has left no plugins
-                    // visible.
                     if (this.collection.all({visible:false})) {
+                        // Remove the `.nav-apps-narow` class if the
+                        // de-selecting the plugin has left no plugins
+                        // visible.
                         $('.nav-apps').removeClass('nav-apps-narrow');
+                    } else {
+                        // Turn off the plugin if another plugin has been selected
+                        // and it hasn't been minimized.
+                        this.get('pluginObject').plugin.turnOff();
                     }
                 }
             },


### PR DESCRIPTION
## Overview

This PR updates the plugin behavior such that we close open, non-minimized plugins and turn off their layers in on selecting a different plugin. For plugins which have been minimized, we keep them/their layers on. We also keep the minimize behavior when the user clicks the name of a plugin which is currently open.

Connects #856 

## Notes

* I'm not entirely sure if this is the desired behavior based on the discussion in #856, but I'm putting this up so we can evaluate it before merging. It may be that we want to close the plugins in all cases except when the minimize button has been clicked, but that would prevent users from having layers from two plugins active & visible simultaneously.

 * The first commit here removes an event listener no longer used in the framework.

## Testing

 * rebuild this branch with the regional planning plugin included
 * verify the following paths in the app:
     * clicking the minimize button for a plugin keeps its layers on and its name highlighted in the list
     * clicking the name of an open plugin minimizes it
     * clicking a new plugin name from the list when another one's active closes the previously active plugin and removes its layers
     * minimizing a plugin, then clicking a new plugin name from the list keeps the first plugin's layers active
     * clicking close on an open plugin closes it & removes its layers