### PR TITLE
Swap out unicode for HTML character entity code

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -40,7 +40,7 @@
             {
                 var id = "link-dd-" + link.GetHashCode();
                 <a href="@link.Url" data-dropdown="#@id" class="dropdown-init">@link.Text
-                    <span class="dropdown-arrow">▼</span>
+                    <span class="dropdown-arrow">&#9660;</span>
                 </a>
                 <div id="@id" class="dropdown dropdown-tip">
                     <ul class="dropdown-menu">


### PR DESCRIPTION
## Overview 
A particular IIS server is having trouble serving the file in the correct
encoding, resulting in a garbled symbol.  Swap out for the equivalent
html code, which happens to also be used on the basemap selector.

Connects #918 

## Notes
In the screenshot below, we see the TNC site unable to render the unicode character on GOTO, but succeeds with the HTML character entity in the basemap:

![screenshot from 2017-03-14 19 39 45](https://cloud.githubusercontent.com/assets/1014341/23927065/1739125e-08ee-11e7-8e36-31895969d570.png)


## Testing
Ensure that the GOTO menu arrow displays correctly.  Note that this is the `master` branch target, and there's no equivalent in the new framework.  If you have any plugins loaded, they must be targeted for this branch.  I'm unable to make VS disregard the encoding in the way that mimics the IIS server, so only ensure that it still works and that the code is equivalent to that of the basemap selector.