### PR TITLE
Reposition legend during plugin print

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -631,6 +631,10 @@ require(['use!Geosite',
                         map.resize();
                         map.reposition();
 
+                        // Move the legend out of the map container for easier styling
+                        var legendNode = $("#legend-container-0").detach();
+                        $(legendNode).appendTo($printSandbox);
+
                         modalConfirmDeferred.resolve();
 
                         // Pass the modal contents to the plugin,
@@ -646,9 +650,11 @@ require(['use!Geosite',
                 },
 
                 closejs: function () {
-                    // Move the map back to it's original container
+                    // Move the map and legend back to the original container
                     var mapNode = $('#map-0').detach();
+                    var legendNode = $("#legend-container-0").detach();
                     $('.map-container').append(mapNode);
+                    $('#map-0').append(legendNode);
                     map.resize(true);
 
                     // Move the scalebar back to it's original location

--- a/src/GeositeFramework/sample_plugins/identify_point/print.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/print.css
@@ -9,4 +9,10 @@
         top: 1710px;
         -webkit-transform: rotate(45deg);
     }    
+
+    #legend-container-0 {
+        position: absolute;
+        bottom: 25px;
+        right: 10px;
+    }
 }


### PR DESCRIPTION
## Overview

Based on feedback from @lesserj, moving the legend out of the map container for the plugin print workflow should aid plugin developers in positioning the map and legend on the printed page. Also updates the identify point plugin print css to demo how to position the legend for printing.

Connects #1059 

### Demo

*A demonstration of plugin print from the identify point plugin*
![image](https://user-images.githubusercontent.com/1042475/34794606-3880cd40-f61d-11e7-8797-a0afac03793c.png)

## Testing Instructions

- Activate the regional planning plugin and add a few layers to the map.
- Activate the identify point plugin, and click the print icon in the plugin header.
- Place a breakpoint [here](https://github.com/CoastalResilienceNetwork/GeositeFramework/blob/36444eda3342c756c257bcf8de6fe24689257ed9/src/GeositeFramework/js/Plugin.js#L586).
- Click the print button.
- The breakpoint should be triggered. In the inspector, verify that the legend is in the print sandbox as a sibling of the map container.
- Continue the breakpoint, and return to the application.
- In the inspector verify that the legend is child of the map container.