### PR TITLE
Adjust mobile modal size

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -595,8 +595,8 @@
                 <h2><%= pluginName %> - <span class="i18n" data-i18n="Print Preview">Print Preview</span></h2>
             </div>
             <div class="print-preview-container">
+                <span class="instructions i18n" data-i18n="Zoom to the view that you want printed in your map.">Zoom to the view that you want printed in your map.</span>
                 <button id="print-preview-print" class="button radius i18n" data-class="Print">Print</button>
-                <p class="instructions i18n" data-i18n="Zoom to the view that you want printed in your map.">Zoom to the view that you want printed in your map.</p>
                 <div id="plugin-print-preview-map"></div>
             </div>
         </div>

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -2133,6 +2133,15 @@ body.x-body {
 }
 
 @media screen and (max-device-width: 736px) {
+    .tbox {
+        max-width: 96vw !important;
+        max-height: 90vh !important;
+    }
+
+    .tcontent {
+        overflow: auto !important;
+    }
+
     #toggle-plugin-container {
         display: none !important;
     }

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -2143,6 +2143,15 @@ body.x-body {
         overflow: auto !important;
     }
 
+    #permalink-tiny-box-modal {
+        width: 85vw !important;
+        height: 60vh !important;
+    }
+
+    #permalink-tiny-box-modal .tcontent {
+        display: block !important;
+    }
+
     #plugin-print-preview .popover.popover-header {
         height: 12vh;
     }

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1983,7 +1983,8 @@ a.active {
     padding: 5px;
 }
 #print-preview-print {
-    float: right;
+    position: absolute;
+    right: 3rem;
 }
 .esriLegendMsg {
     display: none;
@@ -2140,6 +2141,10 @@ body.x-body {
 
     .tcontent {
         overflow: auto !important;
+    }
+
+    #plugin-print-preview .popover.popover-header {
+        height: 12vh;
     }
 
     #toggle-plugin-container {

--- a/src/GeositeFramework/js/Permalink.js
+++ b/src/GeositeFramework/js/Permalink.js
@@ -59,6 +59,7 @@
             var view = this;
 
             TINY.box.show({
+                boxid: 'permalink-tiny-box-modal',
                 html: this.template(view.model.toJSON()),
                 fixed: true,
                 openjs: function () {

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -567,7 +567,9 @@ require(['use!Geosite',
                 $printPreview = $('#print-preview-sandbox'),
                 mapReadyDeferred = $.Deferred(),
                 mapHeight = pluginObject.previewMapSize[1],
-                mapWidth = pluginObject.previewMapSize[0];
+                mapWidth = pluginObject.previewMapSize[0],
+                isMobileSingleAppMode = N.app.singlePluginMode &&
+                    window.matchMedia("screen and (max-device-width: 736px)").matches;
 
             // If the plugin is not set up for map print preview, don't set up a map
             // and resolve any pending print-preview map operations
@@ -583,8 +585,8 @@ require(['use!Geosite',
                 animate: false,
                 html: $mapPrint[0].outerHTML,
                 boxid: 'print-preview-container',
-                width: _.max([mapWidth, 500]),
-                fixed: true,
+                width: isMobileSingleAppMode ? '96vw' : _.max([mapWidth, 500]),
+                fixed: !isMobileSingleAppMode,
                 maskopacity: 40,
                 openjs: function () {
                     // Let the app know that the map is ready for modification

--- a/styleguide/app/cr_files/main.css
+++ b/styleguide/app/cr_files/main.css
@@ -1881,7 +1881,7 @@ a.active {
 .print-preview-container {
     padding: 10px;
 }
-#print-preview-container p {
+#print-preview-container span {
     padding: 5px;
 }
 #print-preview-print {


### PR DESCRIPTION
## Overview

This PR adds some CSS rules to limit the width & height of TINY modals in mobile-single-web-app mode. Previously plugins could instantiate modals larger than the viewport; now these will be limited to 96vw wide and 90vh tall, which should ensure there's always some non-modal area in which to dismiss the modals.

I also added an `overflow: auto` rule to the `.tcontent` class, which is where the TINY content lives. This enables the content to scroll.

Connects #1018

### Demo

![screen shot 2017-11-07 at 3 42 23 pm](https://user-images.githubusercontent.com/4165523/32516802-97aa6786-c3d2-11e7-8a97-7a131cc55433.png)

->

![screen shot 2017-11-07 at 3 42 29 pm](https://user-images.githubusercontent.com/4165523/32516812-9b9bf4ae-c3d2-11e7-81b7-a49a7c471d61.png)

## Testing Instructions
- get this branch, then launch the server and visit the app in a non-mobile browser
- verify that the TINY modal appears & works as before
- open the app in mobile browsers: Android Chrome & iOS Safari. Verify that the modal is limited to the viewport bounds according to the new CSS rules and that the content scrolls.

