### PR TITLE
Ensure search is always visible and works

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1383,7 +1383,7 @@ header .nav-main {
     position: absolute;
     right: 10px;
     top: 12px;
-    z-index: 2800;
+    z-index: 5800;
 }
 /* -----------------------------------------
    Content Area - Map

--- a/src/GeositeFramework/proxy.ashx
+++ b/src/GeositeFramework/proxy.ashx
@@ -50,7 +50,7 @@ public class proxy : IHttpHandler {
             byte[] bytes = new byte[context.Request.InputStream.Length];
             context.Request.InputStream.Read(bytes, 0, (int)context.Request.InputStream.Length);
             req.ContentLength = bytes.Length;
-            req.ContentType = "application/x-www-form-urlencoded";
+            req.ContentType = "application/x-www-form-urlencoded;charset=utf-8";
             using (Stream outputStream = req.GetRequestStream())
             {
                 outputStream.Write(bytes, 0, bytes.Length);


### PR DESCRIPTION
## Overview

The search bar in the header was hidden on IE11 and Edge. The bug was reported 5 months ago where a quick fix to increase the search bar's z-index produced weird behavior. That doesn't seem to be the case anymore, perhaps due to changes to Edge since then. 

Edge *did* act strangely in that it was unable to communicate with IIS, which was solved by changing a param on the http headers the app sends.

Connects #1076 

### Demo
![edgetnc](https://user-images.githubusercontent.com/10568752/44811330-63125e80-aba2-11e8-84ad-1465b14bf4a8.gif)


### Notes

![screen shot 2018-08-29 at 2 23 55 pm](https://user-images.githubusercontent.com/10568752/44810854-0d898200-aba1-11e8-9b84-e65c7de1af01.png)

What are these files? I did not add them to the PR because they seemed autogenerated and unwanted, perhaps.

## Testing Instructions

Run TNC from Visual Studio. From within the VM, open a browser to Browserstack. Hit  `http://localhost:54633` or use your IIS Geosite Framework site URL. See that the search is visible and searches properly in IE11 and Edge17 on Browserstack.
