### PR TITLE
Use fixed rather than relative measurement units for print css rules

### DIFF
--- a/src/GeositeFramework/css/app-print.css
+++ b/src/GeositeFramework/css/app-print.css
@@ -1,35 +1,4 @@
 ﻿@media print {
-    .print-sandbox-header h1 {
-        width: 100%;
-        padding-top: 0.3in;
-        text-align: center;
-    }
-
-    #map-print-sandbox {
-        visibility: visible;
-    }
-
-    #print-map-container {
-        overflow: hidden;
-    }
-
-    .control-container {
-        display: none;
-    }
-
-    #export-print-preview-container {
-        padding-bottom: 5px;
-        visibility: visible;
-    }
-
-    #print-map-container > #export-print-preview-map > #map-0 {
-        height: 100%;
-        width: 100%;
-        position: relative;
-        max-height: 1800px;
-        top: 0;
-    }
-
     .dojoxResizeHandle {
         visibility: hidden;
     }
@@ -68,77 +37,12 @@
         display: none;
     }
 
-    /* Legend can be manually resized by user, which utilizies inline style rules.
-    Without these overrides, the legend would be sized on the print-out as it
-    in the DOM. */
-    #legend-container-0 {
-        margin-left: 0px !important;
-        left: 0px !important;
-        width: 100% !important;
-        position: absolute !important;
-        z-index: 10;
-        background-color: #fff !important; /* Needed for IE */
-    }
-
     .legend-close {
         visibility: hidden;
     }
 
-    .legend-header {
-        height: 15%;
-        font-size: 11px;
-    }
-
     #legend-container-0 .dojoxResizeHandle {
         display: none;
-    }
-
-    /* It's not quite clear why, but removing the !important flags from the next
-    few legend style blocks results in the rules, despite not having any conflicting
-    rules, not having any effect. It could have something to do with how the legend
-    elements are moved around the DOM for printing */
-    div.legend-body {
-        display: -webkit-box;
-        display: -ms-flexbox;
-        display: flex;
-        width: 100% !important;
-        height: 85% !important;
-        background-color: #fff !important; /* Needed for IE */
-    }
-
-    div.layer-legends {
-        display: -webkit-box;
-        display: -ms-flexbox;
-        display: flex;
-        -webkit-box-orient: vertical;
-        -webkit-box-direction: normal;
-            -ms-flex-direction: column;
-                flex-direction: column;
-        -ms-flex-wrap: wrap;
-            flex-wrap: wrap;
-        width: 100%;
-        align-content: flex-start;
-    }
-
-    div.legend-layer {
-        width: auto !important;
-        height: auto !important;
-        font-size: 8px;
-        margin: 0 10px 0 0;
-    }
-
-    div.plugin-legends {
-        display: flex;
-    }
-
-    div.custom-legend {
-        min-width: 100px;
-        max-width: 300px;
-    }
-
-    .legend-layer img {
-        width: 10px;
-        height: 10px;
     }
 }
 

--- a/src/GeositeFramework/css/print-a4-landscape.css
+++ b/src/GeositeFramework/css/print-a4-landscape.css
@@ -6,7 +6,7 @@
     #map-print-sandbox {
         visibility: visible;
         width: 10.69in;
-        height: 7.5in;
+        height: 7.25in;
     }
 
     #map-print-sandbox > .print-sandbox-header {
@@ -21,16 +21,16 @@
 
     #map-print-sandbox > #print-map-container {
         width: 10.69in;
-        height: 6.4in;
+        height: 6.15in;
     }
 
     #map-print-sandbox > #print-map-container > #export-print-preview-map {
         width: 10.59in;
-        height: 6.4in;
+        height: 6.15in;
     }
 
     #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 {
-        height: 6.3in;
+        height: 6.05in;
         width: 10.59in;
         position: relative;
     }
@@ -114,15 +114,15 @@
 
 #map-print-sandbox {
     width: 10.69in;
-    height: 7.5in;
+    height: 7.25in;
 }
 
 #print-map-container {
     width: 10.69in;
-    height: 6.4in;
+    height: 6.15in;
 }
 
 #print-map-container > #export-print-preview-map {
     width: 10.59in;
-    height: 6.4in;
+    height: 6.15in;
 }

--- a/src/GeositeFramework/css/print-a4-landscape.css
+++ b/src/GeositeFramework/css/print-a4-landscape.css
@@ -4,45 +4,125 @@
     }
 
     #map-print-sandbox {
