### PR TITLE
Remove single plugin mode title

### DIFF
--- a/src/GeositeFramework/App_Data/regionSchema.json
+++ b/src/GeositeFramework/App_Data/regionSchema.json
@@ -423,10 +423,6 @@
                 "pluginFolderName": {
                     "type": "string",
                     "required": true
-                },
-                "title": {
-                    "type": "string",
-                    "required": true
                 }
             },
             "additionalProperties": false

--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -142,23 +142,8 @@ namespace GeositeFramework.Models
             jsonObj.Add("pluginFolderNames", new JArray(PluginFolderNames.ToArray()));
 
             // Set public properties needed for View rendering
-            if (SinglePluginMode)
-            {
-                TitleMain = new Link
-                {
-                    Text = (string)jsonObj["singlePluginMode"]["title"],
-                    Url = ""
-                };
-                TitleDetail = new Link
-                {
-                    Text = "About",
-                    Url = ""
-                };
-            } else
-            {
-                TitleMain = ExtractLinkFromJson(jsonObj["titleMain"]);
-                TitleDetail = ExtractLinkFromJson(jsonObj["titleDetail"]);
-            }
+            TitleMain = ExtractLinkFromJson(jsonObj["titleMain"]);
+            TitleDetail = ExtractLinkFromJson(jsonObj["titleDetail"]);
 
             var colorConfig = jsonObj["colors"];
             if (colorConfig != null)

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -3,8 +3,7 @@
     "googleUrlShortenerApiKey": "AIzaSyDd5hwYX4vAMLOH425cnMSq3gte98w4VFA",
     "singlePluginMode": {
         "active": true,
-        "pluginFolderName": "regional-planning",
-        "title": "Single Plugin Mode Title"
+        "pluginFolderName": "regional-planning"
     },
     "titleMain": {
         "text": "Geosite Framework Sample",


### PR DESCRIPTION
## Overview

We decided this was extraneous in #970.

Essentially reverts bf5451a, which should have been reverted in #970.

Connects #966

### Notes

This should have been removed in #970, but I must have not force pushed the update branch.

## Testing Instructions

- Load up the app, verify it is in single plugin mode, and that the app has the standard title.