### PR TITLE
Ensure map tools menu is displayed above legend

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1553,6 +1553,7 @@ header .nav-main {
 .control-container {
     position: absolute;
     width: 100%;
+    z-index: 102;
 }
 .control-container.subregion-active {
     top: 40px;
@@ -1645,8 +1646,6 @@ header .nav-main {
     width: 255px;
     min-width: 255px;
     z-index: 101;
-    /* show over plugin-container */
-
     font-weight: bold;
     background: #FFF;
     font-size: 12px;


### PR DESCRIPTION
## Overview

Adjust the z-index of the map tools parent container so that is displayed above the legend container.

Connects #1034

### Demo

Before:
![image](https://user-images.githubusercontent.com/1042475/33625289-188ad73e-d9c5-11e7-8f16-8eacb003bc14.png)

After:
![image](https://user-images.githubusercontent.com/1042475/33625268-0d1717dc-d9c5-11e7-963d-9c4ae21f99aa.png)

## Testing Instructions

- Open the regional planning plugin and add a bunch of layers to the map so that the legend container grows to it's max height.
- Click the map tools button, and ensure the menu is displayed above the legend container.
