### PR TITLE
Lower .nav-apps z-index

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -792,7 +792,7 @@ nav {
     width: 220px;
     background-color: #333;
     position: relative;
-    z-index: 5001;
+    z-index: 2500;
     padding-bottom: 27px;
     overflow: visible;
 }


### PR DESCRIPTION
## Overview

This PR fixes a bug reported in #1026 whereby the hamburger dropdown menu appeared behind the `.nav-apps` sidebar.

This was caused by having a z-index too high on `.nav-apps`: it was 5001, and the dropdown is 2800. Now `.nav-apps` is 2500.

Connects #1026

### Demo

<img width="477" alt="screen shot 2017-11-29 at 4 16 05 pm" src="https://user-images.githubusercontent.com/4165523/33399429-a0b72bf2-d520-11e7-958e-139ee57e98b4.png">

### Notes

This bug is present on `master` and not `develop`, so we may have inadvertently fixed it in the latter. Going to look through the git history to see if I can find where.

## Testing Instructions
- get this branch, then rebuild and serve the app in VS
- visit the site in Chrome, FF, Safari, and IE 11 and verify that the menu dropdown appears above the nav bar
