### PR TITLE
Rename "Help" -> "Tour" on plugin links sidebar

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -200,7 +200,7 @@
     <script type="text/template" id="template-pane">
         <nav class="nav-apps plugins">
             <div id="sidebar-help-area">
-                <a id="help-overlay-start" href="#">Help</a>
+                <a id="help-overlay-start" href="#" data-i18n="Tour">Tour</a>
             </div>
         </nav>
         <div class="flex-expand">

--- a/src/GeositeFramework/locales/en.json
+++ b/src/GeositeFramework/locales/en.json
@@ -10,6 +10,7 @@
     "Save & Share": "Save & Share",
     "Receive help on how to use this application": "Receive help on how to use this application",
     "Help": "Help",
+    "Tour": "Tour",
     "Allow maps to show different extents": "Allow maps to show different extents",
     "Unlink Maps": "Unlink Maps",
     "Force maps to show the same extent": "Force maps to show the same extent",

--- a/src/GeositeFramework/locales/es.json
+++ b/src/GeositeFramework/locales/es.json
@@ -10,6 +10,7 @@
     "Save & Share": "Guardar y Compartir",
     "Receive help on how to use this application": "Recibir ayuda sobre cómo utilizar esta aplicación",
     "Help": "Ayuda",
+    "Tour": "Tutorial",
     "Allow maps to show different extents": "Permitir que los mapas muestren diferentes zonas",
     "Unlink Maps": "Desvincular mapas 1 y 2",
     "Force maps to show the same extent": "Ver la misma zona en ambos mapas",

--- a/styleguide/app/index.html
+++ b/styleguide/app/index.html
@@ -81,7 +81,7 @@
     <div class="flex-container content" id="left-pane">
         <nav class="nav-apps plugins">
             <div id="sidebar-help-area">
-                <a href="http://lr01.internal.azavea.com:81/HUDSON_TNC_NY_Prototype_206/#" id="help-overlay-start">Help</a>
+                <a href="http://lr01.internal.azavea.com:81/HUDSON_TNC_NY_Prototype_206/#" id="help-overlay-start">Tour</a>
             </div>
             <div class="sidebar-plugin launchpad-0">
                 <button class="nav-apps-button plugin-launcher i18n" data-i18n="[title]Get started using the application" title="Get started using the application"><span class="button-icon"><img src="./cr_files/icon_sm.png"></span> <span class="button-text i18n" data-i18n="Get Started">Get Started</span></button>


### PR DESCRIPTION
## Overview

This PR renames "Help" -> "Tour" in the lefthand sidebar help area, adds a `data-i18n` attribute to the tour link, and adds "Tour" keys & values to both the `en.json` and `es.json` locale files.

For the `es.json` locale file, I chose "Tutorial" as the translation (which Google Translate deemed a translation of "Tutorial", since I wasn't sure whether more direct translations of "Tour" had the connotation of a walkthrough/tutorial for an app.

Connects #852 

## Screenshot

![screen shot 2017-01-26 at 10 27 08 am](https://cloud.githubusercontent.com/assets/4165523/22337048/066328fe-e3b2-11e6-84f3-6971520ee76b.png)

## Notes

I left the existing "Help" keys & values in the translation files as it seems like the framework might afford using them elsewhere in the app.

## Testing

 * rebuild this branch in VS, then view it in the browser
 * verify that the "Help" link has been renamed "Tour"