### PR TITLE
Adjust 3d control CSS & disable search placeholder update

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -252,6 +252,7 @@ require(['use!Geosite',
 
             // The translation lookup isn't ready when this is initialized.
             // A slight delay is needed.
+            /* Commenting this out for the js-api-4x-pilot branch
             window.setTimeout(function() {
                 // Required to set the placeholder text.
                 var sources = search.get("sources");
@@ -259,6 +260,7 @@ require(['use!Geosite',
                 search.set("sources", sources);
                 search.startup();
             }, 200);
+            */
         }
 
         // TODO: Remove this once it's confirmed that it's not necessary for IE11.

--- a/src/GeositeFramework/plugins/mapview-sceneview-toggle/style.css
+++ b/src/GeositeFramework/plugins/mapview-sceneview-toggle/style.css
@@ -1,5 +1,3 @@
 #mapview-sceneview-toggle-control-icon {
     color: grey;
-    font-size: 2.4rem;
-    line-height: 3rem;
 }


### PR DESCRIPTION
## Overview

This PR fixes two small bugs encountered after rebasing the `js-api-4x-pilot` branch on `develop`.

First, it adjusts the CSS rules for the 2-d/3-d toggle button to drop `font-size` and `line-height`. Some CSS updates made on `develop` on behalf of the expand control work to center the globe icon in the control button, and the extra rules in the toggle button's css file now push it off-center.

Second, it disables a routine which seems to handle internationalizing text for the search box. This code was showing an error in the console because `search.get('sources')` was returning an undefined object. I'm going to make another card for fixing it; for now I just commented it out to circumvent the error.

Connects #911 

## Testing
 * rebuild this branch in VS then open it in the browser and verify that everything still works as it should
 * it's probably worth using the 3-d Sample plugin alongside these changes to verify that that still works as well.