### PR TITLE
Display close button for minimized plugins

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -862,10 +862,10 @@ nav {
   transform: translateY(-50%);
   width: 22px;
 }
-.plugin-launcher.active:hover + .button-link.button-sidebar-plugin-close {
+.plugin-launcher.active + .button-link.button-sidebar-plugin-close {
   display: inline-block;
 }
-.plugin-launcher.app-displayed.active:hover + .button-link.button-sidebar-plugin-close {
+.plugin-launcher.app-displayed.active + .button-link.button-sidebar-plugin-close {
   display: none;
 }
 @media (max-width: 991px) {


### PR DESCRIPTION
## Overview

This PR updates some CSS rules in order always to display the close button icon for minimized plugins. Previously it had been displayed only on hover, but #877 requested displaying it in all cases for for minimized apps.

Connects #877 

## Screenshot

![screen shot 2017-02-15 at 6 27 27 pm](https://cloud.githubusercontent.com/assets/4165523/22999991/6cc529b2-f3ac-11e6-8ff6-e1fa2a2c3aaf.png)

## Testing

 * rebuild this branch in VS, then view it in the browser
 * toggle a few plugins on then minimized and verify that the close icon shows for plugins which have been minimized, but does not show in any other case (e.g. open plugins, closed plugins)
 * verify that the close functionality still works and that the rest of the app still works as expected