### PR TITLE
Add MapView-SceneView toggle control

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -84,7 +84,8 @@ require(['use!Geosite',
                         suppressHelpOnStartup: _.partial(suppressHelpOnStartup, model),
                         resize: resizers,
                         activate3d: _.partial(activate3d, mapModel, esriSceneView),
-                        activate2d: _.partial(activate2d, mapModel, esriMapView)
+                        activate2d: _.partial(activate2d, mapModel, esriMapView),
+                        mapIs2d: function() { return mapModel.get('is2dMode'); }
                     },
                     plugin: {
                         turnOff: _.bind(model.turnOff, model)

--- a/src/GeositeFramework/plugins/mapview-sceneview-toggle/main.js
+++ b/src/GeositeFramework/plugins/mapview-sceneview-toggle/main.js
@@ -1,0 +1,30 @@
+define(
+    ["dojo/_base/declare", "framework/PluginBase"],
+    function (declare, PluginBase) {
+        return declare(PluginBase, {
+            toolbarName: "MapView-SceneView Toggle",
+            fullName: "Toggle between 2-D and 3-D mode",
+            toolbarType: "map",
+            allowIdentifyWhenActive: false,
+            closeOthersWhenActive: false,
+
+            initialize: function (args) {
+                declare.safeMixin(this, args);
+            },
+
+            renderLauncher: function () {
+                return '<div id="mapview-sceneview-control">' +
+                       '<span id="mapview-sceneview-toggle-control-icon">' +
+                       '<i class="icon-globe"></i></span></div>';
+            },
+
+            activate: function () {
+                if (this.app.mapIs2d()) {
+                    this.app.activate3d();
+                } else {
+                    this.app.activate2d();
+                }
+            },
+        });
+    }
+);

--- a/src/GeositeFramework/plugins/mapview-sceneview-toggle/plugin.json
+++ b/src/GeositeFramework/plugins/mapview-sceneview-toggle/plugin.json
@@ -1,0 +1,6 @@
+{
+    "css": [
+        "plugins/mapview-sceneview-toggle/style.css"
+    ],
+    "use": {}
+}

--- a/src/GeositeFramework/plugins/mapview-sceneview-toggle/style.css
+++ b/src/GeositeFramework/plugins/mapview-sceneview-toggle/style.css
@@ -1,0 +1,5 @@
+#mapview-sceneview-toggle-control-icon {
+    color: grey;
+    font-size: 2.4rem;
+    line-height: 3rem;
+}


### PR DESCRIPTION
## Overview

This PR adds a map control to toggle the map between a 2D MapView and a 3D SceneView. It works by calling `Plugin.js`'s `activate2d`/`activate3d` methods contextually depending on whether the map is in one state or another.

To allow plugins to keep track of the state, I updated `Plugin.js` to add a `mapIs2d` property which will return the current state of the map. This enables the control to make the appropriate toggle even if, for instance, another plugin has switched the view from 2d to 3d.

Connects #909 

## Screenshots

The new control has a globe icon and sits beneath the other map utilities:

![screen shot 2017-03-16 at 12 57 20 pm](https://cloud.githubusercontent.com/assets/4165523/24008673/ae037a34-0a48-11e7-92b7-c1fd7103de12.png)

->

![screen shot 2017-03-16 at 12 57 28 pm](https://cloud.githubusercontent.com/assets/4165523/24008678/b2390574-0a48-11e7-9cf4-1e557f3d6a98.png)

## Notes

I added this as a framework plugin akin to the existing subregion-toggle control. This seemed like a reasonable way to keep the changes here encapsulated.

## Testing

 * get this branch, along with the 3d-sample plugin, then rebuild the project in VS
 * view the site in the browser and verify that the toggle control works
 * refresh the page, then open the Pilot Flood Demo plugin
 * click the toggle control and verify that it changes the view back to a 2d MapView