### PR TITLE
Adjust basemap selector behavior

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1434,9 +1434,6 @@ header .nav-main {
        and help overlay callouts */
     z-index: 5001;
 }
-.content .map .basemap-selector:hover .basemap-selector-list {
-    display: block;
-}
 .content .map .basemap-selector .basemap-selector-title {
     padding: 10px 15px;
     font-weight: bold;

--- a/src/GeositeFramework/js/BasemapSelector.js
+++ b/src/GeositeFramework/js/BasemapSelector.js
@@ -33,15 +33,24 @@
         // DOM element's 'data-index' attribute tells us which item was clicked
         var index = $(e.currentTarget).data("index");
         view.model.set('selectedBasemapIndex', index);
+        hideBasemapList(view, e);
+    }
+
+    function showBasemapList(view) {
+        view.$el.find('.basemap-selector-list').show();
+    }
+
+    function hideBasemapList(view, e) {
+        view.$el.find('.basemap-selector-list').hide();
+        e.stopPropagation();
     }
 
     N.views = N.views || {};
     N.views.BasemapSelector = Backbone.View.extend({
         initialize: function () { return initialize(this); },
         events: {
-            'click li': function (e) { onItemClicked(this, e); }
+            'click li': function (e) { onItemClicked(this, e); },
+            'click': function (e) { showBasemapList(this); }
         }
-
     });
-
 }(Geosite));

--- a/styleguide/app/cr_files/main.css
+++ b/styleguide/app/cr_files/main.css
@@ -1401,9 +1401,6 @@ header .nav-main {
        and help overlay callouts */
     z-index: 5001;
 }
-.content .map .basemap-selector:hover .basemap-selector-list {
-    display: block;
-}
 .content .map .basemap-selector .basemap-selector-title {
     padding: 10px 15px;
     font-weight: bold;


### PR DESCRIPTION
## Overview

The basemap list is now shown by clicking the basemap dropdown instead of hovering over it.

Per request from TNC.

The previous behavior was handled largely by CSS. To implement the requested behavior, additional event handling code needed to be added.

Connects #935

### Demo

![tnc5](https://cloud.githubusercontent.com/assets/1042475/24563581/e0f398fe-161c-11e7-8d02-b5640bd1a778.gif)

## Testing Instructions

- Verify that the basemap selector no longer opens when you hover over it.
- Click the basemap selector and verify it opens.
- Select a basemap.
- The basemap should update, and the basemap selector should close.

