### PR TITLE
Unify prePrintModal and postPrintModal arguments

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -579,7 +579,7 @@ require(['use!Geosite',
                 // elements outside of its container, a reference to the map, and a reference
                 // to the print modal sandbox, where it can add a form to collect user input.
                 var $modalSandbox = $('#plugin-print-modal-content');
-                pluginObject.prePrintModal(preModalDeferred, $printSandbox, map, $modalSandbox);
+                pluginObject.prePrintModal(preModalDeferred, $printSandbox, $modalSandbox, map);
 
                 // Execute the browser print when the plugin and print modal (if used) have responded.
                 $.when(preModalDeferred, parseDeferred, modalConfirmDeferred, postModalDeferred).then(function() {
@@ -635,8 +635,8 @@ require(['use!Geosite',
 
                         // Pass the modal contents to the plugin,
                         // so it can extract form values, etc.
-                        var modalContent = $(this).parent().siblings('#plugin-print-modal-content');
-                        pluginObject.postPrintModal(postModalDeferred, modalContent, map);
+                        var $modalContent = $(this).parent().siblings('#plugin-print-modal-content');
+                        pluginObject.postPrintModal(postModalDeferred, $printSandbox, $modalContent, map);
 
                         // Move the scalebar inside the map container so
                         // that it stays with the map.

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -99,14 +99,14 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
                 $(this.printButton).show();
             },
 
-            prePrintModal: function(preModalDeferred, $printArea, mapObject, modalSandbox) {
+            prePrintModal: function(preModalDeferred, $printSandbox, $modalSandbox, mapObject) {
                 $.get('sample_plugins/identify_point/html/print-form.html', function(html) {
-                    modalSandbox.append(html);
+                    $modalSandbox.append(html);
                 }).then(preModalDeferred.resolve());
 
                 // Append optional images to print sandbox, which are hidden by default
-                $('#plugin-print-sandbox').append('<div class="sample"><img id="north-arrow-img" src="sample_plugins/identify_point/north-arrow.png"/></div>');
-                $('#plugin-print-sandbox').append('<div class="sample"><img id="logo-img" src="sample_plugins/identify_point/tnc-logo.png"/></div>');
+                $printSandbox.append('<div class="sample"><img id="north-arrow-img" src="sample_plugins/identify_point/north-arrow.png"/></div>');
+                $printSandbox.append('<div class="sample"><img id="logo-img" src="sample_plugins/identify_point/tnc-logo.png"/></div>');
 
                 // Zoom and center to Philadelphia, as a demonstration
                 this.initialZoom = mapObject.getZoom();
@@ -115,16 +115,16 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
                 mapObject.centerAndZoom([-75.1641, 39.9562], 8)
             },
 
-            postPrintModal: function(postModalDeferred, modalSandbox, mapObject) {
-                var includeNorthArrow = $(modalSandbox).find('#north-arrow').is(':checked');
-                var includeTncLogo = $(modalSandbox).find('#tnc-logo').is(':checked');
+            postPrintModal: function(postModalDeferred, $printSandbox, $modalSandbox, mapObject) {
+                var includeNorthArrow = $modalSandbox.find('#north-arrow').is(':checked');
+                var includeTncLogo = $modalSandbox.find('#tnc-logo').is(':checked');
 
                 if (includeNorthArrow) {
-                    $('#plugin-print-sandbox').find('#north-arrow-img').show();
+                    $printSandbox.find('#north-arrow-img').show();
                 }
 
                 if (includeTncLogo) {
-                    $('#plugin-print-sandbox').find('#logo-img').show();
+                    $printSandbox.find('#logo-img').show();
                 }
 
                 window.setTimeout(function() {


### PR DESCRIPTION
## Overview

Adjusts the arguments for prePrintModal and postPrintModal so that all of the arguments provided to one match the other, and all of the arguments have the same name and are in the same order. The print workflow example in the identify point plugin is adjusted to take these changes into account.

Connects #1057 

## Testing Instructions

- Test the identify point plugin (instructions [here](https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/1049)) and verify it still works.
- Verify the [updated documentation](https://github.com/CoastalResilienceNetwork/GeositeFramework/wiki/Plugin-Print-Workflow/_compare/fb687f9c5fb4d23dc613b47b44109303a338e44f...cdd77c94a5a3e1c0e4a978a7ad4f67c84b50c8f5) matches the new function signatures. 