### PR TITLE
Transform print preview map into print modal

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -593,15 +593,14 @@
         </div>
     </script>
 
-    <script type="text/template" id="template-map-preview">
-        <div id="plugin-print-preview">
+    <script type="text/template" id="template-plugin-print-modal">
+        <div id="plugin-print-modal">
             <div class="popover popover-header">
-                <h2><%= pluginName %> - <span class="i18n" data-i18n="Print Preview">Print Preview</span></h2>
+                <h2><%= pluginName %> - <span class="i18n" data-i18n="Print Options">Print Options</span></h2>
             </div>
-            <div class="print-preview-container">
-                <span class="instructions i18n" data-i18n="Zoom to the view that you want printed in your map.">Zoom to the view that you want printed in your map.</span>
-                <button id="print-preview-print" class="button radius i18n" data-class="Print">Print</button>
-                <div id="plugin-print-preview-map"></div>
+            <div class="print-modal-container">
+                <button id="print-modal-confirm" class="button radius i18n" data-class="Print">Ok</button>
+                <div id="plugin-print-modal-content"></div>
             </div>
         </div>
     </script>

--- a/src/GeositeFramework/js/PluginBase.js
+++ b/src/GeositeFramework/js/PluginBase.js
@@ -40,11 +40,11 @@ define(["dojo/_base/declare",
             // Allow the framework to put a custom print button for this plugin
             hasCustomPrint: false,
 
-            // Show a print preview map for plugin printing
-            usePrintPreviewMap: false,
+            // Show a modal dialog for plugin printing
+            usePrintModal: false,
 
-            // The [width, height] of the print preview map
-            previewMapSize: [500, 400],
+            // The [width, height] of the print modal
+            printModalSize: [500, 400],
 
             // This option changes the default launch behavior and is only applicable to topbar plugins.
             // If true, this will deselect other active plugins when launched. If false, this will
@@ -75,11 +75,18 @@ define(["dojo/_base/declare",
             subregionDeactivated: function() {},
             validate: function () { return true; },
 
-            // Auto-resolve the print deferred if the plugin does not implement the function
-            // printDeferred: deferred object to resolve when the printing can commence
+            // Auto-resolve the print deferred if the plugin does not implement this method.
+            // preModalDeferred: deferred object to resolve when the printing can commence
             // $printSandbox: DOM element which the framework provides for printable element arrangement
-            // previewMap: an ESRI map object for the print preview, if `usePrintPreviewMap` is true
-            beforePrint: function (printDeferred, $printSandbox, previewMap) { printDeferred.resolve();  },
+            // mapObject: an ESRI map object referencing the main map
+            // modalSandbox: DOM element which gets rendered in the print modal
+            prePrintModal: function (preModalDeferred, $printSandbox, mapObject, modalSandbox) { preModalDeferred.resolve(); },
+
+            // Auto-resolve the modal deferred if the plugin does not implement this method.
+            // postModalDeferred: deferred object to resolve after the print modal has been dimissed
+            // modalSandbox: DOM element which gets rendered in the print modal. Plugins can now check the value of inputs/form elements
+            // mapObject: an ESRI map object referencing the main map
+            postPrintModal: function (postModalDeferred, modalSandbox, mapObject) { postModalDeferred.resolve(); },
 
             // Called when switching from infographic to the primary view or vice versa.
             onContainerVisibilityChanged: function (visible) {},

--- a/src/GeositeFramework/sample_plugins/identify_point/main.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.css
@@ -6,3 +6,9 @@ hr {
     height: 200px;
     margin-bottom: 100px;
 }
+
+.sample {
+    float: right;
+    color: hotpink;
+    font-size: 24px;
+}

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -17,8 +17,8 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
             allowIdentifyWhenActive: true,
             size: 'small',
             hasCustomPrint: true,
-            usePrintPreviewMap: true,
-            previewMapSize: [500, 350],
+            usePrintModal: true,
+            printModalSize: [500, 350],
             infographic: [500, 300],
 
             initialize: function(frameworkParameters) {
@@ -100,14 +100,21 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
 
             },
 
-            beforePrint: function(printDeferred, $printArea, mapObject) {
-                var layer = new esri.layers.ArcGISDynamicMapServiceLayer("http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer", {
-                        "opacity": 0.8
-                    });
+            prePrintModal: function(preModalDeferred, $printArea, mapObject, modalSandbox) {
+                modalSandbox.append('<label><input type="checkbox" name="checkbox" value="value">Check this box to add demo element.</label>');
 
-                mapObject.addLayer(layer);
+                preModalDeferred.resolve();
+            },
 
-                printDeferred.resolve();
+            postPrintModal: function(postModalDeferred, modalSandbox, mapObject) {
+                var isInputChecked = $(modalSandbox).find('input').is(':checked');
+
+                if (isInputChecked) {
+                    $('#plugin-print-sandbox').append('<div class="sample">Demo element</div>');
+
+                }
+
+                postModalDeferred.resolve();
             },
 
             showHelp: function() {


### PR DESCRIPTION
## Overview

Repurpose the print preview map into a customizable print modal. Plugin authors can provide content, like a form, that will be used to populate the modal. Then, before printing is kicked-off, the plugin will again be given a reference to the modal content. A plugin author can parse the content for user input, and then adjust the print output as necessary.

Connects #1009 

### Demo
![tnc1](https://user-images.githubusercontent.com/1042475/33578368-52b86356-d914-11e7-9279-00653941d609.gif)

### Notes

- The modal and demo element will be cleaned-up in #1007 
- Opting out of the print modal causes the print workflow to fail. This is also the case on `master` when opting out of the print preview map. I spent a little bit of time trying to figure this out, but I was unable to. I'll create a follow-up issue.

## Testing Instructions

- Activate the "Identify point" plugin.
- Click the print icon.
- In the modal that appears, check the checkbox.
- Verify that the text "Demo element" appears on the right side of the print preview page.
- Repeat this process, but do not check the box. Verify that the demo element is not on the print preview.