### PR TITLE
Hide plugin close button on narrow viewports

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -865,13 +865,13 @@ nav {
 .plugin-launcher.active + .button-link.button-sidebar-plugin-close {
   display: inline-block;
 }
+@media (max-width: 991px) {
+  .nav-apps-narrow .button-sidebar-plugin-close {
+    display: none !important;
+  }
+}
 .plugin-launcher.app-displayed.active + .button-link.button-sidebar-plugin-close {
   display: none;
-}
-@media (max-width: 991px) {
-  .plugin-launcher.active:hover + .button-link.button-sidebar-plugin-close {
-    display: none;
-  }
 }
 .button-link.button-sidebar-plugin-close:hover {
   display: inline-block;


### PR DESCRIPTION
## Overview

This PR fixes an error introduced in fixing #877 whereby the close button for minimized plugins was also visible on narrow viewports when the sidebar was narrower. The fix involves nesting the `display: inline-block` rule for the minimized plugins inside a check that the viewport's > 991px wide, which matches the value we use to set the narrow sidebar

Connects #882 

## Screenshots

*Desktop-sized screen*:
![screen shot 2017-02-17 at 5 07 16 pm](https://cloud.githubusercontent.com/assets/4165523/23085135/e26396f8-f533-11e6-9386-e4e03192d3a6.png)

*Tablet width, small sidebar*
![screen shot 2017-02-17 at 5 07 26 pm](https://cloud.githubusercontent.com/assets/4165523/23085140/e61166a4-f533-11e6-9f73-18103c5fd5d2.png)

*Tablet width, expanded sidebar*
![screen shot 2017-02-20 at 10 11 17 am](https://cloud.githubusercontent.com/assets/4165523/23130596/0e06bc40-f755-11e6-9372-b06baf3823a4.png)


## Testing
 * rebuild this branch in VS then view it in the browser
 * at standard desktop width, check that the close plugin button appears properly for minimized plugins
 * at tablet width, check that the close plugin button does not appear for minimized plugins when the sidebar displays only icons, and check that the close button does appear when all open plugins are minimized
 * verify that it still doesn't show up for active, unminimized plugins in either case