### PR TITLE
Use original map in plugin print workflow

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -251,7 +251,7 @@
             </div>
         </nav>
         <div class="flex-expand">
-            <div class="flex-container">
+            <div class="flex-container map-container">
                 @if (Model.SinglePluginMode) {
                 <div id="toggle-plugin-container" class="single-plugin-mode">
                     <span><i class="fa fa-chevron-left" aria-hidden="true"></i></span>

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1949,6 +1949,8 @@ a.active {
 #plugin-print-sandbox {
     position: absolute;
     visibility: hidden;
+    background-color: #fff;
+    z-index: 1;
 }
 #map-print-sandbox {
     position: absolute;

--- a/src/GeositeFramework/css/print.css
+++ b/src/GeositeFramework/css/print.css
@@ -5,28 +5,20 @@
     .print-sandbox-header {
         display: none !important;
     }
-    /* Hide all body an map elements and print preview map controls */
-    body,
-    #plugin-print-preview-map_zoom_slider {
+    /* Hide all body map elements */
+    body {
         visibility: hidden;
     }
 
     html, body {
         overflow: visible !important;
+        height: auto !important;
     }
 
     /* An issue in Chrome for Windows would display the borders of this
        element in print media, despite it being selected by the clause above.*/
     .plugin-launcher {
         display: none;
-    }
-
-    /* Override the map tiles which have inline styles.
-       This avoids having to have an !important on the broader
-       selectors for the rest of the page elements */
-    #map-0_root, #map-0_root img.layerTile,
-    #map-1_root, #map-1_root img.layerTile {
-        visibility: hidden !important;
     }
 
     /* Plugin print will only be one side of a split view map ever, so
@@ -37,13 +29,28 @@
 
     #plugin-print-sandbox {
         visibility: visible;
+        height: 100%;
+        width: 100%;
     }
 
-    #plugin-print-preview-map_container img {
-        visibility: visible;
+    #plugin-print-sandbox .control-container {
+        display: none;
     }
 
     .esriSimpleSlider {
         display: none;
+    }
+
+    /* Default styling for map print out */
+    #plugin-print-sandbox #legend-container-0 {
+        float: right;
+    }
+
+    #plugin-print-sandbox #map-0_root {
+        float: left;
+    }
+
+    #print-map-container {
+        border: none;
     }
 }

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -166,8 +166,6 @@ define(["dojo/_base/declare", "framework/PluginBase"],
 
                 mapObject.addLayer(layer);
 
-                $printArea.append('<img id="sample-graphic-print" src="' + this.infoGraphic + '" >');
-
                 printDeferred.resolve();
             },
 


### PR DESCRIPTION
## Overview

Instead of creating a new map when printing from a plugin, reuse the existing main map. This will make it easier for plugin developers to print maps that match the main map, which appears to be the main use case. Code was added to move the map around from the main area, to the plugin print sandbox, and then back to the main area after printing is complete.

The css was adjusted to not hide the main map, as well as provide a minimal amount of default styling to the print-out. The rules are can be overridden and should provide a good starting point for plugin developers to style their own layouts.

Connects to #998 

### Demo

Chrome:
![image](https://user-images.githubusercontent.com/1042475/31500981-038a0426-af37-11e7-9129-9134dad404a1.png)

Safari:
![image](https://user-images.githubusercontent.com/1042475/31500989-083b3c56-af37-11e7-98d1-e972e332b00b.png)

Firefox:
![image](https://user-images.githubusercontent.com/1042475/31502559-72c1d126-af3b-11e7-96f8-2778cad5ccc8.png)

IE:
![image](https://user-images.githubusercontent.com/1042475/31501978-be9ad48c-af39-11e7-8007-09e4a53f8f30.png)

### Notes

This PR leaves the app in a working state, though the plugin print preview box no longer shows a print preview, and is blank. There are a number of follow-up issues:

https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/1008
https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/1009
https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/1010

## Testing Instructions

- Start the app
- Move or zoom the map, or add a layer with the region planning plugin
- Launch the identify point plugin
- Click a spot on the map to enable plugin print
- Click the "Print" button on the modal that appears
- View the preview or print the document to a PDF. 
- Verify that the map and legend reflect the state of the main map (plus the addition of the layer the plugin adds).
- Return to the app, and verify the map is back in it's original place, with all the appropriate layers, and is still operational.
- Repeat in other browsers.
