### PR TITLE
Implement single plugin mode help pane

### DIFF
--- a/src/GeositeFramework/GeositeFramework.csproj
+++ b/src/GeositeFramework/GeositeFramework.csproj
@@ -188,6 +188,7 @@
     <Content Include="js\PluginBase.js" />
     <Content Include="js\polyfill.js" />
     <Content Include="js\Screen.js" />
+    <Content Include="js\SinglePluginModeHelp.js" />
     <Content Include="js\SubRegion.js" />
     <Content Include="js\lib\backbone.picky.js" />
     <Content Include="js\lib\backbone.picky.min.js" />
@@ -258,6 +259,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Views\Shared\CustomLaunchPadContent.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Shared\SinglePluginModeHelp.cshtml" />
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -179,8 +179,8 @@
         @if (Model.SinglePluginMode) {
         <text>
         .sidebar-content {
-            height: 100% !important;
-            margin-top: 0 !important;
+            height: 100%;
+            margin-top: 0;
         }
 
         .sidebar-nav {
@@ -228,6 +228,13 @@
     </form>
 
     <script type="text/template" id="template-pane">
+        @if (Model.SinglePluginMode) {
+        <text>
+        <div id="single-plugin-mode-help-container">
+            Help
+        </div>
+        </text>
+        }
         <nav class="nav-apps plugins nav-apps-narrow @(Model.SinglePluginMode ? "single-plugin-mode" : "")">
             <div id="sidebar-help-area">
                 <a id="help-overlay-start" href="#" data-i18n="Tour">Tour</a>
@@ -638,6 +645,24 @@
         </div>
     </script>
 
+    <script type="text/template" id="single-plugin-mode-help-template">
+        <div class="sidebar content-scrollable">
+            <div class="sidebar-nav">
+                <h2 class="nav-title" class="i18n" data-i18n="About">
+                    About
+                </h2>
+                <div class="nav-buttons">
+                    <button class="button-link plugin-off i18n" data-i18n="[title]Turn off this plugin" title="Turn off this plugin">
+                        <i class="icon-cancel"></i>
+                    </button>
+                </div>
+            </div>
+            <div class="sidebar-content">
+                <%= content %>
+            </div>
+        </div>
+    </script>
+
     <!-- TOP BAR, FIXED TO THE TOP OF THE SCREEN -->
     <header>
         <div class="dropdown header-dropdown nav-main-dropdown">
@@ -656,7 +681,11 @@
             </ul>
         </div>
         <div class="nav-region-subtitle">
-            @Model.TitleDetail.Text
+            @if (!Model.SinglePluginMode) {
+                @Model.TitleDetail.Text
+            } else {
+                <text><span id="show-single-plugin-mode-help">About</span></text>
+            }
         </div>
         <div id="search"></div>
     </header>
@@ -667,6 +696,10 @@
         change the region setting `launchpad.html = true` to use this content -->
     <div id="custom-launchpad-content" style="display:none;">
         @Html.Partial("CustomLaunchpadContent")
+    </div>
+
+    <div id="single-plugin-mode-help-content" style="display:none;">
+        @Html.Partial("SinglePluginModeHelp")
     </div>
 
     <!-- Area for plugins to arrange their markup independent
@@ -761,6 +794,11 @@
     <script src="js/HelpOverlay.js"></script>
     <script src="js/BasemapSelector.js"></script>
     <script src="js/SidebarToggle.js"></script>
+    @if (@Model.SinglePluginMode) {
+    <text>
+        <script src="js/SinglePluginModeHelp.js"></script>
+    </text>
+    }
     <script src="js/TimeoutWrapper.js"></script>
     <script src="js/Identify.js"></script>
     <script src="js/Map.js"></script>

--- a/src/GeositeFramework/Views/Shared/SinglePluginModeHelp.cshtml
+++ b/src/GeositeFramework/Views/Shared/SinglePluginModeHelp.cshtml
@@ -1,0 +1,4 @@
+<img src="http://placehold.it/300x150">
+<div>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum
+</div>

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -928,6 +928,37 @@ nav {
 .nav-apps-button {
   padding: 7px 10px 7px;
 }
+#single-plugin-mode-help-container {
+    left: 0;
+    background: #fff;
+    height: 100%;
+    position: absolute;
+    z-index: 10;
+    display: none;
+    width: 350px;
+}
+#single-plugin-mode-help-container .sidebar {
+    height: 100%;
+}
+#single-plugin-mode-help-container .sidebar-nav {
+    border-bottom: none;
+    position: relative;
+    display: flex;
+}
+#single-plugin-mode-help-container .sidebar-nav .nav-title {
+    font-size: 14px;
+}
+#single-plugin-mode-help-container .sidebar-content {
+    padding: 10px;
+    margin-top: 0;
+    height: calc(100% - 40px);
+}
+#single-plugin-mode-help-container .plugin-off {
+    cursor: pointer;
+}
+#show-single-plugin-mode-help {
+    cursor: pointer;
+}
 #map-0.map {
     position: absolute;
     top: 0;

