### PR TITLE
Reduce map legend to one column

### DIFF
--- a/src/GeositeFramework/js/Legend.js
+++ b/src/GeositeFramework/js/Legend.js
@@ -233,7 +233,7 @@ define(['use!Geosite',
             // legends. It will do so until the hard-coded limits
             // here are reached.
             var MAX_HEIGHT = 400, // Somewhat arbitrary
-                MAX_WIDTH = 485, // Just enough to fit two columns
+                MAX_WIDTH = 255, // Just enough to fit one column
                 MIN_WIDTH = 255, // Just enough to fit one column
                 LEGEND_BODY_PADDING = 22;
 


### PR DESCRIPTION
## Overview

When the legend is auto-resizing, it will now only use one column instead of two. This is done by setting the min and max width to the same value.

Per request from TNC.

Connects to #938

### Demo

![tnc3](https://user-images.githubusercontent.com/1042475/30657086-530c015a-9e04-11e7-8429-4e7618b5497a.gif)

### Notes

I decided to leave the existing implementation and just adjust the relevant constant because it made for a quick fix and there's a chance this decision may be revisited.

## Testing Instructions

- Activate the regional planning plugin.
- Activate layers until the legend needs to resize. As it resizes, verify that it stays one column wide.
- ~~Manually resize the legend to two columns. Verify that the legend keeps this shape even as layers are turned off.~~
