### PR TITLE
Increase tinybox element z-indexes

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1769,10 +1769,10 @@ header .nav-main {
     TINY overlays and popups
 ------------------------------------------- */
 body .tmask {
-    z-index: 2000; /* Keep above the sidebar */
+    z-index: 5001; /* Keep above the sidebar */
 }
 body .tbox {
-    z-index: 2001; /* Keep above the tmask */
+    z-index: 5002; /* Keep above the tmask */
 }
 
 /* ----------------------------------------


### PR DESCRIPTION
Ensures tinybox modals are displayed on top of every other element in the page.

![image](https://cloud.githubusercontent.com/assets/1042475/23265006/54ee11fe-f9b1-11e6-8062-542c3436b24e.png)

**Testing**
- Open the modal in the sample app and verify that it displays on top of every other element in the app.

Connects to #892