### PR TITLE
Add button to close plugin to sidebar

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -352,7 +352,10 @@
         <button class="nav-apps-button plugin-launcher i18n <%= selected ? 'active' : ''%> <%= displayed ? 'app-displayed' : ''%>" data-i18n="[title]<%=fullName%>">
             <span class="button-icon"><img src="<%- pluginSrcFolder %>/icon_sm.png"></span>
             <span class="button-text i18n" data-i18n="<%- pluginObject.toolbarName %>"><%- pluginObject.toolbarName %></span>
-        </button
+        </button>
+        <button class="button-link button-sidebar-plugin-close plugin-clear">
+            <i class="icon-cancel"></i>
+        </button>
     </script>
 
     <script type="text/template" id="template-topbar-plugin">

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -847,6 +847,49 @@ nav {
         border-top: 5px solid transparent
     }
 }
+.button-link.button-sidebar-plugin-close {
+  display: none;
+  cursor: pointer;
+  position: absolute;
+  right: 5px;
+  color: #fff !important;
+  opacity: 1;
+  background-color: #565656;
+  border-radius: 100%;
+  bottom: 0;
+  height: 22px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 22px;
+}
+.plugin-launcher.active:hover + .button-link.button-sidebar-plugin-close {
+  display: inline-block;
+}
+.plugin-launcher.app-displayed.active:hover + .button-link.button-sidebar-plugin-close {
+  display: none;
+}
+@media (max-width: 991px) {
+  .plugin-launcher.active:hover + .button-link.button-sidebar-plugin-close {
+    display: none;
+  }
+}
+.button-link.button-sidebar-plugin-close:hover {
+  display: inline-block;
+  background-color: #222;
+}
+.button-sidebar-plugin-close .icon-cancel {
+  font-size: 10px;
+  position: relative;
+  left: -2px;
+  top: -1px;
+  color: #fff;
+}
+.sidebar-plugin {
+  position: relative;
+}
+.nav-apps-button {
+  padding: 10px 10px 8px;
+}
 #map-0.map {
     position: absolute;
     top: 0;

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -391,7 +391,9 @@ require(['use!Geosite',
 
             // The base class is a no-op for now, but the function must be declared.
             // Implementing classes will override this event
-            handleClear: function handleClear() {}
+            handleClear: function handleClear() {
+                this.model.turnOff();
+            }
 
         });
     }());


### PR DESCRIPTION
This button allows users to close an active plugin from the sidebar.

Demo:

![tnc](https://cloud.githubusercontent.com/assets/1042475/22791419/4c0ff3c2-eeb7-11e6-9a74-9b5900e7307a.gif)


Testing:

- Verify that the close button appears only for active plugins and that it closes the appropriate plugin when clicked.

Connects to #867 