### PR TITLE
Enable toggle of 3d & 2d mode

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -205,6 +205,7 @@
             <div class="flex-container">
                 <div id="map-0" class="map">
                     <div id="esri-mapview-mount"></div>
+                    <div id="esri-sceneview-mount"></div>
                     <div class="control-container">
                         <div class="top-tools"></div>
                         <div class="map-tools">

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1941,7 +1941,11 @@ body.x-body {
   margin-left: 50%;
   transform: translate(-50%, 0%);
 }
-#esri-mapview-mount {
+#esri-mapview-mount, #esri-sceneview-mount {
     height: 100%;
     width: 100%;
+}
+
+#esri-sceneview-mount {
+    display: none;
 }

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -128,7 +128,7 @@ require([
                         }
                     }
 
-                    // If this plugin is the launchpad, but that feature is not configured in the 
+                    // If this plugin is the launchpad, but that feature is not configured in the
                     // region config, don't create it.
                     var srcFolder = plugin.get('pluginSrcFolder'),
                         pluginRoot = srcFolder.substring(srcFolder.lastIndexOf('/') + 1);
@@ -164,7 +164,7 @@ require([
         //     - We need to create plugin objects before rendering (so we can render their toolbar names).
         //     - We need to pass a map object to the plugin constructors, but that isn't available until after rendering.
 
-        function initPlugins(model, esriMap) {
+        function initPlugins(model, esriMap, esriMapView, esriSceneView) {
             var mapModel = model.get('mapModel'),
                 regionData = model.get('regionData'),
                 savedState = model.get('stateOfPlugins'),
@@ -174,7 +174,8 @@ require([
                 if (checkName(pluginModel, 'launchpad')) {
                     launchpadPlugin = pluginModel;
                 }
-                pluginModel.initPluginObject(regionData, mapModel, esriMap);
+                pluginModel.initPluginObject(regionData, mapModel, esriMap,
+                                             esriMapView, esriSceneView);
             });
 
             // Wait a second before activating a permalink (scenario) to ensure the map
@@ -252,7 +253,9 @@ require([
                 return initialize(this);
             },
 
-            initPlugins: function(esriMap) { return initPlugins(this, esriMap); },
+            initPlugins: function(esriMap, esriMapView, esriSceneView) {
+                return initPlugins(this, esriMap, esriMapView, esriSceneView);
+            },
 
             setPluginState: function(pluginModel, savedState) {
                 var stateWasSet = false;
@@ -356,13 +359,14 @@ require([
                 el: view.$('.map'),
                 paneNumber: view.model.get('paneNumber')
             });
-            var esriMap = view.mapView.esriMap;
-            var esriMapView = view.mapView.esriMapView;
+            var esriMap = view.mapView.esriMap,
+                esriMapView = view.mapView.esriMapView,
+                esriSceneView = view.mapView.esriSceneView;
 
             // Wait for the map to load
             esriMapView.then(function () {
                 // Initialize plugins now that all map properties are available (e.g. extent)
-                view.model.initPlugins(esriMap);
+                view.model.initPlugins(esriMap, esriMapView, esriSceneView);
 
                 // Framework level support for identify is off by default and must
                 // be enabled in the region config

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -27,7 +27,8 @@ require(['use!Geosite',
             _.extend(model, selectable);
         }
 
-        function initPluginObject(model, regionData, mapModel, esriMap) {
+        function initPluginObject(model, regionData, mapModel, esriMap,
+                                  esriMapView, esriSceneView) {
             var pluginObject = model.get('pluginObject'),
                 pluginName = model.get('pluginSrcFolder'),
                 $uiContainer = model.get('$uiContainer'),
@@ -81,7 +82,9 @@ require(['use!Geosite',
                         downloadAsPlainText: requestTextDownload,
                         dispatcher: N.app.dispatcher,
                         suppressHelpOnStartup: _.partial(suppressHelpOnStartup, model),
-                        resize: resizers
+                        resize: resizers,
+                        activate3d: _.partial(activate3d, mapModel, esriSceneView),
+                        activate2d: _.partial(activate2d, mapModel, esriMapView)
                     },
                     plugin: {
                         turnOff: _.bind(model.turnOff, model)
@@ -114,6 +117,16 @@ require(['use!Geosite',
                 .find('input[name=content]').val(JSON.stringify(content)).end()
                 .find('input[name=filename]').val(filename).end()
                 .submit();
+        }
+
+        function activate3d(mapModel, sceneView) {
+            mapModel.set('is2dMode', false);
+            return sceneView;
+        }
+
+        function activate2d(mapModel, mapView) {
+            mapModel.set('is2dMode', true);
+            return mapView;
         }
 
         function setState(model, pluginState) {
@@ -179,7 +192,9 @@ require(['use!Geosite',
 
             isCompliant: function () { return checkPluginCompliance(this); },
 
-            initPluginObject: function (regionData, mapModel, esriMap) { initPluginObject(this, regionData, mapModel, esriMap); },
+            initPluginObject: function (regionData, mapModel, esriMap, esriMapView, esriSceneView) {
+                initPluginObject(this, regionData, mapModel, esriMap, esriMapView, esriSceneView);
+            },
 
             setState: function (pluginState) { setState(this, pluginState); },
 


### PR DESCRIPTION
### Overview
Expose methods to plugins which toggle between SceneViews and MapViews. This is currently done naively by having two views available but one hidden from the DOM.  When hidden, it appears a view does not attempt to render, which makes this a seemingly good approach.

Connects #868 

### Testing
* Clone https://github.com/CoastalResilienceNetwork/3d-sample/pulls into your plugin list on this branch
* Test that 3d view is activated when opening "Pilot Demo" plugin.  Basemaps, etc work as usual.
* 2d is activated when closing
* If demo plugin is hibernated, it stays in 3d and other plugins (regional planning) can add layers.  These layers persist through view changes.
* Zoom level and extent are persisted through view changes

![screenshot from 2017-02-08 14 50 27](https://cloud.githubusercontent.com/assets/1014341/22754574/f944b96a-ee0d-11e6-8b63-72e2e37acd33.png)
