### PR TITLE
Parse suppressHelp value for check

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -296,9 +296,10 @@ require(['use!Geosite',
 
             getSuppressHelpOnStartup: function() {
                 var pluginObject = this.get('pluginObject'),
-                    showValueKey = pluginObject.toolbarName + this.get('startHelpKey');
+                    showValueKey = pluginObject.toolbarName + this.get('startHelpKey'),
+                    suppressHelpValue = localStorage[showValueKey];
 
-                return !!localStorage[showValueKey];
+                return suppressHelpValue ? JSON.parse(suppressHelpValue) : false;
             },
 
             setSuppressHelpOnStartup: function(val) {


### PR DESCRIPTION
## Overview

This PR fixes a bug described in #932 whereby `suppressHelpOnStartup` couldn't be set to `false` after it was once initially set. With it, the `suppressHelpOnStartup` setting will now work as documented.

It turned out this was due to how `localStorage` treats boolean values on reading them back out: `true` and `false` are both read out as strings regardless of whether they're written as booleans, which means they were both truthy for the ensuing check.

As a remedy, this change updates the `getSuppressHelpOnStartup` method to perform an initial check on whether the suppressHelp key exists, then return its `JSON.parse`d value if so (and false if not); In turn, this means the plugin `activate` method's `showHelpOnStart` arg is true if the plugin's suppress help key was set as `true` -- and false otherwise.

Connects #932 

### Notes

Tested this in IE11, Chrome, Firefox, and Safari on desktop.

## Testing Instructions

 * get and rebuild this branch in VS, then open it in Chrome
 * check `localStorage` in the console to see whether the value for `Identify Point-suppress-help-start` is `"true"`. If so, run

```js
delete(localStorage['Identify Point-suppress-help-start'])
```

then refresh the app.

 * activate Identify Point and verify that displays the help message at the bottom:

<img width="387" alt="screen shot 2017-03-27 at 12 57 44 pm" src="https://cloud.githubusercontent.com/assets/4165523/24368049/00708e0e-12ed-11e7-91ee-af7f43333178.png">

 * check `localStorage` in the console and verify that the value's now set to true
 * refresh the page, activate the Identify Point plugin, verify that the message isn't shown
 * in the console, set the plugin's suppressHelp setting to false:

```js
localStorage['Identify Point-suppress-help-start'] = false
```

 * refresh the page, activate Identify Point, verify that you see the help message again 
 * repeat in IE11 and Firefox