### PR TITLE
Initially hide long Save Code, then toggle visible on clicking "Get it here"

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -532,7 +532,7 @@
                       <a href="javascript:void(0);" class="show-long-permalink i18n" data-i18n="Get it here.">
                           Get it here.
                       </a>
-                    <input class="form-control code-like" id="long-permalink-tex" type="text" value="<%= hash %>"/>
+                    <input class="form-control code-like" id="long-permalink-textbox" type="text" value="<%= hash %>"/>
                   </label>
                 </div>
             </div>

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -525,7 +525,13 @@
                           </div>
                       </div>
                   </div>
-                  <label class="popover-section"><div class="h3 i18n" data-i18n="Need the save code for this map?">Need the save code for this map?</div> <a href="javascript:void(0);" class="show-long-permalink i18n" data-i18n="Get it here.">Get it here.</a>
+                  <label class="popover-section">
+                      <div class="h3 i18n" data-i18n="Need the save code for this map?">
+                          Need the save code for this map?
+                      </div>
+                      <a href="javascript:void(0);" class="show-long-permalink i18n" data-i18n="Get it here.">
+                          Get it here.
+                      </a>
                     <input class="form-control code-like" id="long-permalink-tex" type="text" value="<%= hash %>"/>
                   </label>
                 </div>

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1985,3 +1985,6 @@ body.x-body {
   margin-left: 50%;
   transform: translate(-50%, 0%);
 }
+#long-permalink-textbox {
+  display: none;
+}


### PR DESCRIPTION
## Overview

This PR fixes a bug whereby the long Save Code had been visible by default in the new framework. There seemed to be two errors here: first, the `id` for the permalink had gotten truncated from `long-permalink-textbox` to `long-permalink-tex` in the updated framework, which meant that jQuery couldn't find the right element to toggle. Second, the permalink element was not set to hide initially, so clicking "Get it here" for the first time would then hide it.

The second commit here fixes the CSS id typo; the third one sets it to hide until the "Get it here" link has been clicked. First one's here to reformat the elements before making any changes.

Connects #871

## Screenshots

Before clicking "Get it here" ->

![screen shot 2017-02-16 at 9 59 00 am](https://cloud.githubusercontent.com/assets/4165523/23026907/bcfc3784-f430-11e6-9bfc-7254ce1891fa.png)

After clicking "Get it here" ->

![screen shot 2017-02-16 at 9 59 11 am](https://cloud.githubusercontent.com/assets/4165523/23026911/c2fa556c-f430-11e6-8e2b-d1aa3fad0fe6.png)
