### PR TITLE
Reduce padding for tour container when narrow

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1946,6 +1946,10 @@ body.x-body {
     z-index: 1;
 }
 
+.nav-apps-narrow #sidebar-help-area {
+    padding: 4px 5px;
+}
+
 #help-overlay-start {
   color: #d9dbde;
   font-size: 1.7rem;


### PR DESCRIPTION
## Overview
When the nav-apps list is narrow, reduce the padding on the element
containing the tour link so that it is not obscured.

Connects #907 

## Demo
![screenshot from 2017-03-10 10 57 05](https://cloud.githubusercontent.com/assets/1014341/23802116/507167a4-0580-11e7-97a2-8c2f3c1c8574.png)

## Testing
On this branch, observe the tour link when the nav bar is both collapsed and expanded.