### PR TITLE
Drop flex & -ms-flex attributes on .nav-main-title

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1010,10 +1010,6 @@ header .nav-main {
     top: inherit;
 }
 .nav-main-title {
-    -ms-flex: 1;
-    flex: 1
-}
-.nav-main-title {
     font-size: 18px;
     font-weight: 900;
     color: #fff;

--- a/styleguide/app/cr_files/main.css
+++ b/styleguide/app/cr_files/main.css
@@ -988,10 +988,6 @@ header .nav-main {
     top: inherit;
 }
 .nav-main-title {
-    -ms-flex: 1;
-    flex: 1
-}
-.nav-main-title {
     font-size: 18px;
     font-weight: 900;
     color: #fff;


### PR DESCRIPTION
## Overview

This PR fixes a CSS issue in IE11 whereby the title header text would be stacked vertically & thereby overflow its div:

![screen shot 2017-03-14 at 2 29 01 pm](https://cloud.githubusercontent.com/assets/4165523/23916447/9e9bdffa-08c2-11e7-9d77-88992780df46.png)

This was happening because the `-ms-flex` attribute on `.nav-main-title` was being overriden by `flex: 1`. However, after checking into it it turns out that the text displays properly without either attribute, so I just dropped them both for the Framework & the Style Guide.

Connects #920

## Screenshots

Chrome ->

<img width="359" alt="screen shot 2017-03-15 at 10 32 53 am" src="https://cloud.githubusercontent.com/assets/4165523/23953373/c5c3c9c8-096a-11e7-87a6-407bb14524a6.png">

IE 11 ->

<img width="387" alt="screen shot 2017-03-15 at 10 33 21 am" src="https://cloud.githubusercontent.com/assets/4165523/23953401/d8c664e0-096a-11e7-967c-283a459cbe69.png">

Safari ->

<img width="633" alt="screen shot 2017-03-15 at 10 33 45 am" src="https://cloud.githubusercontent.com/assets/4165523/23953422/e29c3b52-096a-11e7-94f8-285ce9ef06b8.png">

Firefox ->

<img width="675" alt="screen shot 2017-03-15 at 10 34 04 am" src="https://cloud.githubusercontent.com/assets/4165523/23953442/ef29fd1e-096a-11e7-917e-4d83899888e8.png">

Style guide ->

<img width="363" alt="screen shot 2017-03-15 at 10 34 40 am" src="https://cloud.githubusercontent.com/assets/4165523/23953462/077684c8-096b-11e7-8ed0-7ebe0f4a4c5b.png">

## Testing

 * rebuild this branch in VS then serve it to the browser
 * check the site in IE11, Chrome, and Firefox to verify that the header still works
 * also might be worth upping the length of the title in the base `region.json` file to verify that longer titles still render correctly