### PR TITLE
Display plugin close buttons if sidebar isn't narrow

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -890,9 +890,13 @@ nav {
 .plugin-launcher.active + .button-link.button-sidebar-plugin-close {
   display: inline-block;
 }
-.nav-apps-narrow-manual .button-sidebar-plugin-close,
-.nav-apps-narrow .button-sidebar-plugin-close {
+.nav-apps-narrow-manual .button-sidebar-plugin-close {
   display: none !important;
+}
+@media (max-width: 991px) {
+    .nav-apps-narrow .button-sidebar-plugin-close {
+        display: none !important;
+    }
 }
 .plugin-launcher.app-displayed.active + .button-link.button-sidebar-plugin-close {
   display: none;


### PR DESCRIPTION
## Overview

This PR remedies a bug noted in #924 whereby the minimized-plugin-close-button would not appear in the sidebar unless all of the plugins were minimized. The bug was due to the `display: none` rule on `.nav-apps-narrow .button-sidebar-plugin-close` not being conditionally applied based on the viewport size.

The `.nav-apps-narrow` class is applied in the sidebar whenever any of the plugins are open; this was done to make it so that rules on the class could take effect immediately on tablets if a person rotated the tablet from landscape to portrait mode.

To fix it, I split the prior `display: none` rule for `button-sidebar-plugin-close` to be two rules: 

- first, we always hide the close buttons when the expand map/collapse sidebar button has been clicked to collapse the sidebar
- second, we hide the buttons if the viewport's narrower than 991px and any plugins are open, visible, and not minimized

Connects #924 

## Screenshots

Tablet, portrait mode, plugin minimized and another open ->

![screen shot 2017-03-16 at 3 57 17 pm](https://cloud.githubusercontent.com/assets/4165523/24016141/65c5f904-0a61-11e7-8ced-38f40edb59c5.png)

Tablet, portrait mode, all plugins minimized ->

![screen shot 2017-03-16 at 3 57 25 pm](https://cloud.githubusercontent.com/assets/4165523/24016146/6a242f52-0a61-11e7-8011-6256505db2fa.png)

Desktop, standard viewport, single plugin minimized ->

![screen shot 2017-03-16 at 3 57 58 pm](https://cloud.githubusercontent.com/assets/4165523/24016149/6db9ad54-0a61-11e7-885e-c32101f9842c.png)

Desktop, standard viewport, single plugin minimized & expanded map mode activated ->

![screen shot 2017-03-16 at 3 58 05 pm](https://cloud.githubusercontent.com/assets/4165523/24016154/71190256-0a61-11e7-93c6-0a46afb943df.png)

## Testing
 * rebuild this branch in VS with regional planning installed, then view it in the browser
 * verify that the bug described in #924 has been fixed and can't be reproduced
 * try a few combinations of toggling the expand button, opening, closing, and minimizing plugins to verify that the close button is hidden for minimized plugins when the sidebar's narrow and that it is visible and clickable for minimized plugins when the sidebar's standard-sized
 * using the device simulator to check the behavior for an iPad-sized device in both portrait and landscape mode, verifying that...
    * in landscape mode, the app behaves the same as it does on desktops
    * in portrait mode, the sidebar narrows automatically on opening a plugin -- and plugins which are minimized while another plugin is open do not have the close button if the sidebar's narrowed
    * note that if you manually expand the sidebar in portrait mode by clicking on the expand button, the minimized plugins should display a close button