--- a/src/GeositeFramework/js/Pane.js
+++ b/src/GeositeFramework/js/Pane.js
@@ -300,6 +300,7 @@ require([
             initPluginViews(view);
             if (N.app.singlePluginMode) {
                 initTogglePlugin(view);
+                initSinglePluginModeHelp(view);
             }
 
             // For on demand export initialization. See Layer Selector print, for example.
@@ -335,6 +336,13 @@ require([
             });
 
             togglePluginView.$el.show();
+        }
+
+        function initSinglePluginModeHelp(view) {
+            new N.views.SinglePluginModeHelp({
+                el: view.$('#single-plugin-mode-help-container'),
+                viewModel: view.model
+            });
         }
 
         function initMapView(view) {

--- a/src/GeositeFramework/js/SinglePluginModeHelp.js
+++ b/src/GeositeFramework/js/SinglePluginModeHelp.js
@@ -1,0 +1,48 @@
+(function (N) {
+    'use strict';
+
+    var $container;
+    var $pluginToggle;
+    var singlePlugin;
+
+    function initialize(view, $el) {
+        $container = $el;
+        $pluginToggle = $('#toggle-plugin-container');
+
+        // Get the content from the developer-provided HTML partial
+        var content = $('#single-plugin-mode-help-content').html();
+
+        // Get the template for the help pane
+        var tmpl = _.template($('#single-plugin-mode-help-template').html());
+
+        // Insert the template, with the custom contents, to the help pane.
+        $container.html(tmpl({ content: content }));
+
+        // It's a bit odd to have this here, but there isn't a more discoverable
+        // place for it to be.
+        $('#show-single-plugin-mode-help').click(function() {
+            $container.show();
+            $pluginToggle.hide();
+            singlePlugin.get('$uiContainer').hide();
+        });
+    }
+
+    function close(view) {
+        $container.hide();
+        $pluginToggle.show();
+        if (singlePlugin.selected) {
+            singlePlugin.get('$uiContainer').show();
+        }
+    }
+
+    N.views = N.views || {};
+    N.views.SinglePluginModeHelp = Backbone.View.extend({
+        initialize: function (options) {
+            singlePlugin = options.viewModel.get('plugins').at(0);
+            return initialize(this, $('#single-plugin-mode-help-container'), singlePlugin);
+        },
+        events: {
+            'click .plugin-off': function (e) { close(this, e); }
+        }
+    });
+}(Geosite));


### PR DESCRIPTION
## Overview 

Add mechanism for developers to provide custom help content in single
plugin mode.

Where possible, code is only included on the client when single plugin
mode is active.

Connects #974

### Demo

![tnc1](https://user-images.githubusercontent.com/1042475/30445942-a9660dec-9955-11e7-89b8-bd9a293d01ce.gif)

## Testing Instructions

- Launch single plugin mode, and verify the app subtitle is replaced with the word "About".
- Click "About", and verify that the help panel opens.
- Launch the app in regular mode, and verify that the subtitle is back.

