### PR TITLE
Add option to hide plugin minimize button

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -416,9 +416,13 @@
                             <i class="icon-info-circled"></i>
                         </button>
                     <% } %>
-                    <button class="button-link plugin-minimize i18n" data-i18n="[title]Minimize this plugin" title="Minimize this plugin">
-                        <i class="icon-window-minimize"></i>
-                    </button>
+
+                    <% if (!hideMinimizeButton) { %>
+                        <button class="button-link plugin-minimize i18n" data-i18n="[title]Minimize this plugin" title="Minimize this plugin">
+                            <i class="icon-window-minimize"></i>
+                        </button>
+                    <% } %>
+
                     <button class="button-link plugin-off i18n" data-i18n="[title]Turn off this plugin" title="Turn off this plugin">
                         <i class="icon-cancel"></i>
                     </button>

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -475,7 +475,8 @@ require(['use!Geosite',
                     hasHelp: pluginObject.hasHelp,
                     hasCustomPrint: pluginObject.hasCustomPrint,
                     sizeClassName: getPluginSizeClassName(pluginObject.size),
-                    customWidth: getCustomPluginWidth(pluginObject.size, pluginObject.width)
+                    customWidth: getCustomPluginWidth(pluginObject.size, pluginObject.width),
+                    hideMinimizeButton: pluginObject.hideMinimizeButton
                 },
                 $uiContainer = $($.trim(N.app.templates['template-plugin-container'](bindings)));
 

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -56,6 +56,9 @@ define(["dojo/_base/declare",
             width: 300, // only used if 'custom' is specified for size
             icon: "globe",
 
+            // If true, the minimize button is hidden in the plugin title bar
+            hideMinimizeButton: false,
+
             initialize: function() {},
             activate: function () {},
             deactivate: function () {},

--- a/src/GeositeFramework/plugins/launchpad/main.js
+++ b/src/GeositeFramework/plugins/launchpad/main.js
@@ -31,6 +31,7 @@ define([
             hasCustomPrint: false,
             toolbarType: "sidebar",
             allowIdentifyWhenActive: true,
+            hideMinimizeButton: _.isUndefined(overrides.hideMinimizeButton) ? false : overrides.hideMinimizeButton,
             uiState: {},
 
             initialize: function (frameworkParameters, currentRegion) {


### PR DESCRIPTION
## Overview

Adds an option to the plugin configuration that allows site admins to
hide the minimize button in a plugin's titlebar.

Support for this option has to be implemented in each plugin, and is
demonstrated here in the launchpad plugin.

Connects #1014

### Demo

![image](https://user-images.githubusercontent.com/1042475/33291995-b17fa7a2-d395-11e7-9e2c-a267b42504b6.png)

## Testing Instructions

- Edit the Launchpad's `overrides.json` and add `hideMinimizeButton: true`.
- Reload the site (this may also require restarting the development server) and verify the Launchpad's minimize button is removed.