### PR TITLE
Add meters and feet as measure tool length options

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -633,6 +633,9 @@
                 <% if (areas) { %>
                 <a class="measure-unit-filter" data-unit="ac" data-alt-unit="mi" title="Acres" href="#">ac</a>
                 <a class="measure-unit-filter" data-unit="ha" data-alt-unit="km" title="Hectares" href="#">ha</a>
+                <% } else { %>
+                <a class="measure-unit-filter" data-unit="m" title="Meters" href="#">m</a>
+                <a class="measure-unit-filter" data-unit="ft" title="Feet" href="#">ft</a>
                 <% } %>
             </div>
             <hr />

--- a/src/GeositeFramework/js/widgets/map_utils/measure/AgsMeasure.js
+++ b/src/GeositeFramework/js/widgets/map_utils/measure/AgsMeasure.js
@@ -68,7 +68,8 @@ define([
                         new dojo.Color([255, 0, 0]), 1),
                         new dojo.Color([255, 0, 0, 0.35])),
 
-                esriLengthUnits: [units.MILES, units.KILOMETERS],
+                esriLengthUnits: [units.MILES, units.KILOMETERS,
+                                  units.METERS, units.FEET],
                 esriAreaUnits: [units.SQUARE_MILES, units.SQUARE_KILOMETERS,
                                 units.ACRES, units.HECTARES]
 
@@ -81,7 +82,8 @@ define([
                 esriKilometers: "km",
                 esriSquareKilometers: "km",
                 esriAcres: "ac",
-                esriHectares: "ha"
+                esriHectares: "ha",
+                esriFeet: "ft"
             },
 
             _points = [],


### PR DESCRIPTION
## Overview
Adds buttons to toggle the new units in the measure popup and adds the required
string constants that allow the existing measure tool to show the new options.

Connects #1015

### Demo

#### Meters

<img width="513" alt="screen shot 2017-11-27 at 4 30 52 pm" src="https://user-images.githubusercontent.com/17363/33295111-f5d3b056-d390-11e7-87c5-eb76005a2be0.png">

#### Feet

<img width="491" alt="screen shot 2017-11-27 at 4 31 06 pm" src="https://user-images.githubusercontent.com/17363/33295116-fb57195a-d390-11e7-8646-d76422bbec22.png">

## Testing Instructions

 * Use the measure tool to draw a line
 * Verify that "m" and "ft" are now clickable options
 * Use the measure tool to draw a polygon and verify that area calculations are not affected.

