### PR TITLE
Fix single plugin mode plugin toggle button

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -409,6 +409,11 @@ require(['use!Geosite',
             render(view);
             view.$el.appendTo($parent);
             createUiContainer(view, paneNumber);
+            if (model.get('pluginObject').infographic && !N.app.singlePluginMode) {
+                addInfographicButton(view,
+                    model.get('pluginObject').infographic,
+                    model.get('pluginSrcFolder'))
+            }
             N.views.BasePlugin.prototype.initialize.call(view);
         }
 
@@ -443,12 +448,6 @@ require(['use!Geosite',
                 // immediately.
                 if (pluginObject.map) {
                     pluginObject.map.resize(true);
-                }
-
-                if (model.get('pluginObject').infographic) {
-                    addInfographicButton(view,
-                        model.get('pluginObject').infographic,
-                        model.get('pluginSrcFolder'))
                 }
             }
 

--- a/src/GeositeFramework/js/SidebarToggle.js
+++ b/src/GeositeFramework/js/SidebarToggle.js
@@ -59,7 +59,7 @@
         adjustToggleIcon: function() {
             const newIconClass =
                 this.viewModel.get('pluginContentVisible') ?
-                'fa fa-chevron-right' : 'fa fa-chevron-left';
+                'fa fa-chevron-left' : 'fa fa-chevron-right';
 
             this.$el.find('i').attr('class', newIconClass);
         },


### PR DESCRIPTION
## Overview

The icon for the single plugin mode plugin toggle button was reversed based on the state of the plugin. That is fixed here.

Also, while working on the above issue, I discovered a bug related to the infographic button and single plugin mode. The button was being rendered in single plugin mode when it shouldn't have been. It was also being rendered multiple times. Both of those issues are fixed here.

Connects #1024 

### Demo

![tnc1](https://user-images.githubusercontent.com/1042475/34120423-9ef7e482-e3f3-11e7-91f0-2a0ab7800b6a.gif)

## Testing Instructions

- Pull down this branch.
- Turn on single plugin mode.
- Toggle the visibility of the plugin.
- Verify that the icon in the toggle button stays in sync with the state of the plugin.
- Verify that the infographic icon is not rendered.
- Turn off single plugin mode and restart the dev server.
- Verify that the infographic button is present for the identify point plugin, and that there is only one button element in the DOM for that plugin.
