### PR TITLE
Collapse basemap list onclickoutside or on title

### DIFF
--- a/src/GeositeFramework/js/BasemapSelector.js
+++ b/src/GeositeFramework/js/BasemapSelector.js
@@ -9,6 +9,17 @@
         render(view);
         // When the map's selected basemap changes, update the title element in the DOM
         view.model.on('change:selectedBasemapIndex', function () { renderSelectedBasemapName(view); });
+        view.model.set('basemapListVisible', false);
+        $(document).on('click', function(e) {
+           if (!_.contains(['basemap-selector-list', 'basemap-selector'], e.target.className)) {
+               hideBasemapList(view);
+           }
+        });
+        // Listen on the "Tour" link element to ensure the
+        // basemap selector closes before the tour overlay's applied
+        $('#help-overlay-start').on('click', function() {
+            hideBasemapList(view);
+        });
     }
 
     function render(view) {
@@ -33,16 +44,24 @@
         // DOM element's 'data-index' attribute tells us which item was clicked
         var index = $(e.currentTarget).data("index");
         view.model.set('selectedBasemapIndex', index);
-        hideBasemapList(view, e);
-    }
-
-    function showBasemapList(view) {
-        view.$el.find('.basemap-selector-list').show();
-    }
-
-    function hideBasemapList(view, e) {
-        view.$el.find('.basemap-selector-list').hide();
         e.stopPropagation();
+        hideBasemapList(view);
+    }
+
+    function toggleBasemapList(view, e) {
+        e.stopPropagation();
+        if (view.model.get('basemapListVisible')) {
+            view.model.set('basemapListVisible', false);
+            view.$el.find('.basemap-selector-list').hide();
+        } else {
+            view.model.set('basemapListVisible', true);
+            view.$el.find('.basemap-selector-list').show();
+        }
+    }
+
+    function hideBasemapList(view) {
+        view.model.set('basemapListVisible', false);
+        view.$el.find('.basemap-selector-list').hide();
     }
 
     N.views = N.views || {};
@@ -50,7 +69,7 @@
         initialize: function () { return initialize(this); },
         events: {
             'click li': function (e) { onItemClicked(this, e); },
-            'click': function (e) { showBasemapList(this); }
+            'click': function (e) { toggleBasemapList(this, e); }
         }
     });
 }(Geosite));


### PR DESCRIPTION
## Overview

This PR updates the basemap selector component to enable toggling the basemap list open and closed on clicking the title and to close it on clicking outside the div.

To make this happen, I added a click listener to the document from the basemap selector, then called the `hideBasemapList` method on any click which was not the list or the title.

Separately, the component now keeps track of the state of whether the list is hidden or visible, then use that state to toggle it open and closed on clicking the title.

Connects #944 

### Demo

![tnc-close-basemap-selector-on-clicks](https://cloud.githubusercontent.com/assets/4165523/24930543/da7a12a0-1ed7-11e7-9629-f11203ff02b8.gif)

## Testing Instructions

 * rebuild this branch in VS, then view it in the browser
 * verify that you can open and close the basemap selector list by clicking on the title
 * verify that selecting a basemap option closes the list
 * verify that clicking anywhere else in the app closes the list if it's open
