### PR TITLE
Update missing pips import in PluginBase.js

### DIFF
--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -22,7 +22,8 @@ define(["dojo/_base/declare",
                 dDeferredList,
                 Deferred,
                 jqueryui,
-                chosen
+                chosen,
+                pips
                 ) {
 
         var URL_PATTERN = /^https?:\/\/.+/,


### PR DESCRIPTION
### Overview

This PR updates the PluginBase's arguments list to include `pips`, which I must have inadvertently dropped when rebasing #906 to merge.

Connects #910 

### Testing

- remove any plugins not included in the base framework from your local
- rebuild this branch in VS
- visit in the browser, then open the identify point plugin
- verify that you see the pips interval markers on the slider and there aren't any errors related to pips in the console (note that the console does currently show an error related to #910)
