### PR TITLE
Adjust legend content size to reduce overflow

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1670,7 +1670,7 @@ header .nav-main {
 .content .legend .legend-body {
     padding: 10px 15px;
     overflow: auto;
-    height: 100%;
+    height: 99%;
     width: 100%;
 }
 .layer-legends {


### PR DESCRIPTION
Previously, once enough items were added to the legend, the last item in the list would very slightly extend beyond the bottom of the legend container. By slightly reducing the size of legend content, the overflow is eliminated. Reported and fixed by @matts5517.

Connects #993

### Demo

**Before**
![image](https://user-images.githubusercontent.com/1042475/30752205-8fbfacd8-9f89-11e7-9372-27683f59823a.png)
*Note white line under legend*

**After**
![image](https://user-images.githubusercontent.com/1042475/30752028-14610ce4-9f89-11e7-8f13-7144fa1425b5.png)

## Testing Instructions

- Add and remove layers and verify that the legend never overflows like in the above *before* photo.