### PR TITLE
Limit the width of the plugin name element

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -823,6 +823,10 @@ nav {
     height: 28px;
     width: 28px;
 }
+.nav-apps-button .button-text {
+    display: inline-block;
+    width: 75%;
+}
 
 @media (max-width: 991px) {
     .nav-apps-narrow {


### PR DESCRIPTION
## Overview

Limiting the width of the plugin name element prevents the close button
from obscuring long names.

Connects to #898

### Demo

![image](https://cloud.githubusercontent.com/assets/1042475/23565002/f040a72a-0019-11e7-9e66-603e78ecf06c.png)

## Testing Instructions

- Activate one of the plugins, then minimize it.
- Using the developer tools, edit the name of the plugin so that it needs to wrap.
- Hover over the plugin name, and verify that the close button does not overlap with the name.