### PR TITLE
Adjust mobile single web app "About" page z-index to prevent obscuring the hamburger menu

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -2224,7 +2224,7 @@ body.x-body {
     }
 
     #single-plugin-mode-help-container {
-        z-index: 5010;
+        z-index: 5001;
     }
 
     #search {


### PR DESCRIPTION
## Overview

This PR adjusts the z-index of the "About" element in mobile-mobile-single-web-app mode so that it will no longer obscure the hamburger menu when the latter's open.

Connects #1013 

### Demo

![screen shot 2018-08-29 at 11 09 48 am](https://user-images.githubusercontent.com/4165523/44796994-2a5f8e80-ab7c-11e8-99c9-e403a068da52.png)

## Testing Instructions

- get this branch
- update the `singlePluginMode` object in `region.json` to set `"active": true`, then rebuild the app in Visual Studio and serve it
- visit the site in Chrome in the normal browser
- verify that the "About" link in the header displays an "About" element and that it's not obscured beneath anything
- verify that the hamburger icon on the right header still functions as usual
- turn on the mobile emulator in Chrome devtools, then hard refresh the page
- click the hamburger icon to verify that the menu appears
- click the "About" link to verify that that element gets displayed
- with the "About" element displayed, click on the hamburger icon again and verify that the selection menu isn't hidden beneath the "About" element
