### PR TITLE
Implement single plugin mode

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -237,6 +237,21 @@
                 },
             },
             "additionalProperties": false
+        },
+        "singlePluginMode": {
+            "type": "object",
+            "required": false,
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "required": true
+                },
+                "pluginFolderName": {
+                    "type": "string",
+                    "required": true
+                }
+            },
+            "additionalProperties": false
         }
     },
     "additionalProperties": false

--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -249,6 +249,10 @@
                 "pluginFolderName": {
                     "type": "string",
                     "required": true
+                },
+                "title": {
+                    "type": "string",
+                    "required": true
                 }
             },
             "additionalProperties": false

--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Web.Helpers;
 using GeositeFramework.Helpers;
 using Newtonsoft.Json.Linq;
 
@@ -60,6 +61,7 @@ namespace GeositeFramework.Models
         public String TertiaryColor { get; private set; }
         public String ActiveAppColor { get; private set; }
         public String PrintHeaderLogo { get; private set; }
+        public Boolean SinglePluginMode { get; private set; }
 
         /// <summary>
         /// Create a Geosite object by loading the "region.json" file and enumerating plug-ins, using the specified paths.
@@ -122,6 +124,19 @@ namespace GeositeFramework.Models
             }
 
             PluginFolderNames = existingPluginFolderNames;
+
+            // If single plugin mode is active, remove every plugin besides the specified plugin
+            // from the plugin lists.
+            if (jsonObj["singlePluginMode"] != null && (bool)jsonObj["singlePluginMode"]["active"])
+            {
+                SinglePluginMode = true;
+                var singlePlugin = (string)jsonObj["singlePluginMode"]["pluginFolderName"];
+                PluginFolderNames = PluginFolderNames.Where(p => p.Contains(singlePlugin)).ToList();
+                pluginModuleNames = pluginModuleNames.Where(p => p.Contains(singlePlugin)).ToList();
+            } else
+            {
+                SinglePluginMode = false;
+            }
 
             // Augment the JSON so the client will have the full list of folder names
             jsonObj.Add("pluginFolderNames", new JArray(PluginFolderNames.ToArray()));

--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -142,8 +142,23 @@ namespace GeositeFramework.Models
             jsonObj.Add("pluginFolderNames", new JArray(PluginFolderNames.ToArray()));
 
             // Set public properties needed for View rendering
-            TitleMain = ExtractLinkFromJson(jsonObj["titleMain"]);
-            TitleDetail = ExtractLinkFromJson(jsonObj["titleDetail"]);
+            if (SinglePluginMode)
+            {
+                TitleMain = new Link
+                {
+                    Text = (string)jsonObj["singlePluginMode"]["title"],
+                    Url = ""
+                };
+                TitleDetail = new Link
+                {
+                    Text = "About",
+                    Url = ""
+                };
+            } else
+            {
+                TitleMain = ExtractLinkFromJson(jsonObj["titleMain"]);
+                TitleDetail = ExtractLinkFromJson(jsonObj["titleDetail"]);
+            }
 
             var colorConfig = jsonObj["colors"];
             if (colorConfig != null)

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -207,7 +207,7 @@
     </form>
 
     <script type="text/template" id="template-pane">
-        <nav class="nav-apps plugins nav-apps-narrow">
+        <nav class="nav-apps plugins nav-apps-narrow @(Model.SinglePluginMode ? "single-plugin-mode" : "")">
             <div id="sidebar-help-area">
                 <a id="help-overlay-start" href="#" data-i18n="Tour">Tour</a>
                 <div id="sidebar-toggle">

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -793,6 +793,9 @@ nav {
     padding-bottom: 27px;
     overflow: visible;
 }
+.nav-apps.single-plugin-mode {
+    display: none;
+}
 .nav-apps-button {
     width: 100%;
     text-align: left;

--- a/src/GeositeFramework/js/App.js
+++ b/src/GeositeFramework/js/App.js
@@ -28,6 +28,11 @@
                 N.app.loadedWithState = true;
             }
 
+            N.app.singlePluginMode = false;
+            if (regionData.singlePluginMode) {
+                N.app.singlePluginMode = regionData.singlePluginMode.active;
+            }
+
             // Set up the google url shortener service
             gapi.client.load('urlshortener', 'v1');
             if (regionData.googleUrlShortenerApiKey) {

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -168,12 +168,14 @@ require([
             var mapModel = model.get('mapModel'),
                 regionData = model.get('regionData'),
                 savedState = model.get('stateOfPlugins'),
-                launchpadPlugin = null;
+                // Either the launchpad or the specified plugin for single plugin mode
+                initialPlugin = null;
 
             model.get('plugins').each(function(pluginModel) {
-                if (checkName(pluginModel, 'launchpad')) {
-                    launchpadPlugin = pluginModel;
+                if (checkName(pluginModel, 'launchpad') || N.app.singlePluginMode) {
+                    initialPlugin = pluginModel;
                 }
+
                 pluginModel.initPluginObject(regionData, mapModel, esriMap);
             });
 
@@ -184,8 +186,8 @@ require([
 
                 // If no savedState and there is a launchpad plugin, active it first.
                 // A saveCode key would indicate that another plugin should be active
-                if (Object.keys(savedState).length === 0 && launchpadPlugin) {
-                    launchpadPlugin.toggleSelected();
+                if (Object.keys(savedState).length === 0 && initialPlugin) {
+                    initialPlugin.toggleSelected();
                 }
             }, 1000);
         }

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -3,7 +3,8 @@
     "googleUrlShortenerApiKey": "AIzaSyDd5hwYX4vAMLOH425cnMSq3gte98w4VFA",
     "singlePluginMode": {
         "active": true,
-        "pluginFolderName": "regional-planning"
+        "pluginFolderName": "regional-planning",
+        "title": "Single Plugin Mode Title"
     },
     "titleMain": {
         "text": "Geosite Framework Sample",

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -1,6 +1,10 @@
 {
     "language": "en",
     "googleUrlShortenerApiKey": "AIzaSyDd5hwYX4vAMLOH425cnMSq3gte98w4VFA",
+    "singlePluginMode": {
+        "active": true,
+        "pluginFolderName": "regional-planning"
+    },
     "titleMain": {
         "text": "Geosite Framework Sample",
         "url": "http://www.azavea.com/"


### PR DESCRIPTION
## Overview

Takes a first pass at implementing single plugin mode. There is some follow-up work to do, but the basics are implemented here. See commit messages for details.

Connects #966 
Connects #965 

### Demo

![image](https://user-images.githubusercontent.com/1042475/29466235-1c207c70-840a-11e7-9a8e-8ceee8a19e38.png)

### Notes

Follow-up work:

- Decide on launchpad implementation
- Disable subregions in single plugin mode
- Remove plugin minimize/close buttons.

## Testing Instructions

* Launch the site and verify it is in single plugin mode. The sidebar should be hidden, the layer picker should be active, and the app title should mention single plugin mode.
* Update the region config to disable single plugin mode. Reload the site, and confirm the app loads and works as normal.