### PR TITLE
Allow short code basemap URLs

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -41,11 +41,16 @@ require(['use!Geosite',
         // Return an ESRI Basemap object for the currently-selected basemap spec
         var basemap = getSelectedBasemap(model);
         if (basemap.layer === undefined) {
-            basemap.layer = new Basemap({
-                baseLayers: [new TileLayer(basemap.url)],
-                id: basemap.name,
-                title: basemap.name
-            });
+            if (basemap.url.substring(0,4) === 'http') {
+                basemap.layer = new Basemap({
+                    baseLayers: [new TileLayer(basemap.url)],
+                    id: basemap.name,
+                    title: basemap.name
+                });
+            } else {
+                // It's valid to also specify a short code for a well known basemap
+                basemap.layer = basemap.url;
+            }
         }
         return basemap.layer;
     }

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -73,7 +73,10 @@
         { "name": "Physical"           , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Physical_Map/MapServer" },
         { "name": "Shaded Relief"      , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer" },
         { "name": "Streets"            , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer" },
-        { "name": "Terrain"            , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer" }
+        { "name": "Terrain"            , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer" },
+        { "name": "Night"              , "url": "streets-night-vector" },
+        { "name": "Streets Relief"     , "url": "streets-relief-vector" },
+        { "name": "Streets Navigation" , "url": "streets-navigation-vector" }
     ],
     "pluginFolders": [
         "plugins",


### PR DESCRIPTION
### Overview
Vector tile rendering support is native to the 4.x API, but the official
basemap options are made available as string codes and the URL doesn't
have to be specified. This commit allows that type of basemap entry which
will allow vector tile demonstration.

Connects #873 

### Demo
![screenshot from 2017-02-13 15 08 10](https://cloud.githubusercontent.com/assets/1014341/22900986/44bca0f8-f1fe-11e6-86f5-c5de8c2e7d0f.png)

![screenshot from 2017-02-13 15 10 26](https://cloud.githubusercontent.com/assets/1014341/22901089/90b52a98-f1fe-11e6-8866-49a2d094796a.png)

### Testing
* Clone https://github.com/CoastalResilienceNetwork/3d-sample/ if you don't already have it
* Rebuild the framework and verify you can use the new vector map options as provided in the sample `region.json` configuration.  With one selected, open the 3D plugin and verify the same tile set is used on the globe.  
* Note that on my windows VM, rendering performance is not excellent.