### PR TITLE
Disable subregions in single plugin mode

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -159,7 +159,9 @@ require(['use!Geosite',
             // would be detached from the body and the parent would not be accessible
             view.$infoWindowParent = $(esriMap.infoWindow.domNode).parent();
 
-            setupSubregions(N.app.data.region.subregions, esriMap);
+            if (!N.app.singlePluginMode) {
+                setupSubregions(N.app.data.region.subregions, esriMap);
+            }
         });
 
         function setupSubregions(subregions, esriMap) {


### PR DESCRIPTION
## Overview

The subregion "availablePlugins" configuration option conflicts with single plugin mode, as well as adds complications to supporting single plugin mode.

Connects to #972

## Testing Instructions

- Activate the app in regular mode. Verify the subregion geometries are on the map.
- Activate the app in single plugin mode. Verify the subregion geometries are removed from the map.