### PR TITLE
Plugin print preview map demo

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -284,7 +284,9 @@ require(['use!Geosite',
                 result = [];
             _.each(services, function (service) {
                 var serviceInfo = view.model.serviceInfos[service.id];
-                if (serviceInfo && service.visible && serviceInfo.pluginObject.showServiceLayersInLegend) {
+                if (serviceInfo && service.visible &&
+                    serviceInfo.pluginObject.showServiceLayersInLegend &&
+                    serviceInfo.visibleLayers) {
                     service.visibleLayers.sort(function(a, b) { return a - b; });
                     _.each(service.visibleLayers, function(layerId) {
                         var layer,

--- a/src/GeositeFramework/sample_plugins/identify_point/html/print-form.html
+++ b/src/GeositeFramework/sample_plugins/identify_point/html/print-form.html
@@ -13,4 +13,8 @@
         <input type="checkbox" name="checkbox" value="value" id="add-layer">
         Add Sample Layer
     </label>
+    <div class="print-preview">
+        Adjust the map to fit your desired printing area.
+        <div class="print-preview-map-container"></div>
+    </div>
 </form>

--- a/src/GeositeFramework/sample_plugins/identify_point/main.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.css
@@ -16,13 +16,3 @@ hr {
 .sample img {
     display: none;
 }
-
-#north-arrow-img {
-    height: 60px;
-    width: 100px;
-}
-
-#logo-img {
-    height: 60px;
-    width: 200px;
-}

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -143,8 +143,8 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
                 window.setTimeout(function() {
                     if (mapObject.updating) {
                         var delayedPrint = mapObject.on('update-end', function() {
-                                delayedPrint.remove();
-                                postModalDeferred.resolve();
+                            delayedPrint.remove();
+                            postModalDeferred.resolve();
                         });
                     } else {
                         postModalDeferred.resolve();

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -18,7 +18,7 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
             size: 'small',
             hasCustomPrint: true,
             usePrintModal: true,
-            printModalSize: [500, 200],
+            printModalSize: [500, 475],
             infographic: [500, 300],
 
             initialize: function(frameworkParameters) {
@@ -102,6 +102,11 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
             prePrintModal: function(preModalDeferred, $printSandbox, $modalSandbox, mapObject) {
                 $.get('sample_plugins/identify_point/html/print-form.html', function(html) {
                     $modalSandbox.append(html);
+
+                    var mapNode = $("#map-0").detach();
+                    $(mapNode).appendTo('.print-preview-map-container');
+                    mapObject.resize(true);
+                    mapObject.reposition();
                 }).then(preModalDeferred.resolve());
 
                 // Append optional images to print sandbox, which are hidden by default

--- a/src/GeositeFramework/sample_plugins/identify_point/print.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/print.css
@@ -17,7 +17,69 @@
     }
 
     #map-0 {
-       height: 10in;
-       width: 10in;
+       height: 8in;
+       width: 8in;
     }
+}
+
+#north-arrow-img {
+    height: 60px;
+    width: 70px;
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+}
+
+#logo-img {
+    height: 60px;
+    width: 200px;
+}
+
+/**
+    Rules related to the print preview map:
+    1. Overrides to the print modal to fit the map
+    2. Overrides to the map to better fit in the modal
+**/
+
+.print-preview {
+    width: 100%;
+    margin-top: 10px;
+}
+
+.print-preview-map-container {
+    width: 100%;
+    height: 100%;
+}
+
+.print-preview-map-container #map-0.map {
+    position: relative;
+    height: 325px;
+}
+
+.popover-section {
+    height: 400px;
+}
+
+.print-modal-confirm-container {
+    position: initial;
+}
+
+.map-tools {
+    display: none;
+}
+
+.basemap-selector {
+    display: none;
+}
+
+#map-0_zoom_slider {
+    top: 10px;
+    right: 10px;
+}
+
+.print-modal-confirm-container {
+    position: relative !important;
+    margin-top: 30px;
+    bottom: 0px !important;
+    left: 0px !important;
 }


### PR DESCRIPTION
## Overview

Add a print preview map to the identify point plugin. This serves as a demo to plugin developers of how to add a print preview map to the plugin print workflow.

Also, make some adjustments to the optional print images and map size for the plugin to compensate for the new sizing units.

Connects #1103 

### Demo

![image](https://user-images.githubusercontent.com/1042475/45371461-a9ab8400-b5b8-11e8-9110-6ac4e8c3ac72.png)

## Testing Instructions

- Open up the identify point plugin
- Click the print button
- Verify there is a map in the print modal.
- Reposition the map, click print, and verify the browser print preview shows the map in the new position.
