### PR TITLE
Demo printing after map update

### DIFF
--- a/src/GeositeFramework/sample_plugins/identify_point/html/print-form.html
+++ b/src/GeositeFramework/sample_plugins/identify_point/html/print-form.html
@@ -8,4 +8,9 @@
         <input type="checkbox" name="checkbox" value="value" id="tnc-logo">
         Add TNC Logo
     </label>
+    <br>
+    <label>
+        <input type="checkbox" name="checkbox" value="value" id="add-layer">
+        Add Sample Layer
+    </label>
 </form>

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -118,6 +118,7 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
             postPrintModal: function(postModalDeferred, $printSandbox, $modalSandbox, mapObject) {
                 var includeNorthArrow = $modalSandbox.find('#north-arrow').is(':checked');
                 var includeTncLogo = $modalSandbox.find('#tnc-logo').is(':checked');
+                var addLayer = $modalSandbox.find('#add-layer').is(':checked');
 
                 if (includeNorthArrow) {
                     $printSandbox.find('#north-arrow-img').show();
@@ -127,14 +128,36 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
                     $printSandbox.find('#logo-img').show();
                 }
 
+                if (addLayer) {
+                    if (this.layer) {
+                        this.layer.setVisibility(true);
+                    } else {
+                        this.layer = new esri.layers.ArcGISDynamicMapServiceLayer("http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer", {
+                            "opacity": 0.8
+                        });
+
+                        mapObject.addLayer(this.layer);
+                    }
+                }
+
                 window.setTimeout(function() {
-                    postModalDeferred.resolve();
-                }, 1);
+                    if (mapObject.updating) {
+                        var delayedPrint = mapObject.on('update-end', function() {
+                                delayedPrint.remove();
+                                postModalDeferred.resolve();
+                        });
+                    } else {
+                        postModalDeferred.resolve();
+                    }
+                }, 500);
             },
 
             postPrintCleanup: function(mapObject) {
                 // Reset map to initial position
                 mapObject.centerAndZoom(this.initialCenter, this.initialZoom);
+                if (this.layer) {
+                    this.layer.setVisibility(false);
+                }
             },
 
             showHelp: function() {


### PR DESCRIPTION
## Overview

Update the identify point plugin print to with an asynchronous action (adding a layer to the map). This requires waiting for the map to update before proceeding with printing. 

The timeout is extended to give the map object time to realize it needs to update. Proceeding too quickly results in the layer being added after printing.

This implementation is largely based off of https://github.com/CoastalResilienceNetwork/future_habitat_v2.

Connects to #1062

## Testing Instructions

- Place a breakpoint on line 143 of `src/GeositeFramework/sample_plugins/identify_point/main.js`.
- Activate the plugin print process for the identify point plugin.
- In the modal that appears, add the north arrow and logo, but not the layer, and proceed.
- Verify the breakpoint is not triggered, and that the two images are on the map in print preview.
- Dismiss and activate the print process again.
- Check the box to add the layer to the map, and proceed.
- Verify that the breakpoint is triggered. 
- Proceed and verify that the layer is on the map in print preview.