### PR TITLE
Include plugin legends in printed map legend

### DIFF
--- a/src/GeositeFramework/css/app-print.css
+++ b/src/GeositeFramework/css/app-print.css
@@ -93,42 +93,34 @@
     few legend style blocks results in the rules, despite not having any conflicting
     rules, not having any effect. It could have something to do with how the legend
     elements are moved around the DOM for printing */
-    .legend-body {
+    div.legend-body {
+        display: -webkit-box;
+        display: -ms-flexbox;
         display: flex;
-        flex-wrap: wrap;
         width: 100% !important;
         height: 85% !important;
         background-color: #fff !important; /* Needed for IE */
     }
 
-    .layer-legends {
-        height: 100% !important;
-        width: 100% !important;
+    div.layer-legends {
+        display: -webkit-box;
+        display: -ms-flexbox;
         display: flex;
-        flex-direction: column;
-        flex-wrap: wrap;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+            -ms-flex-direction: column;
+                flex-direction: column;
+        -ms-flex-wrap: wrap;
+            flex-wrap: wrap;
+        width: 100%;
+        align-content: flex-start;
     }
 
-    .legend-layer {
+    div.legend-layer {
         width: auto !important;
-        font-size: 8px;
         height: auto !important;
-        display: flex;
-        flex-direction: column;
-        flex-shrink: 1;
-    }
-
-    .legend-title {
-        max-width: 75%;
-    }
-
-    .print-legend-coll {
-        display: flex !important;
-        flex-direction: column;
-        flex-wrap: wrap;
-        height: 60px;
-        align-content: stretch;
-        justify-content: center;
+        font-size: 8px;
+        margin: 0 10px 0 0;
     }
 
     .legend-layer img {

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -50,7 +50,10 @@ require(['use!Geosite'],
                 orientDeferred = $.Deferred(),
                 resizeDeferred = $.Deferred(),
                 legendDeferred = $.Deferred(),
-                postPrintAction = _.noop;
+                postPrintAction = function() {
+                    var pluginLegend = $('.plugin-legends').detach();
+                    $(pluginLegend).appendTo('.legend-body');
+                }
 
             $('#export-button').on('click', function() {
                 var mapNode = $("#map-0").detach();
@@ -90,6 +93,8 @@ require(['use!Geosite'],
                         $(".legend-close").click();
                         postPrintAction = function() {
                             $(".legend-close").click();
+                            var pluginLegend = $('.plugin-legends').detach();
+                            $(pluginLegend).appendTo('.legend-body');
                         };
                     }
 
@@ -109,13 +114,13 @@ require(['use!Geosite'],
                         $(".esriScalebar").toggleClass("page-bottom");
                         $(".esriControlsBR").toggleClass("page-bottom");
                     }
-                    // wrap all legend items in a div to style separately from header
-                    $(".legend-layer").each(
-                        function(el) {
-                            $(this)
-                                .children(".item")
-                                .wrapAll("<div class='print-legend-coll'></div>");
-                        });
+
+                    // Temporarily move plugin legends container into
+                    // layer legends container so that they can coexist
+                    // in the same flexbox layout
+                    var pluginLegend = $('.plugin-legends').detach();
+                    $(pluginLegend).appendTo('.layer-legends');
+
                     _.delay(legendDeferred.resolve, 1000);
                 });
 


### PR DESCRIPTION
## Overview

Previously, plugin legends were not displayed in the printed map legend because they were not accounted for in the print stylesheets. This resulted in the legends being rendered off the page. Now, the plugin legends container is temporarily moved into the layer legends container. That, combined with modifications to the print stylesheets, makes the plugin legends visible on the printed page.

In the course of this work, the general legend print styling was also improved and a superfluous wrapping of legend elements in a special print class was removed.

It should be noted that while this does allow for the plugin legends to be displayed in the printed legends, most plugin legends are SVG and will not display well. They will likely be taller than the legend area, which will result in the legends being cut-off. However, the scope of this PR was just to get them to display. Plugin authors will be responsible for getting the legends to display well.

Connects to #1001

## Notes

The print workflow no longer works in Safari because of this dialog that appears when `windows.print()` is called. The timing of the workflow is now off.

![image](https://user-images.githubusercontent.com/1042475/33342639-c418b7e4-d450-11e7-893e-40dcf2217c95.png)

## Demo

In the screenshots below, the "Likelihood of flooding" legend comes from a plugin. The other layers are from Regional Planning.

**Previously, in Chrome**
![image](https://user-images.githubusercontent.com/1042475/33343668-33acb332-d454-11e7-8d1c-95939075e5a8.png)

**Chrome**
![image](https://user-images.githubusercontent.com/1042475/33342568-8dd9c6aa-d450-11e7-9200-a93ef53b4544.png)

**Firefox**
![image](https://user-images.githubusercontent.com/1042475/33342682-f08c9e26-d450-11e7-9391-63d1339e808d.png)

**Internet Explorer**
![image](https://user-images.githubusercontent.com/1042475/33343577-cc840642-d453-11e7-9cc9-962f7fba6d1b.png)

## Testing instructions

- Add a plugin to the framework that includes a legend. I used "Ecosystem effects of sea level change" in the above screenshots, so it may be worth trying a different plugin to get more test cases.
- Add layers from Regional Planning.
- Select the "Create Map" option.
- Verify the printed map legend contains both the Regional Planning layers and the plugin legend. It's easy to do this in Chrome because of the print preview. In Firefox and Internet Explorer, printing to PDF is the quickest way.