### PR TITLE
Collapse sidebar by default

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -206,7 +206,7 @@
     </form>
 
     <script type="text/template" id="template-pane">
-        <nav class="nav-apps plugins nav-apps-narrow nav-apps-narrow-manual">
+        <nav class="nav-apps plugins nav-apps-narrow-manual">
             <div id="sidebar-help-area">
                 <a id="help-overlay-start" href="#" data-i18n="Tour">Tour</a>
             </div>

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -206,7 +206,7 @@
     </form>
 
     <script type="text/template" id="template-pane">
-        <nav class="nav-apps plugins">
+        <nav class="nav-apps plugins nav-apps-narrow nav-apps-narrow-manual">
             <div id="sidebar-help-area">
                 <a id="help-overlay-start" href="#" data-i18n="Tour">Tour</a>
             </div>

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -206,7 +206,7 @@
     </form>
 
     <script type="text/template" id="template-pane">
-        <nav class="nav-apps plugins nav-apps-narrow-manual">
+        <nav class="nav-apps plugins nav-apps-narrow">
             <div id="sidebar-help-area">
                 <a id="help-overlay-start" href="#" data-i18n="Tour">Tour</a>
             </div>

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -850,12 +850,6 @@ nav {
     border-top: 5px solid transparent
 }
 @media (max-width: 991px) {
-    .nav-apps-narrow {
-        width: 46px;
-    }
-    .nav-apps-narrow .button-text {
-        display:none;
-    }
     .nav-apps-button:hover .button-text:after {
         content: "";
         top: 16px;

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -828,13 +828,13 @@ nav {
     width: 75%;
 }
 
-.nav-apps-narrow-manual {
+.nav-apps-narrow {
     width: 46px;
 }
-.nav-apps-narrow-manual .button-text {
+.nav-apps-narrow .button-text {
     display:none;
 }
-.nav-apps-narrow-manual .nav-apps-button:hover .button-text:after {
+.nav-apps-narrow .nav-apps-button:hover .button-text:after {
     content: "";
     top: 16px;
     left: -12px;
@@ -884,7 +884,7 @@ nav {
 .plugin-launcher.active + .button-link.button-sidebar-plugin-close {
   display: inline-block;
 }
-.nav-apps-narrow-manual .button-sidebar-plugin-close {
+.nav-apps-narrow .button-sidebar-plugin-close {
   display: none !important;
 }
 @media (max-width: 991px) {

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -199,13 +199,6 @@ require(['use!Geosite',
                     this.get('pluginObject').deactivate();
                     this.set('visible', false);
                     this.trigger('plugin:deselected');
-                    // Remove the `.nav-apps-narow` class if the
-                    // de-selecting the plugin has left no plugins
-                    // visible.
-                    if (this.collection.all({visible:false})) {
-                        $('.nav-apps').removeClass('nav-apps-narrow');
-                        N.app.dispatcher.trigger('map-size:change');
-                    }
                 }
             },
 
@@ -424,7 +417,6 @@ require(['use!Geosite',
                     displayed: model.selected,
                     fullName: model.get('pluginObject').fullName
                 })),
-                sidebarNavSizedForTablet = !!$('.nav-apps-narrow'),
                 pluginContentHidden = model.collection.all({visible:false});
 
             view.$el.empty().append(html);
@@ -433,14 +425,8 @@ require(['use!Geosite',
             if (view.$uiContainer) {
                 if (view.model.selected === true) {
                     view.$uiContainer.show();
-                    if (sidebarNavSizedForTablet) {
-                        setSideBarPluginTextVisibility(false);
-                    }
                 } else {
                     view.$uiContainer.hide();
-                    if (pluginContentHidden) {
-                        setSideBarPluginTextVisibility(true);
-                    }
                 }
 
                 // Call the `resize` method on the Esri map, passing it
@@ -464,19 +450,6 @@ require(['use!Geosite',
             }
 
             return view;
-        }
-
-        function setSideBarPluginTextVisibility(visible) {
-            if (visible === undefined) {
-                throw new Error(
-                    '`setSideBarPluginTextVisibility` method requires a boolean arg');
-            } else if (visible) {
-                $('.nav-apps').removeClass('nav-apps-narrow');
-                N.app.dispatcher.trigger('map-size:change');
-            } else if (!visible) {
-                $('.nav-apps').addClass('nav-apps-narrow');
-                N.app.dispatcher.trigger('map-size:change');
-            }
         }
 
         function getContainerId(view) {

--- a/src/GeositeFramework/plugins/map_expand/main.js
+++ b/src/GeositeFramework/plugins/map_expand/main.js
@@ -21,7 +21,6 @@ define(
             initialize: function (args) {
                 declare.safeMixin(this, args);
                 this.$sidebar = $('.nav-apps.plugins');
-                this.autoSidebarNarrowClassName = 'nav-apps-narrow';
                 this.manualSidebarNarrowClassName = 'nav-apps-narrow-manual';
 
                 this.bindEvents();
@@ -43,9 +42,7 @@ define(
             activate: function () {
                 if (this.isSidebarNarrow()) {
                     this.$sidebar.removeClass(this.manualSidebarNarrowClassName);
-                    this.$sidebar.removeClass(this.autoSidebarNarrowClassName);
                 } else {
-                    this.$sidebar.addClass(this.autoSidebarNarrowClassName);
                     this.$sidebar.addClass(this.manualSidebarNarrowClassName);
                 }
 
@@ -61,16 +58,7 @@ define(
             },
 
             isSidebarNarrow: function() {
-                var docWidth = $(document).width(),
-                    narrowWidthThreshold = 991;
-
-                if (this.$sidebar.hasClass(this.manualSidebarNarrowClassName) ||
-                    (docWidth <= narrowWidthThreshold &&
-                    this.$sidebar.hasClass(this.autoSidebarNarrowClassName))) {
-                    return true;
-                }
-
-                return false;
+                return this.$sidebar.hasClass(this.manualSidebarNarrowClassName);
             },
 
             updateIcon: function() {

--- a/src/GeositeFramework/plugins/map_expand/main.js
+++ b/src/GeositeFramework/plugins/map_expand/main.js
@@ -21,7 +21,7 @@ define(
             initialize: function (args) {
                 declare.safeMixin(this, args);
                 this.$sidebar = $('.nav-apps.plugins');
-                this.manualSidebarNarrowClassName = 'nav-apps-narrow-manual';
+                this.manualSidebarNarrowClassName = 'nav-apps-narrow';
 
                 this.bindEvents();
             },

--- a/styleguide/app/index.html
+++ b/styleguide/app/index.html
@@ -94,7 +94,7 @@
     </header><!-- If a view is provided (overwritten via the region repo), a user can
         change the region setting `launchpad.html = true` to use this content -->
     <div class="flex-container content" id="left-pane">
-        <nav class="nav-apps plugins nav-apps-narrow-manual">
+        <nav class="nav-apps plugins nav-apps-narrow">
             <div id="sidebar-help-area">
                 <a href="http://lr01.internal.azavea.com:81/HUDSON_TNC_NY_Prototype_206/#" id="help-overlay-start">Tour</a>
             </div>

--- a/styleguide/app/index.html
+++ b/styleguide/app/index.html
@@ -94,7 +94,7 @@
     </header><!-- If a view is provided (overwritten via the region repo), a user can
         change the region setting `launchpad.html = true` to use this content -->
     <div class="flex-container content" id="left-pane">
-        <nav class="nav-apps plugins">
+        <nav class="nav-apps plugins nav-apps-narrow nav-apps-narrow-manual">
             <div id="sidebar-help-area">
                 <a href="http://lr01.internal.azavea.com:81/HUDSON_TNC_NY_Prototype_206/#" id="help-overlay-start">Tour</a>
             </div>

--- a/styleguide/app/index.html
+++ b/styleguide/app/index.html
@@ -94,7 +94,7 @@
     </header><!-- If a view is provided (overwritten via the region repo), a user can
         change the region setting `launchpad.html = true` to use this content -->
     <div class="flex-container content" id="left-pane">
-        <nav class="nav-apps plugins nav-apps-narrow nav-apps-narrow-manual">
+        <nav class="nav-apps plugins nav-apps-narrow-manual">
             <div id="sidebar-help-area">
                 <a href="http://lr01.internal.azavea.com:81/HUDSON_TNC_NY_Prototype_206/#" id="help-overlay-start">Tour</a>
             </div>


### PR DESCRIPTION
## Overview

This PR sets the plugins sidebar to be collapsed by default unless explicitly expanded by clicking on the map control.

Connects #945 

### Notes

This works by adding the specified classes to the `nav` element initially; later toggles look to check whether those classes exist to do their toggling.

Also updated the style guide CSS to match.

## Testing Instructions

 * get this branch and check IE 11, Firefox, Safari, Chrome, and iPad Safari to verify that the following behavior holds:
    * on loading the app the sidebar is collapsed
    * on clicking to open, close, or minimize a plugin, or to switch plugins, the sidebar is collapsed
    * clicking the expand map control expands the sidebar and keeps it expanded through future plugin opens, closes, minimizes, and un-minimizes

