### PR TITLE
Fix rendering of plugin legends in print

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -294,8 +294,8 @@
                             <a class="legend-close i18n" data-i18n="[title]Hide Legend" href="javascript:;">_</a>
                         </div>
                         <div class="legend-body">
-                            <div class="layer-legends"></div>
                             <div class="plugin-legends"></div>
+                            <div class="layer-legends"></div>
                         </div>
                     </div>
                     <div class="subregion-tooltip"></div>

--- a/src/GeositeFramework/css/app-print.css
+++ b/src/GeositeFramework/css/app-print.css
@@ -123,6 +123,15 @@
         margin: 0 10px 0 0;
     }
 
+    div.plugin-legends {
+        display: flex;
+    }
+
+    div.custom-legend {
+        min-width: 100px;
+        max-width: 300px;
+    }
+
     .legend-layer img {
         width: 10px;
         height: 10px;

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -55,10 +55,7 @@ require(['use!Geosite'],
                 orientDeferred = $.Deferred(),
                 resizeDeferred = $.Deferred(),
                 legendDeferred = $.Deferred(),
-                postPrintAction = function() {
-                    var pluginLegend = $('.plugin-legends').detach();
-                    $(pluginLegend).appendTo('.legend-body');
-                }
+                postPrintAction = _.noop;
 
             $('#export-button').on('click', function() {
                 var mapNode = $("#map-0").detach();
@@ -100,8 +97,6 @@ require(['use!Geosite'],
                         $(".legend-close").click();
                         postPrintAction = function() {
                             $(".legend-close").click();
-                            var pluginLegend = $('.plugin-legends').detach();
-                            $(pluginLegend).appendTo('.legend-body');
                         };
                     }
 
@@ -121,12 +116,6 @@ require(['use!Geosite'],
                         $(".esriScalebar").toggleClass("page-bottom");
                         $(".esriControlsBR").toggleClass("page-bottom");
                     }
-
-                    // Temporarily move plugin legends container into
-                    // layer legends container so that they can coexist
-                    // in the same flexbox layout
-                    var pluginLegend = $('.plugin-legends').detach();
-                    $(pluginLegend).appendTo('.layer-legends');
 
                     _.delay(legendDeferred.resolve, 1000);
                 });


### PR DESCRIPTION
## Overview

Changes introduced in #1051 exposed an issue with the solution introduced in #1027 to include plugin legends on printed maps.

In #1027, the plugin legends DOM element was moved into the layer legends DOM element for printing. However, the layer legends DOM element is dynamically updated and gets redrawn when the map updates. Because the changes in #1027 force many more map updates to
ensure layers don't get out of sync when the map size changes, the plugin layers element is overwritten when the layer legends element is rerendered.

I was able to remove the solution introduced in #1027, and make a much simpler fix, which is to move the plugin legends element ahead of the layer legends element in the DOM. This does have the side-effect of placing the plugin legends first in the legend container. It's not totally clear why this solution works, other than it being a result of the CSS rules in place for the legend during printing. Much work has already been invested in these rules, so I did not want to modify them any further. I did, however, include some new style rules for plugin legends to add a minimal set of constraints on them since they are often very different from one another.

Connects to #1050

### Demo

Screenshot from Chrome demonstrating multiple plugin legends and layer legends coexisting.

![image](https://user-images.githubusercontent.com/1042475/34180023-27a4662e-e4db-11e7-87ae-e62a6063a8d9.png)

Screenshot from Firefox demonstrating that the Multiexplorer/Restoration Explorer plugin legend does show up in the printed legend. It does not currently show up in Chrome.

![image](https://user-images.githubusercontent.com/1042475/34179971-f92b29ae-e4da-11e7-8986-1bf1f2f45b67.png)

## Note

#1050 was created to verify that legends for image layers showed up in the printed legend. Since all plugin legends are now included in the printed legend, it does not matter what types of layers a plugin uses. However, the legend for multi-explorer (this is the plugin that was suggested to us for testing) does not show up in the printed legend for Chrome. It does work in Firefox and IE, however. It's not clear why this is happening, but it most likely has something to do with how the legend for this particular plugin is constructed. Other SVG legends do show and are included in the example screenshot above.

## Testing Instructions

- Add several plugins to your framework installation.
- Toggle on the plugins as well as some layers from the regional planning plugin.
- Use the "Create Map" feature to print the map
- Verify any plugin legends that were in map legend are displayed in the printed legend.