### PR TITLE
Fix app-print cleanup

### DIFF
--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -10,7 +10,7 @@ require(['use!Geosite'],
             $('<link>', {
                 rel: 'stylesheet',
                 href: 'css/app-print.css',
-                'class': '.app-print-css' 
+                'class': 'app-print-css' 
             }).appendTo('head');
             var html = N.app.templates['template-export-window']();
             view.$el.empty().append(html);


### PR DESCRIPTION
Currently the app-print.css file, with class 'app-print-css' is not getting removed from the app when closing the print dialog because the class is created with a "." in it.  The class shouldn't be prepended with a "." in the class attribute.  Removing fixes the problem and the css file is correctly removed on cleanup. c.c. @zferdana

## Overview

Fixes the naming of the app-print-css class so the app can correctly reference it

## Testing Instructions

Open a plugin with print functionality.
Open your browsers dev tools and expand the head section in elements.
Click the print button in the app.
See css/app-print.css file with class=".app-print-css" added to the head.
Click close on the print dialog.
The css/app-print.css file is not removed from the document head.  Opening the print dialog again with add another copy of the css/app-print.css file.

