### PR TITLE
Move menu to right in single plugin mode

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -40,7 +40,7 @@
                         <i class="dropdown-icon icon-angle-right"></i>
                     </a>
 
-                    <ul class="dropdown-menu">
+                    <ul class="dropdown-menu" id="region-links">
                         @RenderRegionLinks(link.Items)
                     </ul>
                 </li>
@@ -193,6 +193,13 @@
         }
         #toggle-plugin-container button:hover {
             background-color: @Model.SecondaryColor;
+        }
+
+        /* Ideally these would be stored in class, but when the ESRI search is
+        initialized, existing classes are overwritten */
+        #search {
+            right: 45px;
+            z-index: 10000;
         }
         </text>
         }
@@ -665,6 +672,7 @@
 
     <!-- TOP BAR, FIXED TO THE TOP OF THE SCREEN -->
     <header>
+        @if (!@Model.SinglePluginMode) {
         <div class="dropdown header-dropdown nav-main-dropdown">
             <button class="button dropdown-toggle nav-main-button" type="button" id="header-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <div class="nav-main">
@@ -680,6 +688,13 @@
                 @RenderLinks(Model.HeaderLinks)
             </ul>
         </div>
+        } else {
+        <div class="nav-main">
+            <div class="nav-main-title">
+                @Model.TitleMain.Text
+            </div>
+        </div>
+        }
         <div class="nav-region-subtitle">
             @if (!Model.SinglePluginMode) {
                 @Model.TitleDetail.Text
@@ -688,6 +703,20 @@
             }
         </div>
         <div id="search"></div>
+        @if (@Model.SinglePluginMode) {
+        <div class="dropdown header-dropdown nav-main-dropdown single-plugin-mode">
+            <button class="button dropdown-toggle nav-main-button" type="button" id="header-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <div class="nav-main">
+                    <div class="dropdown-icon-container">
+                        <i class="dropdown-icon icon-menu"></i>
+                    </div>
+                </div>
+            </button>
+            <ul class="dropdown-menu" aria-labelledby="header-menu">
+                @RenderLinks(Model.HeaderLinks)
+            </ul>
+        </div>
+        }
     </header>
 
     @Html.Partial("TourInfo")

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -969,7 +969,7 @@ nav {
 header {
     background-color: #5394B6;
     flex-shrink: 0;
-    z-index: 2800;
+    z-index: 5002;
 }
 header,
 header .nav-main {
@@ -983,9 +983,18 @@ header .nav-main {
     padding-right: 12px;
     height: 55px;
 }
+.single-plugin-mode .nav-main {
+    padding-right: 0;
+}
 .header-dropdown {
     height: 55px;
     z-index: 2200
+}
+.header-dropdown.single-plugin-mode {
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 10000;
 }
 .header-dropdown.dropdown>button {
     padding: 0;
@@ -1003,6 +1012,10 @@ header .nav-main {
     margin-right: 10px;
     line-height: 50px;
     height: 100%;
+}
+.single-plugin-mode .dropdown-icon-container {
+    margin-right: 0;
+    border-right: none;
 }
 .header-dropdown .button.active,
 .header-dropdown .button.hover,
@@ -1054,6 +1067,12 @@ header .nav-main {
 }
 .dropdown-submenu > .dropdown-menu:after {
     top: inherit;
+}
+.single-plugin-mode .dropdown-menu {
+    left: -175px;
+}
+.single-plugin-mode .dropdown-menu #region-links {
+    left: -282px;
 }
 .nav-main-title {
     font-size: 18px;


### PR DESCRIPTION
## Overview

Per request from TNC. I believe this was requested so that the app title is the only thing on the left side of the header.

Connects #982 

### Demo

![image](https://user-images.githubusercontent.com/1042475/30752806-68561662-9f8b-11e7-882f-694000e1d644.png)

### Testing

- Load the app in single plugin mode in every browser, and verify that the menu is on the left and visible.