### PR TITLE
Ensure plugin button border radius is set to 0

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -814,6 +814,7 @@ nav {
     cursor: pointer;
     border-bottom: 1px solid rgba(232, 232, 232, 0.2);
     padding: 7px 10px 7px;
+    border-radius: 0;
 }
 .nav-apps-button.active {
     background-color: #3bb3be;


### PR DESCRIPTION
## Overview

Chrome temporarily included base styling which gave buttons a border radius of 4. This resulted in the plugin buttons looking odd. Chrome appears to have removed this style rule, but an override is added here in case it comes back, and for older versions of the browser.

Connects to #1036

### Demo

![image](https://user-images.githubusercontent.com/1042475/34058930-c321b7b6-e1aa-11e7-9dbd-3b3bf5fb0875.png)

## Testing Instructions

- Ensure the added rule is valid and assigned to the correct class.