### PR TITLE
Place scalebar inside of map for plugin print

### DIFF
--- a/src/GeositeFramework/css/print-a4-landscape.css
+++ b/src/GeositeFramework/css/print-a4-landscape.css
@@ -28,7 +28,7 @@
     }
 
     .page-bottom {
-        bottom: 1%;
+        bottom: 2%;
     }
 }
 

--- a/src/GeositeFramework/css/print-a4-portrait.css
+++ b/src/GeositeFramework/css/print-a4-portrait.css
@@ -28,7 +28,7 @@
     }
 
     .page-bottom {
-        bottom: 1%;
+        bottom: 2%;
     }
 }
 

--- a/src/GeositeFramework/css/print-letter-landscape.css
+++ b/src/GeositeFramework/css/print-letter-landscape.css
@@ -28,7 +28,7 @@
     }
 
     .page-bottom {
-        bottom: 1%;
+        bottom: 2%;
     }
 }
 

--- a/src/GeositeFramework/css/print-letter-portrait.css
+++ b/src/GeositeFramework/css/print-letter-portrait.css
@@ -28,7 +28,7 @@
     }
 
     .page-bottom {
-        bottom: 1%;
+        bottom: 2%;
     }
 }
 

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -637,6 +637,11 @@ require(['use!Geosite',
                         var modalContent = $(this).siblings('#plugin-print-modal-content');
                         pluginObject.postPrintModal(postModalDeferred, modalContent, map);
 
+                        // Move the scalebar inside the map container so
+                        // that it stays with the map.
+                        var scalebar = $('.esriScalebar').detach();
+                        $(scalebar).appendTo('#map-0_root');
+
                         // Close out the modal, which calls the closejs method
                         TINY.box.hide();
                     });
@@ -647,6 +652,10 @@ require(['use!Geosite',
                     var mapNode = $('#map-0').detach();
                     $('.map-container').append(mapNode);
                     map.resize(true);
+
+                    // Move the scalebar back to it's original location
+                    var scalebar = $('.esriScalebar').detach();
+                    $(scalebar).appendTo('#map-0');
 
                     // Remove print related CSS
                     $('.base-plugin-print-css').remove();


### PR DESCRIPTION
## Overview

This change prevents the scalebar from moving to the bottom of the page, and keeps it within the map container so that it is always visible.

Connects #1012 

### Demo

Before:
![image](https://user-images.githubusercontent.com/1042475/33622773-bf2a1806-d9bc-11e7-8650-dc750915b463.png)

After:
![image](https://user-images.githubusercontent.com/1042475/33622682-8f3446d0-d9bc-11e7-995a-cf8176a21646.png)

### Notes

Original comment triggering this issue: https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/1005#issuecomment-336263041

## Testing Instructions

- Activate the identify point plugin.
- Click the plugin print button.
- Advance through the print modal.
- In the print preview window (or PDF, if you are using a browser other than chrome), verify that the scalebar is within the map.