### PR TITLE
Fix removal of layout-specific print stylesheets

### DIFF
--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -71,7 +71,7 @@ require(['use!Geosite'],
                 $('<link>', {
                     rel: 'stylesheet',
                     href: pageCssLink(pageOrientation),
-                    'class': '.print-orientation-css',
+                    'class': 'print-orientation-css',
                 }).appendTo('head');
                 _.delay(orientDeferred.resolve, 1000);
 


### PR DESCRIPTION
## Overview

Class name should not have a leading ".". This is only required when
querying the DOM. The leading "." prevented the CSS import from being
found during print clean-up.

Connects to #987

## Testing Instructions

- Run through the print/"create map" workflow a few times and specify each page layout at least once.
- After this, ensure that any imports of `print-portrait.css` and `print-landscape.css` have been removed.

