### PR TITLE
Replace region dropdown with region subtitle in header

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -636,21 +636,8 @@
                 @RenderLinks(Model.HeaderLinks)
             </ul>
         </div>
-        <div class="dropdown header-dropdown nav-locations">
-            <button class="button dropdown-toggle nav-main-button" type="button" id="installation-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-                <div class="nav-locations-content">
-                    @Model.TitleDetail.Text
-                    @if(Model.RegionLinks != null) {
-                        <i class="dropdown-icon icon-angle-down"></i>
-                    }
-                </div>
-            </button>
-
-            @if(Model.RegionLinks != null) {
-                <ul class="dropdown-menu" aria-labelledby="installation-menu">
-                    @RenderRegionLinks(Model.RegionLinks)
-                </ul>
-            }
+        <div class="nav-region-subtitle">
+            @Model.TitleDetail.Text
         </div>
         <div id="search"></div>
     </header>

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -933,21 +933,6 @@ header .nav-main {
 .header-dropdown .dropdown-menu>li>a:hover {
     background-color: #188690
 }
-.nav-locations {
-    height: 60px;
-    padding-left: 8px;
-    padding-right: 8px;
-    display: -ms-flexbox;
-    display: flex
-}
-.nav-locations .dropdown-menu {
-    width: 220px;
-    left: -2px!important
-}
-.nav-locations .dropdown-menu>li>a {
-    white-space: normal
-}
-.nav-locations-content,
 .nav-main-title {
     -ms-flex: 1;
     flex: 1

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -958,6 +958,10 @@ header .nav-main {
     color: #fff;
     text-align: left
 }
+.nav-region-subtitle {
+    color: #fff;
+    padding-top: 3px;
+}
 .dropdown-icon.icon-angle-down {
     position: relative;
     left: 5px;


### PR DESCRIPTION
## Overview

This PR removes the region links dropdown from the header and replaces it with a subtitle from `region.json`'s `titleDetail.text` property. In addition to removing the loop which configured the links, I replaced the nested divs with a single `nav-region-subtitle` div and some rules to style it.

Connects #858

## Screenshot

<img width="500" alt="screen shot 2017-01-25 at 2 58 48 pm" src="https://cloud.githubusercontent.com/assets/4165523/22306990/5648eb72-e30f-11e6-96bd-76e17409b54b.png">

## Notes

I picked up #853 which is related to this.

## Testing

* rebuild this branch, then view in the browser
* verify that you see the "Sample Region" subtitle and that it's no longer a button