### PR TITLE
Move region links into main dropdown

### DIFF
--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -161,12 +161,11 @@ namespace GeositeFramework.Models
             {
                 HeaderLinks = jsonObj["headerLinks"]
                     .Select(ExtractLinkFromJson).ToList();
-            }
 
-            if (jsonObj["regionLinks"] != null)
-            {
-                RegionLinks = jsonObj["regionLinks"]
-                    .Select(ExtractLinkFromJson).ToList();
+                if (jsonObj["regionLinks"] != null)
+                {
+                    HeaderLinks.Add(AddRegionLinksToHeaderLinks(jsonObj["regionLinks"]));
+                }
             }
 
             // JSON to be inserted in generated JavaScript code
@@ -245,6 +244,15 @@ namespace GeositeFramework.Models
             return json["items"] != null
                 ? json["items"].Select(ExtractLinkFromJson).ToList()
                 : new List<Link>();
+        }
+
+        private static Link AddRegionLinksToHeaderLinks(JToken regionLinksJson)
+        {
+            return new Link
+            {
+                Text = "Other Regions",
+                Items = regionLinksJson.Select(ExtractLinkFromJson).ToList()
+            };
         }
 
         // Example plugin.json file:

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -36,7 +36,7 @@
             {
                 <li class="dropdown-submenu">
                     <a id="region-header-menu" href="#">
-                        @link.Text
+                        Other Regions
                         <i class="dropdown-icon icon-angle-right"></i>
                     </a>
                     <ul class="dropdown-menu">

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -34,15 +34,15 @@
             }
             else if (link.Items != null && link.Items.Any())
             {
-                var id = "link-dd-" + link.GetHashCode();
-                <a href="@link.Url" data-dropdown="#@id" class="dropdown-init">@link.Text
-                    <span class="dropdown-arrow">▼</span>
-                </a>
-                <div id="@id" class="dropdown dropdown-tip">
+                <li class="dropdown-submenu">
+                    <a id="region-header-menu" href="#">
+                        @link.Text
+                        <i class="dropdown-icon icon-angle-right"></i>
+                    </a>
                     <ul class="dropdown-menu">
-                        @RenderLinks(link.Items, false)
+                        @RenderRegionLinks(link.Items)
                     </ul>
-                </div>
+                </li>
             }
             else
             {
@@ -58,7 +58,7 @@
     if (links != null) {
         foreach (var link in links) {
             <li id="@link.ElementId">
-                <a target="_blank" href="@link.Url">@link.Text</a>
+                <a target="_blank" href="@link.Url">@link.Text <i class="icon-link-ext"></i></a>
             </li>
         }
     }
@@ -165,6 +165,9 @@
         body .tlypageguide_shadow:after {
             background-color: @Model.SecondaryColor;
             opacity: 0.2;
+        }
+        .dropdown-submenu > a:not(:hover) {
+            background-color: @Model.SecondaryColor;
         }
     </style>
 

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -876,9 +876,6 @@ header .nav-main {
     height: 60px;
     z-index: 2200
 }
-.header-dropdown.dropdown.open .dropdown-icon {
-    color: #3bb3be
-}
 .header-dropdown.dropdown>button {
     padding: 0;
     background-color: transparent;
@@ -903,7 +900,7 @@ header .nav-main {
     background-color: transparent
 }
 .header-dropdown .dropdown-menu {
-    left: 0!important;
+    left: 0;
     position: absolute;
     top: 60px;
     border-radius: 0;
@@ -932,6 +929,20 @@ header .nav-main {
 }
 .header-dropdown .dropdown-menu>li>a:hover {
     background-color: #188690
+}
+.dropdown-submenu {
+    position: relative;
+}
+.dropdown-submenu:hover > .dropdown-menu {
+    display: block;
+}
+.dropdown-submenu > .dropdown-menu {
+    top: 0px;
+    left: 100%;
+    width: inherit;
+}
+.dropdown-submenu > .dropdown-menu:after {
+    top: inherit;
 }
 .nav-main-title {
     -ms-flex: 1;

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -11,22 +11,20 @@
     },
     "headerLinks": [
         { "text": "Azavea", "url": "http://www.azavea.com/" },
-        { "text": "GIS", "url": "http://en.wikipedia.org/wiki/Geographic_information_system" },
-        { "text": "Other Regions", "items":
-            [
-                { "text": "California", "url": "http://maps.coastalresilience.org/california/" },
-                { "text": "Connecticut", "url": "http://maps.coastalresilience.org/connecticut" },
-                { "text": "Global", "url": "http://maps.coastalresilience.org/global/" },
-                { "text": "Grenada, St. Vincent & the Grenadines", "url": "http://maps.coastalresilience.org/gsvg/" },
-                { "text": "MesoAmerican Reef", "url": "http://maps.coastalresilience.org/mar/" },
-                { "text": "New York", "url": "http://maps.coastalresilience.org/newyork" },
-                { "text": "New Jersey", "url": "http://maps.coastalresilience.org/newjersey" },
-                { "text": "Southeast Florida", "url": "http://maps.coastalresilience.org/seflorida/" },
-                { "text": "United States", "url": "http://maps.coastalresilience.org/unitedstates/" },
-                { "text": "U.S. Virgin Islands", "url": "http://maps.coastalresilience.org/usvi/" },
-                { "text": "Washington", "url": "http://maps.coastalresilience.org/pugetsound" }
-            ]
-        }
+        { "text": "GIS", "url": "http://en.wikipedia.org/wiki/Geographic_information_system" }
+    ],
+    "regionLinks": [
+        { "text": "California", "url": "http://maps.coastalresilience.org/california/" },
+        { "text": "Connecticut", "url": "http://maps.coastalresilience.org/connecticut" },
+        { "text": "Global", "url": "http://maps.coastalresilience.org/global/" },
+        { "text": "Grenada, St. Vincent & the Grenadines", "url": "http://maps.coastalresilience.org/gsvg/" },
+        { "text": "MesoAmerican Reef", "url": "http://maps.coastalresilience.org/mar/" },
+        { "text": "New York", "url": "http://maps.coastalresilience.org/newyork" },
+        { "text": "New Jersey", "url": "http://maps.coastalresilience.org/newjersey" },
+        { "text": "Southeast Florida", "url": "http://maps.coastalresilience.org/seflorida/" },
+        { "text": "United States", "url": "http://maps.coastalresilience.org/unitedstates/" },
+        { "text": "U.S. Virgin Islands", "url": "http://maps.coastalresilience.org/usvi/" },
+        { "text": "Washington", "url": "http://maps.coastalresilience.org/pugetsound" }
     ],
     "initialExtent": [
         -98.61328125,

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -11,20 +11,22 @@
     },
     "headerLinks": [
         { "text": "Azavea", "url": "http://www.azavea.com/" },
-        { "text": "GIS", "url": "http://en.wikipedia.org/wiki/Geographic_information_system" }
-    ],
-    "regionLinks": [
-        { "text": "California", "url": "http://maps.coastalresilience.org/california/" },
-        { "text": "Connecticut", "url": "http://maps.coastalresilience.org/connecticut" },
-        { "text": "Global", "url": "http://maps.coastalresilience.org/global/" },
-        { "text": "Grenada, St. Vincent & the Grenadines", "url": "http://maps.coastalresilience.org/gsvg/" },
-        { "text": "MesoAmerican Reef", "url": "http://maps.coastalresilience.org/mar/" },
-        { "text": "New York", "url": "http://maps.coastalresilience.org/newyork" },
-        { "text": "New Jersey", "url": "http://maps.coastalresilience.org/newjersey" },
-        { "text": "Southeast Florida", "url": "http://maps.coastalresilience.org/seflorida/" },
-        { "text": "United States", "url": "http://maps.coastalresilience.org/unitedstates/" },
-        { "text": "U.S. Virgin Islands", "url": "http://maps.coastalresilience.org/usvi/" },
-        { "text": "Washington", "url": "http://maps.coastalresilience.org/pugetsound" }
+        { "text": "GIS", "url": "http://en.wikipedia.org/wiki/Geographic_information_system" },
+        { "text": "Other Regions", "items":
+            [
+                { "text": "California", "url": "http://maps.coastalresilience.org/california/" },
+                { "text": "Connecticut", "url": "http://maps.coastalresilience.org/connecticut" },
+                { "text": "Global", "url": "http://maps.coastalresilience.org/global/" },
+                { "text": "Grenada, St. Vincent & the Grenadines", "url": "http://maps.coastalresilience.org/gsvg/" },
+                { "text": "MesoAmerican Reef", "url": "http://maps.coastalresilience.org/mar/" },
+                { "text": "New York", "url": "http://maps.coastalresilience.org/newyork" },
+                { "text": "New Jersey", "url": "http://maps.coastalresilience.org/newjersey" },
+                { "text": "Southeast Florida", "url": "http://maps.coastalresilience.org/seflorida/" },
+                { "text": "United States", "url": "http://maps.coastalresilience.org/unitedstates/" },
+                { "text": "U.S. Virgin Islands", "url": "http://maps.coastalresilience.org/usvi/" },
+                { "text": "Washington", "url": "http://maps.coastalresilience.org/pugetsound" }
+            ]
+        }
     ],
     "initialExtent": [
         -98.61328125,


### PR DESCRIPTION
## Overview

This PR moves the `regionLinks` out of a previously used separate dropdown menu into the main hamburger menu dropdown. Along with updating the index file and the CSS, the changes here also adjust the structure of `region.json` to nest the `regionLinks` in the `headerLinks`. 

(If we keep the `region.json` change, we'll need to update the Wiki instructions and any regions which build).

Connects #853 

## Screenshots

<img width="637" alt="screen shot 2017-01-25 at 5 23 49 pm" src="https://cloud.githubusercontent.com/assets/4165523/22311769/106b0298-e323-11e6-8641-7b90a35342b2.png">

## Notes

The first commit here is from #861 

## Testing

 * rebuild this branch in VS, then view in the browser
 * open the menu and mouseover the "Other Regions" item
 * verify that a submenu of outbound links appears and that the links work