### PR TITLE
Add OSM basemap option

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -7,6 +7,7 @@ require(['use!Geosite',
          'framework/util/ajax',
          'esri/map',
          'esri/dijit/Scalebar',
+         'esri/layers/OpenStreetMapLayer',
          'esri/layers/ArcGISTiledMapServiceLayer',
          'esri/geometry/Extent',
          'esri/SpatialReference',
@@ -18,6 +19,7 @@ require(['use!Geosite',
              ajaxUtil,
              Map,
              ScaleBar,
+             OpenStreetMapLayer,
              ArcGISTiledMapServiceLayer,
              Extent,
              SpatialReference,
@@ -29,7 +31,11 @@ require(['use!Geosite',
         var basemap = getSelectedBasemap(model);
         if (basemap.layer === undefined) {
             // This basemap has no layer yet, so make one and cache it
-            basemap.layer = new ArcGISTiledMapServiceLayer(basemap.url);
+            if (basemap.name.toLowerCase() === 'openstreetmap') {
+                basemap.layer = new OpenStreetMapLayer();
+            } else {
+                basemap.layer = new ArcGISTiledMapServiceLayer(basemap.url);
+            }
             esriMap.addLayer(basemap.layer);
         }
         return basemap.layer;

--- a/src/GeositeFramework/region.json
+++ b/src/GeositeFramework/region.json
@@ -77,7 +77,8 @@
         { "name": "Physical"           , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Physical_Map/MapServer" },
         { "name": "Shaded Relief"      , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer" },
         { "name": "Streets"            , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer" },
-        { "name": "Terrain"            , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer" }
+        { "name": "Terrain"            , "url": "http://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer" },
+        { "name": "OpenStreetMap"      , "url": "" }
     ],
     "pluginFolders": [
         "plugins",


### PR DESCRIPTION
## Overview

We offer a lot of basemaps the user can select from, but not OSM surprisingly. This PR adds the ability to select an OSM layer as the basemap. It's hard to find older JS API documentation but I think the OSM layer feature has existed for some time. The issue refers to OSM capability that was added since v3.24, which I'm guessing refers to the [new OSM vector tile basemap ](https://www.esri.com/arcgis-blog/products/js-api-arcgis/mapping/new-osm-vector-basemap/) which I don't imagine we will use.

Connects #1082 

### Demo
![screen shot 2018-09-05 at 9 33 09 am](https://user-images.githubusercontent.com/10568752/45096700-1d4c1d80-b0ef-11e8-87dc-1e9e0816e8c3.png)
![screen shot 2018-09-05 at 9 33 26 am](https://user-images.githubusercontent.com/10568752/45096701-1d4c1d80-b0ef-11e8-9bc8-f688da1f1c16.png)


## Notes

Note this branch was built on top of the js api upgrade branch, following the assumption in the issue. I don't think it is dependent on the upgrade after all, but doesn't hurt to continue to merge it as so.

## Testing Instructions

Pull down this branch and refresh in the browser. The layer selector should include OSM and it should be selectable.

If OSM doesn't show up in the dropdown, it may be that visual studio cache has clogged up. I had to exit VS and reopen my project once to get the changes to take.

