### PR TITLE
Reimplement legend display fix cross-browser

### DIFF
--- a/src/GeositeFramework/js/Legend.js
+++ b/src/GeositeFramework/js/Legend.js
@@ -62,10 +62,11 @@ define(['use!Geosite',
         },
 
         getLayerTemplate: function(legend, service, layer) {
-            // exclude some layers from legend
-            if ( layer.name.startsWith("_") ){ 
+            // Exclude layers from legend if they begin with an _
+            if (layer.name[0] === '_'){ 
                 return null; 
             }
+
             // Not all layers have legends.
             if (!legend) {
                 return null;


### PR DESCRIPTION


## Overview

A cross browser compatible fix to using a prepended underscore to indicate
layers which should not be displayed in the legend.


### Demo

![screenshot from 2018-02-01 14 05 22](https://user-images.githubusercontent.com/1014341/35697722-044a7db2-0759-11e8-9ffb-d398c8ef96b5.png)


### Notes

See #1071 

## Testing Instructions

 * Rename a layer in your layers.json file to start with `_` and ensure it doesn't show in the legend, as above.
