### PR TITLE
Drop explicit jQuery import in AgsMeasure.js

### DIFF
--- a/src/GeositeFramework/js/widgets/map_utils/measure/AgsMeasure.js
+++ b/src/GeositeFramework/js/widgets/map_utils/measure/AgsMeasure.js
@@ -1,6 +1,5 @@
 define([
         "use!Geosite",
-        "jquery",
         "esri/geometry/Polyline",
         "esri/geometry/Polygon",
         "esri/geometry/geodesicUtils",
@@ -17,7 +16,6 @@ define([
         "esri/layers/GraphicsLayer"
     ],
     function(N,
-             $,
              Polyline,
              Polygon,
              geodesicUtils,


### PR DESCRIPTION
## Overview

This PR remedies a timing issue in IE whereby `N.models.Map` would not be available when `Pane.js` was being initialized, causing the error described in #917. That issue has a trail of more detailed comments, but the problem appears to be that the map utils, and the Measure tool specifically, take too long an interval to initialize in IE.

Drilling down through the imports list, it turned out that the `jquery` import in `AgsMeasure` caused things to hang up a bit, so this change drops the explicit import in favor of using the globally available `$`. I believe the explicit import might be a vestige of this being set up as a plugin rather than as part of the framework.

With these changes, the site will now load in IE. I also tested this in Chrome, Safari, and Firefox without any additional plugins installed and it loaded in each browser and the measure tool still works in each browser

Connects #917 

## Screenshots

Here's Chrome using the measure tool:

![screen shot 2017-03-14 at 2 18 51 pm](https://cloud.githubusercontent.com/assets/4165523/23916160/ae01c56e-08c1-11e7-97f5-377e3db7781b.png)

Here's IE11 using the measure tool:

<img width="741" alt="screen shot 2017-03-14 at 2 19 54 pm" src="https://cloud.githubusercontent.com/assets/4165523/23916173/b86182c4-08c1-11e7-993c-d0868640de97.png">

## Notes

The "Geosite Framework Sample" text is a little bunched up on IE, so I'll make another card to fix that. (See #920)

## Testing

 * get this branch, `rm -rf` all plugins which are not part of the base framework, then load the site in IE11, Firefox, Chrome, and Safari and verify that
     * the site loads in each
     * the sample/identify point plugin has the proper styling
     * the maputils -- and the measure tool specifically -- still work
     * the rest of the app works as it should
 * add the regional-planning plugin, and repeat the testing steps above to verify that the app still works across browsers.
