### PR TITLE
Restore highlight & select for Save & Share

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -502,7 +502,7 @@
             <div class="popover-content">
                 <div class="row" id="permalink-dialog">
                   <label class="popover-section"><div class="h3 i18n" data-i18n="Permalink">Permalink</div>
-                    <input class="form-control code-like permalink-tex" type="text" value="<%= shortUrl %>"/></label>
+                    <input class="form-control code-like permalink-textbox" type="text" value="<%= shortUrl %>"/></label>
                   <label class="popover-section h3" data-i18n="Embed"><div class="h3">Embed</div></label>
                   <p>You can copy and paste the following code to embed this map on your website.</p><br>
                   <span id="iframe-embed"></span>


### PR DESCRIPTION
## Overview

This PR fixes a bug which had prevented the shortlink from being selected when the Save & Share popup opened. 

The problem seems to be a typo on a CSS classname for that input which made its way into the app when we created the prototype: previously the input had a class named `permalink-textbox`, but during the transition to the prototype, the class was updated to `permalink-tex` without a corresponding change in the `Permalink.js` file.

Here's the previous code:

https://github.com/CoastalResilienceNetwork/GeositeFramework/blame/590c09222009537457159e82270c4174e9789562/src/GeositeFramework/Views/Home/Index.cshtml

To fix this I changed the class name back to `permalink-textbox`.

Connects #852 

## Screenshot

<img width="810" alt="screen shot 2017-01-30 at 1 53 36 pm" src="https://cloud.githubusercontent.com/assets/4165523/22436810/9bba76de-e6f3-11e6-8ddb-10af5f93cd66.png">

## Testing

* rebuild this branch in VS, then open it in the browser
* open the Save & Share and verify that the Permalink input is focused and selected. Copy the value to the clipboard, open another browser tab, then paste the text and it should show the permalink and lead back to the site.