+        visibility: visible;
         width: 10.69in;
-        height: 5.76in;
+        height: 7.5in;
     }
 
-    #print-map-container {
-        width: 10.69in;
-        height: 5.76in;
+    #map-print-sandbox > .print-sandbox-header {
+        height: 1in;
     }
 
-    #print-map-container > #export-print-preview-map {
+    #map-print-sandbox > .print-sandbox-header > h1 {
+        width: 10.69in;
+        padding-top: 0.3in;
+        text-align: center;
+    }
+
+    #map-print-sandbox > #print-map-container {
+        width: 10.69in;
+        height: 6.4in;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map {
         width: 10.59in;
-        height: 5.66in;
+        height: 6.4in;
     }
 
-    #legend-container-0 {
-        top: 80% !important;
-        height: 20% !important;
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 {
+        height: 6.3in;
+        width: 10.59in;
+        position: relative;
     }
 
-    .above-legend {
-        bottom: 21%;
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > .control-container {
+        display: none;
     }
 
-    .page-bottom {
-        bottom: 2%;
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 {
+        bottom: 0 !important;
+        height: 1.5in !important;
+        margin-left: 0 !important;
+        left: 0 !important;
+        width: 10.59in !important;
+        position: absolute !important;
+        z-index: 10;
+        background-color: #fff !important; /* Needed for IE */
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-header {
+        height: 0.3in;
+        font-size: 11px;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        width: 10.59in !important;
+        height: 1.2in !important;
+        background-color: #fff !important; /* Needed for IE */
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .plugin-legends {
+        display: flex;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .plugin-legends > .custom-legend {
+        min-width: 100px;
+        max-width: 300px;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        width: 10.59in;
+        align-content: flex-start;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends > .legend-layer {
+        width: auto !important;
+        height: auto !important;
+        font-size: 8px;
+        margin: 0 0.2in 0 0;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends > .legend-layer > img {
+        width: 0.25in;
+        height: 0.25in;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #map-0_root > .esriControlsBR.above-legend {
+        bottom: 2.7in !important;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #map-0_root > .esriControlsBR.page-bottom {
+        bottom: 1.2in !important;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > .above-legend {
+        bottom: 1.6in;
     }
 }
 
 #map-print-sandbox {
     width: 10.69in;
-    height: 5.76in;
+    height: 7.5in;
 }
 
 #print-map-container {
     width: 10.69in;
-    height: 5.76in;
+    height: 6.4in;
 }
 
 #print-map-container > #export-print-preview-map {
     width: 10.59in;
-    height: 5.66in;
+    height: 6.4in;
 }

--- a/src/GeositeFramework/css/print-a4-portrait.css
+++ b/src/GeositeFramework/css/print-a4-portrait.css
@@ -1,48 +1,128 @@
 @media print {
     @page {
-        size: letter portrait;
+        size: A4 portrait;
     }
 
     #map-print-sandbox {
-        width: 7.76in;
-        height: 9.69in;
+        visibility: visible;
+        width: 8.25in;
+        height: 11in;
     }
 
-    #print-map-container {
-        width: 7.76in;
-        height: 9.34in;
+    #map-print-sandbox > .print-sandbox-header {
+        height: 1in;
     }
 
-    #print-map-container > #export-print-preview-map {
-        width: 7.66in;
-        height: 9.19in;
+    #map-print-sandbox > .print-sandbox-header > h1 {
+        width: 8.25in;
+        padding-top: 0.3in;
+        text-align: center;
     }
 
-    #legend-container-0 {
-        top: 75% !important;
-        height: 25% !important;
+    #map-print-sandbox > #print-map-container {
+        width: 8.25in;
+        height: 9.9in;
     }
 
-    .above-legend {
-        bottom: 26%;
+    #map-print-sandbox > #print-map-container > #export-print-preview-map {
+        width: 8.2in;
+        height: 9.9in;
     }
 
-    .page-bottom {
-        bottom: 2%;
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 {
+        height: 9.8in;
+        width: 8.19in;
+        position: relative;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > .control-container {
+        display: none;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 {
+        bottom: 0 !important;
+        height: 1.5in !important;
+        margin-left: 0 !important;
+        left: 0 !important;
+        width: 8.19in !important;
+        position: absolute !important;
+        z-index: 10;
+        background-color: #fff !important; /* Needed for IE */
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-header {
+        height: 0.3in;
+        font-size: 11px;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        width: 8.19in !important;
+        height: 1.2in !important;
+        background-color: #fff !important; /* Needed for IE */
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .plugin-legends {
+        display: flex;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .plugin-legends > .custom-legend {
+        min-width: 100px;
+        max-width: 300px;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        width: 8.19in;
+        align-content: flex-start;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends > .legend-layer {
+        width: auto !important;
+        height: auto !important;
+        font-size: 8px;
+        margin: 0 0.2in 0 0;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends > .legend-layer > img {
+        width: 0.25in;
+        height: 0.25in;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #map-0_root > .esriControlsBR.above-legend {
+        bottom: 2.7in !important;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #map-0_root > .esriControlsBR.page-bottom {
+        bottom: 1.2in !important;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > .above-legend {
+        bottom: 1.6in;
     }
 }
 
 #map-print-sandbox {
-    width: 7.76in;
-    height: 9.69in;
+    width: 8.25in;
+    height: 11in;
 }
 
 #print-map-container {
-    width: 7.76in;
-    height: 9.34in;
+    width: 8.25in;
+    height: 9.9in;
 }
 
 #print-map-container > #export-print-preview-map {
-    width: 7.66in;
-    height: 9.19in;
+    width: 8.2in;
+    height: 9.9in;
 }

--- a/src/GeositeFramework/css/print-letter-landscape.css
+++ b/src/GeositeFramework/css/print-letter-landscape.css
@@ -4,45 +4,125 @@
     }
 
     #map-print-sandbox {
-        width: 10in;
-        height: 6in;
+        visibility: visible;
+        width: 11in;
+        height: 8in;
     }
 
-    #print-map-container {
-        width: 10in;
-        height: 6in;
+    #map-print-sandbox > .print-sandbox-header {
+        height: 1in;
     }
 
-    #print-map-container > #export-print-preview-map {
-        width: 9.9in;
-        height: 5.9in;
+    #map-print-sandbox > .print-sandbox-header > h1 {
+        width: 11in;
+        padding-top: 0.3in;
+        text-align: center;
     }
 
-    #legend-container-0 {
-        top: 80% !important;
-        height: 20% !important;
+    #map-print-sandbox > #print-map-container {
+        width: 11in;
+        height: 6.9in;
     }
 
-    .above-legend {
-        bottom: 21%;
+    #map-print-sandbox > #print-map-container > #export-print-preview-map {
+        width: 10.90in;
+        height: 6.9in;
     }
 
-    .page-bottom {
-        bottom: 2%;
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 {
+        height: 6.8in;
+        width: 10.90in;
+        position: relative;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > .control-container {
+        display: none;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 {
+        bottom: 0 !important;
+        height: 1.5in !important;
+        margin-left: 0 !important;
+        left: 0 !important;
+        width: 10.90in !important;
+        position: absolute !important;
+        z-index: 10;
+        background-color: #fff !important; /* Needed for IE */
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-header {
+        height: 0.3in;
+        font-size: 11px;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        width: 10.90in !important;
+        height: 1.2in !important;
+        background-color: #fff !important; /* Needed for IE */
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .plugin-legends {
+        display: flex;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .plugin-legends > .custom-legend {
+        min-width: 100px;
+        max-width: 300px;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        width: 10.90in;
+        align-content: flex-start;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends > .legend-layer {
+        width: auto !important;
+        height: auto !important;
+        font-size: 8px;
+        margin: 0 0.2in 0 0;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends > .legend-layer > img {
+        width: 0.25in;
+        height: 0.25in;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #map-0_root > .esriControlsBR.above-legend {
+        bottom: 2.7in !important;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #map-0_root > .esriControlsBR.page-bottom {
+        bottom: 1.2in !important;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > .above-legend {
+        bottom: 1.6in;
     }
 }
 
 #map-print-sandbox {
-    width: 10in;
-    height: 6in;
+    width: 11in;
+    height: 8in;
 }
 
 #print-map-container {
-    width: 10in;
-    height: 6in;
+    width: 11in;
+    height: 6.9in;
 }
 
 #print-map-container > #export-print-preview-map {
-    height: 5.9in;
-    width: 9.9in;
+    width: 11in;
+    height: 6.9in;
 }

--- a/src/GeositeFramework/css/print-letter-portrait.css
+++ b/src/GeositeFramework/css/print-letter-portrait.css
@@ -1,48 +1,128 @@
 @media print {
     @page {
-        size: letter portrait;
+        size: A4 portrait;
     }
 
     #map-print-sandbox {
+        visibility: visible;
         width: 8in;
-        height: 9in;
+        height: 11in;
     }
 
-    #print-map-container {
-        width: 8in;
-        height: 8.65in;
+    #map-print-sandbox > .print-sandbox-header {
+        height: 1in;
     }
 
-    #print-map-container > #export-print-preview-map {
+    #map-print-sandbox > .print-sandbox-header > h1 {
+        width: 8in;
+        padding-top: 0.3in;
+        text-align: center;
+    }
+
+    #map-print-sandbox > #print-map-container {
+        width: 8in;
+        height: 9.9in;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map {
         width: 7.9in;
-        height: 8.5in;
+        height: 9.9in;
     }
 
-    #legend-container-0 {
-        top: 75% !important;
-        height: 25% !important;
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 {
+        height: 9.8in;
+        width: 7.89in;
+        position: relative;
     }
 
-    .above-legend {
-        bottom: 26%;
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > .control-container {
+        display: none;
     }
 
-    .page-bottom {
-        bottom: 2%;
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 {
+        bottom: 0 !important;
+        height: 1.5in !important;
+        margin-left: 0 !important;
+        left: 0 !important;
+        width: 7.89in !important;
+        position: absolute !important;
+        z-index: 10;
+        background-color: #fff !important; /* Needed for IE */
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-header {
+        height: 0.3in;
+        font-size: 11px;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        width: 7.89in !important;
+        height: 1.2in !important;
+        background-color: #fff !important; /* Needed for IE */
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .plugin-legends {
+        display: flex;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .plugin-legends > .custom-legend {
+        min-width: 100px;
+        max-width: 300px;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends {
+        display: -webkit-box;
+        display: -ms-flexbox;
+        display: flex;
+        -webkit-box-orient: vertical;
+        -webkit-box-direction: normal;
+        -ms-flex-direction: column;
+        flex-direction: column;
+        -ms-flex-wrap: wrap;
+        flex-wrap: wrap;
+        width: 7.89in;
+        align-content: flex-start;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends > .legend-layer {
+        width: auto !important;
+        height: auto !important;
+        font-size: 8px;
+        margin: 0 0.2in 0 0;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #legend-container-0 > .legend-body > .layer-legends > .legend-layer > img {
+        width: 0.25in;
+        height: 0.25in;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #map-0_root > .esriControlsBR.above-legend {
+        bottom: 2.7in !important;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > #map-0_root > .esriControlsBR.page-bottom {
+        bottom: 1.2in !important;
+    }
+
+    #map-print-sandbox > #print-map-container > #export-print-preview-map > #map-0 > .above-legend {
+        bottom: 1.6in;
     }
 }
 
 #map-print-sandbox {
     width: 8in;
-    height: 9in;
+    height: 11in;
 }
 
 #print-map-container {
     width: 8in;
-    height: 8.65in;
+    height: 9.9in;
 }
 
 #print-map-container > #export-print-preview-map {
-    height: 8.5in;
     width: 7.9in;
+    height: 9.9in;
 }

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -43,7 +43,6 @@ require(['use!Geosite'],
             $('#plugin-print-sandbox').empty();
             $('.plugin-print-css').remove();
             $('.base-plugin-print-css').remove();
-            addAppPrintCSSFile();
 
             var html = N.app.templates['template-export-window']();
             view.$el.empty().append(html);
@@ -115,6 +114,7 @@ require(['use!Geosite'],
                 invalidateSize(context.map);
             });
 
+            addAppPrintCSSFile();
             addPagePrintCSSFile(debug);
 
             _.delay(orientDeferred.resolve, 1000);


### PR DESCRIPTION
## Overview

This PR adjusts the print-related CSS stylesheets to use fixed unit measurements rather than relative units whenever possible. This should simplify the process of positioning elements for a specific paper size and orientation in future.

Connects #1061 

### Notes

Second commit here is there to make it easier to have a intervening step in the print debug workflow in which the print DOM is inspectable; otherwise it doesn't do anything.

## Testing Instructions

- get this branch plus regional planning
- use app print for the four supported paper shapes without a layer legend and verify that each works and prints on a single page
- add some layers, then use app print for the four shapes again with a layer legend and verify that each works and also prints on a single page
