### PR TITLE
Translate search and legend text

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -284,10 +284,16 @@
             <% }) %>
             <% if (legend.length > 5) { %>
                 <div class="item expand">
-                    <a href="#" class="expand-legend">View <% print(legend.length - 5) %> more</a>
+                    <a href="#" class="expand-legend">
+                        <span class="i18n" data-i18n="View">View</span>
+                        <span> <% print(legend.length - 5) %> </span>
+                        <span class="i18n" data-i18n="more">more</span>
+                    </a>
                 </div>
                 <div class="item extra collapse">
-                    <a href="#" class="expand-legend">View less</a>
+                    <a href="#" class="expand-legend">
+                        <span class="i18n" data-i18n="View less">View less</span>
+                    </a>
                 </div>
             <% } %>
         </div>

--- a/src/GeositeFramework/js/Legend.js
+++ b/src/GeositeFramework/js/Legend.js
@@ -122,6 +122,10 @@ define(['use!Geosite',
                     } else {
                         $container.append(tmpl(legend));
                     }
+
+                    if ($.i18n) {
+                        $container.localize();
+                    }
                 }
             });
 

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -185,7 +185,15 @@ require(['use!Geosite',
                 enableHighlight: false,
             }, "search");
 
-            search.startup();
+            // The translation lookup isn't ready when this is initialized.
+            // A slight delay is needed.
+            window.setTimeout(function() {
+                // Required to set the placeholder text.
+                var sources = search.get("sources");
+                sources[0].placeholder = i18next.t("Find address or place");
+                search.set("sources", sources);
+                search.startup();
+            }, 200);
         }
 
         // On IE8, the map.onload event will often not fire at all, which breaks

--- a/src/GeositeFramework/locales/en.json
+++ b/src/GeositeFramework/locales/en.json
@@ -73,5 +73,9 @@
     "Double-click to end a line segment. Single-click the first node to end a polygon.": "Double-click to end a line segment. Single-click the first node to end a polygon.",
     "Click the map to start measuring": "Click the map to start measuring",
     "More": "More",
-    "Less": "Less"
+    "Less": "Less",
+    "View": "View",
+    "more": "more",
+    "View less": "View less",
+    "Find address or place": "Find address or place"
 }

--- a/src/GeositeFramework/locales/es.json
+++ b/src/GeositeFramework/locales/es.json
@@ -72,6 +72,10 @@
     "Length:": "Longitud:",
     "Double-click to end a line segment. Single-click the first node to end a polygon.": "De doble-clic para terminar la línea. De un clic en el primer nodo para terminar el polígono",
     "Click the map to start measuring": "Haga clic en el mapa para comenzar a medir",
-    "More": "Mas",
-    "Less": "Menos"
+    "More": "Más",
+    "Less": "Menos",
+    "View": "Ver",
+    "more": "más",
+    "View less": "Ver menos",
+    "Find address or place": "Encontrar dirección o lugar"
 }


### PR DESCRIPTION
These areas were missed when the app was initially translated.

<img width="450" alt="screen shot 2017-02-17 at 11 37 29 am" src="https://cloud.githubusercontent.com/assets/1042475/23074045/9682075c-f505-11e6-81a3-7002822c045c.png">

**Testing**
- Set the framework's language to `es` and verify that the search input placeholder text and legend "view more/view less" links are translated.

Connects to #872