### PR TITLE
Reduce the width of the sidebar

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -786,7 +786,7 @@ nav {
 }
 .nav-apps {
     text-align: left;
-    width: 240px;
+    width: 220px;
     background-color: #333;
     position: relative;
     z-index: 2100;
@@ -976,7 +976,7 @@ header .nav-main {
     border-radius: 0;
     border: 0;
     margin-top: 0;
-    width: 240px;
+    width: 220px;
     background-color: #3bb3be
 }
 .header-dropdown .dropdown-menu:after {

--- a/styleguide/app/cr_files/main.css
+++ b/styleguide/app/cr_files/main.css
@@ -786,7 +786,7 @@ nav {
 }
 .nav-apps {
     text-align: left;
-    width: 240px;
+    width: 220px;
     background-color: #333;
     position: relative;
     z-index: 2100;
@@ -912,7 +912,7 @@ header .nav-main {
 .nav-main {
     padding-left: 12px;
     padding-right: 12px;
-    min-width: 240px;
+    min-width: 220px;
     height: 60px;
 }
 .header-dropdown {


### PR DESCRIPTION
## Overview

Per request from TNC.

Connects to #936

### Demo

Before:

![image](https://cloud.githubusercontent.com/assets/1042475/24566632/2fccfe38-1628-11e7-91f3-e78b289fa3a8.png)

After:

![image](https://cloud.githubusercontent.com/assets/1042475/24566620/222217d2-1628-11e7-95a9-b557ee95992e.png)


## Testing Instructions

- Verify that the sidebar is indeed reduced by 20px from it's previous width.
- Activate a plugin, then minimize it. Verify that the plugin text still wraps correctly so that the plugin close button does not cover up the plugin name.
- Open the header dropdown menu, and verify that it is the same width as the sidebar.
- Toggle the sidebar size manually with the expand map control. Verify that it is restored to the correct width.

