### PR TITLE
Upgrade to Arcgis JS API 3.25

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -82,6 +82,7 @@
     <link rel='shortcut icon' href='img/favicon.ico' type='image/x-icon'/ >
 
     <link rel="stylesheet" href="//js.arcgis.com/3.25/dijit/themes/claro/claro.css">
+    <link rel="stylesheet" href="//js.arcgis.com/3.25/esri/css/esri.css">
     <link rel="stylesheet" href="//js.arcgis.com/3.10/js/dojo/dojox/layout/resources/ResizeHandle.css">
     <link rel="stylesheet" href="//js.arcgis.com/o/232546/geosite-v1.0.10/esri/css/esri.css">
 

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -81,9 +81,9 @@
     }
     <link rel='shortcut icon' href='img/favicon.ico' type='image/x-icon'/ >
 
-    <link rel="stylesheet" href="//js.arcgis.com/3.11/dijit/themes/claro/claro.css">
+    <link rel="stylesheet" href="//js.arcgis.com/3.25/dijit/themes/claro/claro.css">
     <link rel="stylesheet" href="//js.arcgis.com/3.10/js/dojo/dojox/layout/resources/ResizeHandle.css">
-    <link rel="stylesheet" href="//js.arcgis.com/o/232546/geosite-v1.0.9/esri/css/esri.css">
+    <link rel="stylesheet" href="//js.arcgis.com/o/232546/geosite-v1.0.10/esri/css/esri.css">
 
     <link rel="stylesheet" href="css/TinyBox2.css">
     <link rel="stylesheet" href="css/pageguide.min.css"/>
@@ -791,7 +791,7 @@
     <script src="js/lib/i18next-jquery-0.0.14.min.js"></script>
     <script src="js/lib/i18next-SprintfPostProcessor-0.2.2.min.js"></script>
 
-    <script src="//js.arcgis.com/o/232546/geosite-v1.0.9/dojo/dojo.js"></script>
+    <script src="//js.arcgis.com/o/232546/geosite-v1.0.10/dojo/dojo.js"></script>
     <script src="Scripts/json2.min.js"></script> <!-- Can be removed when IE8 support is dropped -->
     <script src="js/lib/backbone.picky.js"></script>
     <script src="js/lib/jquery.history.min.js"></script>


### PR DESCRIPTION
## Overview

JSAPI v 3.11 uses an older version of dojo and xstyle. xstyle handles pseudo-css-elements in a way that is incompatible with Chrome and in a past CSS standard, and modern Chrome simply won't load the framework. Newer versions of JS API (3.24+) should fix.

ESRI [recently added](https://www.esri.com/arcgis-blog/products/js-api-arcgis/mapping/new-osm-vector-basemap/) the OpenStreetMap (OSM) basemap. Upgrading the JSAPI version should allow access.

Connects #1081 

### Demo

Missing icons on upgrade:
![screen shot 2018-08-30 at 5 22 09 pm](https://user-images.githubusercontent.com/10568752/44995008-3b8b0f80-af6f-11e8-99fb-1745ad6c43a8.png)

Icons reinstanted with some code changes:
![screen shot 2018-08-30 at 4 59 04 pm](https://user-images.githubusercontent.com/10568752/45032996-32f31180-b021-11e8-8f72-201150619999.png)



### Notes

![screen shot 2018-08-31 at 4 48 26 pm](https://user-images.githubusercontent.com/10568752/44989288-64090e80-af5b-11e8-9f5b-5e2edf1e8464.png)

There's still a bunch of console errors. The first 3 are also seen on develop or production sites, but the CORS errors are new. My instinct was to fake a header in `proxy.ashx` [sniffing out this ESRI CORS documentation](https://developers.arcgis.com/javascript/3/jssamples/exp_cors_buffer.html), but didn't succeed.  Ultimately, nothing is broken but I made this PR WIP and want to ask for help here.

## Testing Instructions

Pull down this branch and start the project. See that nothing is broken in all evergreen browsers.

