### PR TITLE
dropped height from sidebar-content

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -769,7 +769,6 @@ nav {
 }
 .sidebar-content {
     position: relative;
-    height: calc(100% - 40px);
     overflow-y: auto;
     margin-top: 40px;
     width: 100%;


### PR DESCRIPTION
The height property (even without calc) hides elements in some apps. Removing it makes them show up. It appears to have no effect on other apps.

