### PR TITLE
Enable debugging print styles in browser

### DIFF
--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -83,6 +83,23 @@ require(['use!Geosite'],
             map.reposition();
         }
 
+        function moveScaleBarAboveLegendForPrint() {
+            $(".esriScalebar").addClass("above-legend");
+            $(".esriControlsBR").addClass("above-legend");
+        }
+
+        function moveScaleBarToPageBottomForPrint() {
+            $(".esriScalebar").toggleClass("page-bottom");
+            $(".esriControlsBR").toggleClass("page-bottom");
+        }
+
+        function restoreScaleBarAfterPrint() {
+            $(".esriScalebar").removeClass("above-legend");
+            $(".esriScalebar").removeClass("page-bottom");
+            $(".esriControlsBR").removeClass("above-legend");
+            $(".esriControlsBR").removeClass("page-bottom");
+        }
+
         function createPrintableMap(
             context, previewDeferred, orientDeferred, resizeDeferred, legendDeferred, postPrintAction
         ) {
@@ -130,15 +147,12 @@ require(['use!Geosite'],
                     context.legend.css({ visibility: "visible" });
                     $(".item.expand>.expand-legend").click();
                     $(".item.extra.collapse").hide();
-                    $(".esriScalebar").toggleClass("above-legend");
-                    $(".esriControlsBR").toggleClass("above-legend");
-
+                    moveScaleBarAboveLegendForPrint();
                 } else {
                     // if the style rule is changed via jquery, that state seems to
                     // "stick", regardless of what's in the stylesheet
                     context.legend.css({ visibility: "hidden" });
-                    $(".esriScalebar").toggleClass("page-bottom");
-                    $(".esriControlsBR").toggleClass("page-bottom");
+                    moveScaleBarToPageBottomForPrint();
                 }
 
                 _.delay(legendDeferred.resolve, 1000);

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -2,16 +2,49 @@
 
 require(['use!Geosite'],
     function(N) {
-    "use strict";
+        "use strict";
+
+        function addAppPrintCSSFile() {
+            $('<link>', {
+                rel: 'stylesheet',
+                href: 'css/app-print.css',
+                'class': 'app-print-css'
+            }).appendTo('head');
+        }
+
+        function addPagePrintCSSFile(debug) {
+            var pageOrientation,
+                pageSize;
+
+            if (!debug) {
+                pageOrientation = $("[name='export-orientation']:checked").val();
+                pageSize = $("[name='export-page-size']:checked").val();
+            } else {
+                pageOrientation = 'portrait';
+                pageSize = 'letter';
+            }
+
+            $('<link>', {
+                rel: 'stylesheet',
+                href: pageCssLink(pageOrientation, pageSize),
+                'class': 'print-orientation-css',
+            }).appendTo('head');
+        }
+
+        function removeAppPrintCSSFile() {
+            $('.app-print-css').remove();
+        }
+
+        function removePagePrintCSSFile() {
+            $('.print-orientation-css').remove();
+        }
+
         function render(view) {
             $('#plugin-print-sandbox').empty();
             $('.plugin-print-css').remove();
             $('.base-plugin-print-css').remove();
-            $('<link>', {
-                rel: 'stylesheet',
-                href: 'css/app-print.css',
-                'class': 'app-print-css' 
-            }).appendTo('head');
+            addAppPrintCSSFile();
+
             var html = N.app.templates['template-export-window']();
             view.$el.empty().append(html);
             if (view.$uiContainer) {
@@ -73,11 +106,7 @@ require(['use!Geosite'],
                 var pageOrientation = $("[name='export-orientation']:checked").val();
                 var pageSize = $("[name='export-page-size']:checked").val();
 
-                $('<link>', {
-                    rel: 'stylesheet',
-                    href: pageCssLink(pageOrientation, pageSize),
-                    'class': 'print-orientation-css',
-                }).appendTo('head');
+                addPagePrintCSSFile();
 
                 _.delay(orientDeferred.resolve, 1000);
 
@@ -123,18 +152,22 @@ require(['use!Geosite'],
                 function afterPrintHandler() {
                     _.delay(previewDeferred.resolve, 250);
                 }
+
                 $.when(orientDeferred, legendDeferred, resizeDeferred)
                  .then(function () {
-                    /* 
+                    /*
                         Chrome's exposed 'window.print' method includes a preview and
                         blocks, whereas non-Chrome browsers do neither; similarly,
                         Chrome does not expose an 'onafterprint' event while the
                         others do.
                     */
+
                     if (!isChrome()) {
                         window.onafterprint = afterPrintHandler;
                     }
+
                     window.print();
+
                     if (isChrome()) {
                         previewDeferred.resolve();
                     }
@@ -157,8 +190,8 @@ require(['use!Geosite'],
                 exportMap = $("#export-print-preview-map"),
                 exportContainer = $("#export-print-preview-container");
 
-            $('.app-print-css').remove();
-            $('.print-orientation-css').remove();
+            removeAppPrintCSSFile();
+            removePagePrintCSSFile();
 
             context.legend.css({ visibility: "visible" });
             _.delay(restoreCssDeferred.resolve, 1000);

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -261,7 +261,7 @@ require(['use!Geosite'],
                     destroyExport(context);
                 }
             });
-            
+
             return mapReadyDeferred;
         }
 
@@ -320,7 +320,7 @@ require(['use!Geosite'],
         render: function () {
             var view = this,
                 body = N.app.templates['template-export-window']();
-            
+
             this.$el
                 .empty()
                 .append(body);


### PR DESCRIPTION
## Overview

This PR adds code to the `Export.js` class to facilitate inspecting the print-specific stylesheets in the browser for debugging purposes.

It works by allowing the user to add a querystring like `?debug=true&size=letter&orientation=portrait` to the site URL, which is then read in `Export.js` to determine whether the app is in print debug mode.

If it's not in debug mode, everything will work as before with regard to printing

If it is in debug mode, clicking "Generate Map Export" in the "Create Map" modal will create the same print-styled document that's output for printing when a developer selects "print" from the "Emulate CSS Media" tool depicted here:

![screen shot 2018-09-05 at 5 31 30 pm](https://user-images.githubusercontent.com/4165523/45122371-9a988200-b131-11e8-9c58-281a7107fa37.png)

This is essentially prep work for #1010 and #1061. #1010 has some pretty involved instructions for handling printing stylesheet setup, and #1061 was difficult to debug past a certain point without being able to inspect the DOM.

Connects #1010 
Connects #1061 

### Demo

![screen shot 2018-09-05 at 5 26 01 pm](https://user-images.githubusercontent.com/4165523/45122400-b2700600-b131-11e8-8df9-4ce4c268c6e4.png)

### Notes

It probably makes sense for this to work only in development (and possibly staging) versions, so I'm happy to add some additional guards to prevent debugging from being active in production.

## Testing Instructions

- build this branch, then visit the main page at the `/` path and use framework print to "Generate Map Export", verifying that it works as it does on `develop`.
- reload the app with the following querystrings and try the sequence below to create an inspectable map print document in the browser:

`?debug=true&size=letter&orientation=portrait`
`?debug=true&size=letter&orientation=landscape`
`?debug=true&size=a4&orientation=portrait`
`?debug=true&size=a4&orientation=landscape`

For each of those the steps to generate an inspectable map document are:

- click "Create Map" in the tools
- click "Generate Map Export" in the modal
- when the background map disappears, open the "Rendering" tab of Chrome developer tools and then select "Print" from the "Emulate CSS Media Dropdown":

![screen shot 2018-09-05 at 5 31 30 pm](https://user-images.githubusercontent.com/4165523/45122631-670a2780-b132-11e8-869f-34f415048cf4.png)

Note that you'll have to refresh between debugging sessions to restore the map properly.