### PR TITLE
Replace ES6 method with non-ES6 method syntax

### DIFF
--- a/src/GeositeFramework/js/SidebarToggle.js
+++ b/src/GeositeFramework/js/SidebarToggle.js
@@ -56,7 +56,7 @@
             'click': 'togglePluginVisibility'
         },
 
-        adjustToggleIcon() {
+        adjustToggleIcon: function() {
             const newIconClass =
                 this.viewModel.get('pluginContentVisible') ?
                 'fa fa-chevron-right' : 'fa fa-chevron-left';


### PR DESCRIPTION
## Overview

This PR fixes a problem whereby the site wouldn't load properly in IE11. The cause was a stray bit of ES6 method declaration syntax which isn't supported in IE11; the fix is to use `name: function() {` syntax.

Connects #1017

### Demo

![screen shot 2017-11-28 at 2 26 23 pm](https://user-images.githubusercontent.com/4165523/33339751-2463180a-d448-11e7-845e-889c371cb2d3.png)

## Testing Instructions
- get this branch, then rebuild in VS and view the project in Chome, IE11, FF, and Safari and verify that everything still works as expected

