### PR TITLE
Demo single plugin mode

### DIFF
--- a/src/GeositeFramework/Models/Geosite.cs
+++ b/src/GeositeFramework/Models/Geosite.cs
@@ -131,8 +131,25 @@ namespace GeositeFramework.Models
             {
                 SinglePluginMode = true;
                 var singlePlugin = (string)jsonObj["singlePluginMode"]["pluginFolderName"];
-                PluginFolderNames = PluginFolderNames.Where(p => p.Contains(singlePlugin)).ToList();
-                pluginModuleNames = pluginModuleNames.Where(p => p.Contains(singlePlugin)).ToList();
+
+                if (String.IsNullOrEmpty(singlePlugin))
+                {
+                    const string msg = "Single plugin mode is active but no plugin is defined.";
+                    throw new Exception(msg);
+                }
+
+                var singlePluginFolderName = PluginFolderNames.Where(p => p.Contains(singlePlugin)).ToList();
+                var singlePluginModuleName = pluginModuleNames.Where(p => p.Contains(singlePlugin)).ToList();
+
+                if (String.IsNullOrEmpty(singlePluginFolderName.FirstOrDefault()))
+                {
+                    const string msg = "The specified plugin for single plugin mode was not found.";
+                    throw new Exception(msg);
+                } else
+                {
+                    PluginFolderNames = singlePluginFolderName;
+                    pluginModuleNames = singlePluginModuleName;
+                }
             } else
             {
                 SinglePluginMode = false;

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -77,7 +77,8 @@ require(['use!Geosite',
                         downloadAsPlainText: requestTextDownload,
                         dispatcher: N.app.dispatcher,
                         suppressHelpOnStartup: _.partial(suppressHelpOnStartup, model),
-                        resize: resizers
+                        resize: resizers,
+                        singlePluginMode: N.app.singlePluginMode
                     },
                     plugin: {
                         turnOff: _.bind(model.turnOff, model)

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -3,7 +3,7 @@
     "googleUrlShortenerApiKey": "AIzaSyDd5hwYX4vAMLOH425cnMSq3gte98w4VFA",
     "singlePluginMode": {
         "active": true,
-        "pluginFolderName": "regional-planning"
+        "pluginFolderName": "identify_point"
     },
     "titleMain": {
         "text": "Geosite Framework Sample",

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -94,7 +94,7 @@ define(["dojo/_base/declare", "framework/PluginBase"],
                 if (showHelpOnStart) {
                     this.showHelp();
 
-                    // Don't show this help on startup anymore, after the first time 
+                    // Don't show this help on startup anymore, after the first time
                     this.app.suppressHelpOnStartup(true);
                 }
 

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -1,4 +1,13 @@
-﻿
+require({
+    packages: [
+        {
+            name: "jquery",
+            location: "//ajax.googleapis.com/ajax/libs/jquery/1.9.0",
+            main: "jquery.min"
+        }
+    ]
+});
+
 define(["dojo/_base/declare", "framework/PluginBase"],
     function (declare, PluginBase) {
         return declare(PluginBase, {

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -20,8 +20,13 @@ define(["dojo/_base/declare", "framework/PluginBase"],
             usePrintPreviewMap: true,
             previewMapSize: [500, 350],
 
-            initialize: function(args) {
-                declare.safeMixin(this, args);
+            initialize: function(frameworkParameters) {
+                declare.safeMixin(this, frameworkParameters);
+
+                if (frameworkParameters.app.singlePluginMode) {
+                    $(this.container).append('<h2>Welcome to single plugin mode!</h2>');
+                }
+
                 $(this.container).append(
                     '<h4 style="padding: 5px;">' + i18next.t('Click any point on the map to display Latitude and Longitude') + '</h4>');
 


### PR DESCRIPTION
## Overview

Demos single plugin mode by showing a custom message in the identify plugin. Also, some basic guards were added when parsing the config for single plugin mode.

The identify plugin is patched up so that it can function as a stand alone plugin. It previously relied on other plugins bringing in jQuery. 

Connects #967 

### Demo

![image](https://user-images.githubusercontent.com/1042475/29825671-1cae759c-8ca3-11e7-877f-793a0d99a8bd.png)

## Testing Instructions

- Load the app, which should be in single plugin mode. Verify that the identify point plugin loads and displays some text about single plugin mode. 
- Turn off single plugin mode, and reload the app. Open the identify plugin, and verify that text about single plugin mode is not displayed.
- In the config, enter an invalid plugin name for single plugin mode. Verify that the app does not load.
- In the config, remove the plugin name for single plugin mode. Verify that the app does not load.