### PR TITLE
Fix sidebar toggle

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -828,13 +828,13 @@ nav {
     width: 75%;
 }
 
-.nav-apps-narrow {
+.nav-apps-narrow-manual {
     width: 46px;
 }
-.nav-apps-narrow .button-text {
+.nav-apps-narrow-manual .button-text {
     display:none;
 }
-.nav-apps-button:hover .button-text:after {
+.nav-apps-narrow-manual .nav-apps-button:hover .button-text:after {
     content: "";
     top: 16px;
     left: -12px;

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1940,13 +1940,9 @@ body.x-body {
 #sidebar-help-area {
     position: fixed;
     bottom: 0;
-    padding: 4px 10px;
+    padding: 4px 5px;
     width: inherit;
     z-index: 1;
-}
-
-.nav-apps-narrow #sidebar-help-area {
-    padding: 4px 5px;
 }
 
 #help-overlay-start {

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -890,6 +890,7 @@ nav {
 .plugin-launcher.active + .button-link.button-sidebar-plugin-close {
   display: inline-block;
 }
+.nav-apps-narrow-manual .button-sidebar-plugin-close,
 .nav-apps-narrow .button-sidebar-plugin-close {
   display: none !important;
 }

--- a/src/GeositeFramework/plugins/map_expand/main.js
+++ b/src/GeositeFramework/plugins/map_expand/main.js
@@ -1,9 +1,19 @@
+﻿require({
+    packages: [
+        {
+            name: "underscore",
+            location: "//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3",
+            main: "underscore-min"
+        }
+    ]
+});
+
 define(
-    ["dojo/_base/declare", "framework/PluginBase"],
-    function (declare, PluginBase) {
+    ["dojo/_base/declare", "framework/PluginBase", "underscore"],
+    function (declare, PluginBase, _) {
         return declare(PluginBase, {
-            toolbarName: "Map Expand",
-            fullName: "Expand the map",
+            toolbarName: "Map Expand/Shrink",
+            fullName: "Expand/shrink the map",
             toolbarType: "map",
             allowIdentifyWhenActive: true,
             closeOthersWhenActive: false,
@@ -11,9 +21,17 @@ define(
             initialize: function (args) {
                 declare.safeMixin(this, args);
                 this.$sidebar = $('.nav-apps.plugins');
-                this.sidebarNarrowClassName = 'nav-apps-narrow';
+                this.autoSidebarNarrowClassName = 'nav-apps-narrow';
+                this.manualSidebarNarrowClassName = 'nav-apps-narrow-manual';
 
+                this.bindEvents();
+            },
+
+            bindEvents: function() {
                 this.app.dispatcher.on('map-size:change', this.updateIcon, this);
+
+                var debouncedUpdateIcon = _.debounce(_.bind(this.updateIcon, this), 250);
+                $(window).resize(debouncedUpdateIcon);
             },
 
             renderLauncher: function () {
@@ -24,9 +42,11 @@ define(
 
             activate: function () {
                 if (this.isSidebarNarrow()) {
-                    this.$sidebar.removeClass(this.sidebarNarrowClassName);
+                    this.$sidebar.removeClass(this.manualSidebarNarrowClassName);
+                    this.$sidebar.removeClass(this.autoSidebarNarrowClassName);
                 } else {
-                    this.$sidebar.addClass(this.sidebarNarrowClassName);
+                    this.$sidebar.addClass(this.autoSidebarNarrowClassName);
+                    this.$sidebar.addClass(this.manualSidebarNarrowClassName);
                 }
 
                 this.updateIcon();
@@ -41,7 +61,9 @@ define(
             },
 
             isSidebarNarrow: function() {
-                if (this.$sidebar.hasClass(this.sidebarNarrowClassName)) {
+                if (this.$sidebar.hasClass(this.manualSidebarNarrowClassName) ||
+                    ($(document).width() <= 991 &&
+                    this.$sidebar.hasClass(this.autoSidebarNarrowClassName))) {
                     return true;
                 }
 

--- a/src/GeositeFramework/plugins/map_expand/main.js
+++ b/src/GeositeFramework/plugins/map_expand/main.js
@@ -61,8 +61,11 @@ define(
             },
 
             isSidebarNarrow: function() {
+                var docWidth = $(document).width(),
+                    narrowWidthThreshold = 991;
+
                 if (this.$sidebar.hasClass(this.manualSidebarNarrowClassName) ||
-                    ($(document).width() <= 991 &&
+                    (docWidth <= narrowWidthThreshold &&
                     this.$sidebar.hasClass(this.autoSidebarNarrowClassName))) {
                     return true;
                 }


### PR DESCRIPTION
The initial implementation of this tool duplicated the CSS rules that
were contained in a media query to make the sidebar narrow. Doing this
meant that the sidebar became narrow at any screensize once a plugin was
activated. To fix this, a different class name is now used for the tool.

Also, the logic to check whether or not the sidebar is narrow was improved
here to take the size of the viewport into account.

To better keep the tool button icon in sync with the state of the sidebar,
changes to the viewport size are listened to and the icon is updated if
need be.

One side-effect of having a tool to manually toggle the state of the
sidebar is that users may have to expand the sidebar using the button
on small screens if the sidebar was initially toggled manually and any
active plugins are turned off.

Connects to #912

**Testing**
- With a plugin active, resize the viewport and verify that the plugin icon is update/kept in sync with the viewport changes.
- Verify that on large screens, when the app loads and the launchpad starts, the sidebar is not collapsed.
- Do the above on small screens, but verify that the sidebar is collapsed.
- Manually toggle the state of the sidebar using the plugin. Verify the it produces the expected behavior at different screen sizes and with plugins on and off.
