### PR TITLE
remove min-height from tinner class

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1796,7 +1796,6 @@ header .nav-main {
 .tinner {
     overflow: hidden;
     padding: 0!important;
-    min-height: 380px!important;
     width: 100%;
 }
 .tinner .tclose:hover {


### PR DESCRIPTION
Class tinner is a wrapper div for the Tiny box popups. The framework
adds a min-height of 380px to this wrapper. If you need a popup with a
height less-than 380px it adds unwanted white-space at the bottom of the
popup. Removing or significantly lowering the min-height would give more
control to the height of the popup windows.