### PR TITLE
Fix layer alignment in framework print

### DIFF
--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -45,6 +45,11 @@ require(['use!Geosite'],
             return 'css/print-' + pageSize + "-" + pageOrientation + '.css';
         }
 
+        function invalidateSize(map) {
+            map.resize();
+            map.reposition();
+        }
+
         function setupExport(context) {
             var previewDeferred = $.Deferred(),
                 orientDeferred = $.Deferred(),
@@ -61,9 +66,11 @@ require(['use!Geosite'],
 
                 $('.print-sandbox-header h1').text($("#export-title").val());
                 exportMap.append(mapNode);
+                invalidateSize(context.map);
 
                 context.mapReadyDeferred.then(function() {
                     exportMap.detach().appendTo($("#print-map-container"));
+                    invalidateSize(context.map);
                 });
 
                 var pageOrientation = $("[name='export-orientation']:checked").val();
@@ -80,7 +87,7 @@ require(['use!Geosite'],
                 orientDeferred.then(function() {
                     context.map.width = parseFloat(exportMap.css("width"));
                     context.map.height = parseFloat(exportMap.css("height"));
-                    context.map.resize(true);
+                    invalidateSize(context.map);
                     context.map.centerAt(context.mapDimensions.extent.getCenter());
                     _.delay(resizeDeferred.resolve, 1000);
                 });
@@ -172,6 +179,7 @@ require(['use!Geosite'],
                 var mapNode = $("#map-0").detach();
                 context.mapNodeParent.append(mapNode);
                 exportMap.detach().appendTo(exportContainer);
+                invalidateSize(context.map);
                 $(".esriScalebar").removeClass("above-legend");
                 $(".esriScalebar").removeClass("page-bottom");
                 $(".esriControlsBR").removeClass("above-legend");
@@ -182,7 +190,7 @@ require(['use!Geosite'],
             restoreNodeDeferred.then(function() {
                 context.map.width = context.mapDimensions.width;
                 context.map.height = context.mapDimensions.height;
-                context.map.resize(true);
+                invalidateSize(context.map);
                 _.delay(restoreMapDeferred.resolve, 250);
             });
 


### PR DESCRIPTION
## Overview

Resize and reposition the map each time it is moved in the DOM. This ensures that layers are redrawn in the correct location when the map is refreshed.

The helper function to do this is named after the Leaflet function that performs a similar purpose.

Connects to #1035

## Testing Instructions

- Before pulling down this branch, on `develop`, activate the regional planning plugin.
- Add one of the NJ layers, and pan to NJ.
- Select "Create Map" from the map toolbar.
- Click through the print dialog.
- In the print preview dialog, note that the layer is slightly mispositioned.
- Close the print preview dialog, and repeat the above process.
- Note that the map is moved even further out of position.
- Now check out this branch, and repeat the above process. Ensure that the layer stays in the correct location through each print cycle.
