### PR TITLE
Implement "expand sidebar" button

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -175,6 +175,27 @@
         .dropdown-submenu > a:not(:hover) {
             background-color: @Model.SecondaryColor;
         }
+
+        @if (Model.SinglePluginMode) {
+        <text>
+        .sidebar-content {
+            height: 100% !important;
+            margin-top: 0 !important;
+        }
+
+        .sidebar-nav {
+            display:none;
+        }
+
+        #toggle-plugin-container button {
+            background-color: @Model.PrimaryColor;
+            border-color: @Model.PrimaryColor;
+        }
+        #toggle-plugin-container button:hover {
+            background-color: @Model.SecondaryColor;
+        }
+        </text>
+        }
     </style>
 
     @if (Model.GoogleAnalyticsPropertyId != null)
@@ -217,6 +238,11 @@
         </nav>
         <div class="flex-expand">
             <div class="flex-container">
+                @if (Model.SinglePluginMode) {
+                <div id="toggle-plugin-container" class="single-plugin-mode">
+                    <span><i class="fa fa-chevron-left" aria-hidden="true"></i></span>
+                </div>
+                }
                 <div id="map-0" class="map">
                     <div class="control-container">
                         <div class="top-tools"></div>

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -742,7 +742,7 @@ nav {
 }
 .sidebar {
   box-shadow: 0px 0px 26px 0px rgba(51, 51, 51, 0.42);
-  z-index: 1;
+  z-index: 2;
 }
 .sidebar-nav,
 .sidebar-with-nav-vertical {
@@ -773,6 +773,7 @@ nav {
     overflow-y: auto;
     margin-top: 40px;
     width: 100%;
+    background-color: #fff;
 }
 .sidebar-content section:not(:last-child) {
     border-bottom: 1px solid #cdd5d5;
@@ -883,6 +884,18 @@ nav {
   top: 50%;
   transform: translateY(-50%);
   width: 22px;
+}
+#toggle-plugin-container {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  z-index: 2;
+  padding: 7px 12px;
+  background-color: #DDD;
+  cursor: pointer;
+}
+#toggle-plugin-container span {
+  color: #000;
 }
 .plugin-launcher.active + .button-link.button-sidebar-plugin-close {
   display: inline-block;

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -298,6 +298,9 @@ require([
             initSidebarToggle(view);
             initMapView(view);
             initPluginViews(view);
+            if (N.app.singlePluginMode) {
+                initTogglePlugin(view);
+            }
 
             // For on demand export initialization. See Layer Selector print, for example.
             var paneNumber = view.model.get('paneNumber');
@@ -323,6 +326,15 @@ require([
             new N.views.SidebarToggle({
                 el: view.$('#sidebar-toggle')
             });
+        }
+
+        function initTogglePlugin(view) {
+            var togglePluginView = new N.views.TogglePlugin({
+                el: view.$('#toggle-plugin-container'),
+                viewModel: view.model
+            });
+
+            togglePluginView.$el.show();
         }
 
         function initMapView(view) {

--- a/src/GeositeFramework/js/SidebarToggle.js
+++ b/src/GeositeFramework/js/SidebarToggle.js
@@ -42,4 +42,25 @@
             'click': function (e) { toggle(this, e); }
         }
     });
+
+    // Single plugin mode button to toggle plugin visibility
+    N.views.TogglePlugin = Backbone.View.extend({
+        initialize: function(options) {
+            this.singlePlugin = options.viewModel.get('plugins').at(0);
+        },
+
+        events: {
+            'click': 'togglePluginVisibility'
+        },
+
+        togglePluginVisibility: function() {
+            if (this.singlePlugin.selected) {
+                this.singlePlugin.deselect();
+                this.$el.find('i').attr('class', 'fa fa-chevron-right');
+            } else {
+                this.singlePlugin.select();
+                this.$el.find('i').attr('class', 'fa fa-chevron-left');
+            }
+        }
+    });
 }(Geosite));


### PR DESCRIPTION
## Overview

Implements the "toggle sidebar" button which hides/restores the plugin in single plugin mode. Also removes some of the plugin UI in single plugin mode to match the wireframes.

Connects #973

### Demo

![tnc1](https://user-images.githubusercontent.com/1042475/30344890-0af01d22-97d1-11e7-867a-4995eade050d.gif)

### Notes

~~As you will note in the demo video above, the CSS for the plugin minimize button is not final. It's tricky to have an element that lives outside the plugin content (so that it is outside the scope of the plugin) but does not interfere with the plugin contents. I'll need to consult with @jfrankl.~~

## Testing Instructions

- Launch the app with single plugin mode enabled.
- Minimize the activate plugin using the "Hide sidebar" plugin.
- Use the "Expand sidebar" button to restore the plugin.
- Verify that these buttons are not displayed in regular mode.

Also looking for feedback on:
- Use of razor templating within underscore templates for single plugin mode elements and style. It's a little confusing, but I think results in cleaner templates (instead of lots of if/else in JS templates).
- Location of "toggle sidebar" button code. I wasn't sure of the best place for this.