### PR TITLE
Ensure help pane is displayed on top of map scale

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -933,7 +933,7 @@ nav {
     background: #fff;
     height: 100%;
     position: absolute;
-    z-index: 10;
+    z-index: 100;
     display: none;
     width: 350px;
 }


### PR DESCRIPTION
Connects #974

## Demo

*Before*
![image](https://user-images.githubusercontent.com/1042475/30708948-865aba9a-9ece-11e7-934a-adc781dcf9dd.png)

*After*
![image](https://user-images.githubusercontent.com/1042475/30708955-91148038-9ece-11e7-97b1-9248442b1d62.png)

## Testing Instructions

Toggle the `About` pane and verify that it is displayed on top of the map scale.