### PR TITLE
Add WMS Server needed for future_habitat_v2

### DIFF
--- a/src/GeositeFramework/proxy.config
+++ b/src/GeositeFramework/proxy.config
@@ -22,6 +22,7 @@
     <serverUrl matchAll="true" url="http://lr13:6080/"></serverUrl>
     <serverUrl matchAll="true" url="http://sampleserver1.arcgisonline.com"></serverUrl>
     <serverUrl matchAll="true" url="http://preview.grid.unep.ch:8080"></serverUrl>
+    <serverUrl matchAll="true" url="http://mapserver.maine.gov"></serverUrl>
   </serverUrls>
 
 </ProxyConfig>


### PR DESCRIPTION
We need to use the WMS Server provided by mapserver.maine.gov as requested for the future_habitat_v2 app.  They provide LIDAR data in our region of interest.

## Overview

Adds a rule for the mapserver.maine.gov WMS server

Connects #XXX

## Testing Instructions

Build the future_habitat_v2 app with this change and turn on the LIDAR layer.  LIDAR layer should be proxied through the CoastalResilience proxy and displayed on the map.

