### PR TITLE
Reduce sidebar z-index to fix dropshadow bug

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -742,7 +742,7 @@ nav {
 }
 .sidebar {
   box-shadow: 0px 0px 26px 0px rgba(51, 51, 51, 0.42);
-  z-index: 2000;
+  z-index: 1;
 }
 .sidebar-nav,
 .sidebar-with-nav-vertical {


### PR DESCRIPTION
## Overview

Changing the z-index from 2000 to 1 fixes the dropshadow white-out bug,
but does not impact the visual style of the app.

Fix provided by @lesserj.

Connects to #958

## Testing Instructions

I haven't been able to reproduce this locally, but I was able to test the fix by doing the following

- Visit http://maps.coastalresilience.org/hawaii/
- Activate the "Ecosystem Effects of Sea Level Change".
- Note the white sidebar
- Apply the change from this PR to the stylesheet in chrome.
- The white sidebar should go away.