### PR TITLE
Make launchpad asset paths relative

### DIFF
--- a/src/GeositeFramework/plugins/launchpad/main.js
+++ b/src/GeositeFramework/plugins/launchpad/main.js
@@ -131,7 +131,7 @@ define([
             showInfographic: function(config) {
                 TINY.box.show({
                     animate: true,
-                    url: '/plugins/launchpad/infographic.html',
+                    url: 'plugins/launchpad/infographic.html',
                     fixed: true,
                     width: config.infographic.width,
                     height: config.infographic.height

--- a/src/GeositeFramework/plugins/launchpad/templates.html
+++ b/src/GeositeFramework/plugins/launchpad/templates.html
@@ -90,6 +90,6 @@
 
 <script type="text/template" id="infographic-button">
     <button class="button button-default infographic-icon">
-        <img src="/plugins/launchpad/infographic-icon.png" alt="Show infographic">
+        <img src="plugins/launchpad/infographic-icon.png" alt="Show infographic">
     </button>
 </script>


### PR DESCRIPTION
This is needed so that when the app is served under a virtual folder/directory (like maps.coastalresilience.org/site-name), the assets are loaded correctly.

Connects to #939