### PR TITLE
Hide legend controls in print

### DIFF
--- a/src/GeositeFramework/css/app-print.css
+++ b/src/GeositeFramework/css/app-print.css
@@ -89,6 +89,10 @@
         font-size: 11px;
     }
 
+    #legend-container-0 .dojoxResizeHandle {
+        display: none;
+    }
+
     /* It's not quite clear why, but removing the !important flags from the next
     few legend style blocks results in the rules, despite not having any conflicting
     rules, not having any effect. It could have something to do with how the legend

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1954,6 +1954,8 @@ a.active {
     visibility: hidden;
     background-color: #fff;
     z-index: 1;
+    height: 100%;
+    width: 100%;
 }
 #map-print-sandbox {
     position: absolute;

--- a/src/GeositeFramework/css/print.css
+++ b/src/GeositeFramework/css/print.css
@@ -53,4 +53,13 @@
     #print-map-container {
         border: none;
     }
+
+    .legend-close {
+        visibility: hidden;
+    }
+
+    #legend-container-0 .dojoxResizeHandle {
+        visibility: hidden;
+    }
+
 }

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -161,7 +161,6 @@ require(['use!Geosite'],
             $('.print-orientation-css').remove();
 
             context.legend.css({ visibility: "visible" });
-            $('.legend-close').css({ visibility: "visible" });
             _.delay(restoreCssDeferred.resolve, 1000);
 
             restoreCssDeferred.then(function() {

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -663,6 +663,7 @@ require(['use!Geosite',
 
                     // Remove print related CSS
                     $('.base-plugin-print-css').remove();
+                    $('.plugin-print-css').remove();
 
                     pluginObject.postPrintCleanup(map);
                 }

--- a/src/GeositeFramework/sample_plugins/identify_point/print.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/print.css
@@ -15,4 +15,9 @@
         bottom: 25px;
         right: 10px;
     }
+
+    #map-0 {
+       height: 10in;
+       width: 10in;
+    }
 }


### PR DESCRIPTION
## Overview

Hide the legend minimize and resize controls during printing.

Connects to #1058

### Demo

*Before*
![image](https://user-images.githubusercontent.com/1042475/34794606-3880cd40-f61d-11e7-8797-a0afac03793c.png)

*After*
![image](https://user-images.githubusercontent.com/1042475/34796335-3220adb6-f623-11e7-85b0-e87fd9d7ac26.png)

## Testing Instructions
- Activate the regional planning plugin and add a few layers to the map.
- Test both the framework print ("Create Map") and plugin print (through the identify point plugin) and verify in both cases that the legend controls are hidden on the printed page.