### PR TITLE
Translate additional framework elements

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -245,7 +245,7 @@
         }
         <nav class="nav-apps plugins nav-apps-narrow @(Model.SinglePluginMode ? "single-plugin-mode" : "")">
             <div id="sidebar-help-area">
-                <a id="help-overlay-start" href="#" data-i18n="Tour">Tour</a>
+                <a id="help-overlay-start" href="#" class="i18n" data-i18n="Tour">Tour</a>
                 <div id="sidebar-toggle">
                     <a><i class="fa fa-chevron-right"></i></a>
                 </div>

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -547,7 +547,10 @@
                   <label class="popover-section"><div class="h3 i18n" data-i18n="Permalink">Permalink</div>
                     <input class="form-control code-like permalink-textbox" type="text" value="<%= shortUrl %>"/></label>
                   <label class="popover-section h3" data-i18n="Embed"><div class="h3">Embed</div></label>
-                  <p>You can copy and paste the following code to embed this map on your website.</p><br>
+                  <p class="i18n" data-i18n="You can copy and paste the following code to embed this map on your website.">
+                      You can copy and paste the following code to embed this map on your website.
+                  </p>
+                  <br>
                   <span id="iframe-embed"></span>
                   <div class="popover-container">
                       <div class="row">

--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -485,7 +485,7 @@
                         <label class="form-component">
                             <input type="radio" name="export-orientation" value="landscape" checked="checked"/>
                             <div class="check"></div>
-                            <span class="form-text i18n" data-i18n="landscape">Landscape</span>
+                            <span class="form-text i18n" data-i18n="Landscape">Landscape</span>
                         </label>
                         <label class="form-component">
                             <input type="radio" name="export-orientation" value="portrait"/>

--- a/src/GeositeFramework/js/Export.js
+++ b/src/GeositeFramework/js/Export.js
@@ -259,7 +259,7 @@ require(['use!Geosite'],
 
         function showMapExportModal(model) {
             var mapMarkup = N.app.templates['template-export-window']({ pluginName: "Test" }),
-                $mapPrint = $($.trim(mapMarkup)),
+                $mapPrint = $($.trim(mapMarkup)).localize(),
                 mapReadyDeferred = $.Deferred(),
                 map = model.get('esriMap'),
                 mapElement = $("#map-0"),

--- a/src/GeositeFramework/locales/en.json
+++ b/src/GeositeFramework/locales/en.json
@@ -80,4 +80,6 @@
     "Find address or place": "Find address or place",
     "Letter": "Letter",
     "Page Size": "Page Size",
+    "Embed": "Embed",
+    "You can copy and paste the following code to embed this map on your website.": "You can copy and paste the following code to embed this map on your website."
 }

--- a/src/GeositeFramework/locales/en.json
+++ b/src/GeositeFramework/locales/en.json
@@ -77,5 +77,7 @@
     "View": "View",
     "more": "more",
     "View less": "View less",
-    "Find address or place": "Find address or place"
+    "Find address or place": "Find address or place",
+    "Letter": "Letter",
+    "Page Size": "Page Size",
 }

--- a/src/GeositeFramework/locales/es.json
+++ b/src/GeositeFramework/locales/es.json
@@ -80,4 +80,6 @@
     "Find address or place": "Encontrar dirección o lugar",
     "Letter": "Carta",
     "Page Size": "Tamaño de página",
+    "Embed": "Empotrar",
+    "You can copy and paste the following code to embed this map on your website.": "Puede copiar y pegar el siguiente código para insertar este mapa en su sitio web."
 }

--- a/src/GeositeFramework/locales/es.json
+++ b/src/GeositeFramework/locales/es.json
@@ -10,7 +10,7 @@
     "Save & Share": "Guardar y Compartir",
     "Receive help on how to use this application": "Recibir ayuda sobre cómo utilizar esta aplicación",
     "Help": "Ayuda",
-    "Tour": "Tutorial",
+    "Tour": "Gira",
     "Allow maps to show different extents": "Permitir que los mapas muestren diferentes zonas",
     "Unlink Maps": "Desvincular mapas 1 y 2",
     "Force maps to show the same extent": "Ver la misma zona en ambos mapas",

--- a/src/GeositeFramework/locales/es.json
+++ b/src/GeositeFramework/locales/es.json
@@ -77,5 +77,7 @@
     "View": "Ver",
     "more": "más",
     "View less": "Ver menos",
-    "Find address or place": "Encontrar dirección o lugar"
+    "Find address or place": "Encontrar dirección o lugar",
+    "Letter": "Carta",
+    "Page Size": "Tamaño de página",
 }

--- a/src/GeositeFramework/plugins/launchpad/main.js
+++ b/src/GeositeFramework/plugins/launchpad/main.js
@@ -106,6 +106,10 @@ define([
                 if (config.infographic) {
                     this.addInfographicButton(config);
                 }
+
+                if ($.i18n) {
+                    $($el).localize();
+                }
             },
 
             getTemplateById: function(id) {

--- a/src/GeositeFramework/plugins/launchpad/templates.html
+++ b/src/GeositeFramework/plugins/launchpad/templates.html
@@ -10,7 +10,7 @@
         <% } %>
 
         <% if (plugins) { %>
-        <h3>Start exploring</h3>
+        <h3 class="i18n" data-i18n="Start exploring">Start exploring</h3>
         <div class="plugins">
             <ul>
             <% _.each(plugins, function(plugin) { %>
@@ -33,7 +33,7 @@
                             <p><%= plugin.description %></p>
                         <% } %>
                     </div>
-                    <button class="button launch-plugin" data-plugin-name="<%= plugin.pluginName %>">Go</button>
+                    <button class="button launch-plugin i18n" data-i18n="Go" data-plugin-name="<%= plugin.pluginName %>">Go</button>
                 </li>
             <% }); %>
             </ul>
@@ -41,7 +41,7 @@
         <% } %>
 
         <% if (scenarios) { %>
-        <h3>One-click maps</h3>
+        <h3 class="i18n" data-i18n="One-click maps">One-click maps</h3>
         <div class="scenarios">
             <ul>
             <% _.each(scenarios, function(scenario) { %>
@@ -64,7 +64,7 @@
                             <p><%= scenario.description %></p>
                         <% } %>
                     </div>
-                    <button class="button launch-scenario" data-save-code="<%= scenario.saveCode %>">Go</button>
+                    <button class="button launch-scenario i18n" data-i18n="Go" data-save-code="<%= scenario.saveCode %>">Go</button>
                 </li>
             <% }); %>
             </ul>
@@ -72,7 +72,7 @@
         <% } %>
 
         <% if (partners) { %>
-        <h3>Partners</h3>
+        <h3 class="i18n" data-i18n="Partners">Partners</h3>
         <div class="partners">
             <ul>
             <% _.each(partners, function(partner) { %>


### PR DESCRIPTION
## Overview

Fixes some translation issues and adds more translations for various parts of the framework and plugins. See commit messages for details.

Connects #1104 

### Demo

![image](https://user-images.githubusercontent.com/1042475/45571963-fbad0d80-b835-11e8-921a-20a154def575.png)

![image](https://user-images.githubusercontent.com/1042475/45571933-e1732f80-b835-11e8-9406-6fea8e2f84a6.png)

![image](https://user-images.githubusercontent.com/1042475/45571950-efc14b80-b835-11e8-9931-24af0d9410a6.png)

### Notes

- It was requested that we support translation of the tour content. However, this content is provided via a partial and can be translated directly when setting up a region. 
- Due to https://github.com/CoastalResilienceNetwork/regional-planning/issues/101, I was unable to verify that the opacity controls are now translated. I'll double-check that they are once a fix is in.

## Testing Instructions

- In addition to checking out this branch, check out https://github.com/CoastalResilienceNetwork/regional-planning/pull/102 for the regional planning plugin.
- Switch the framework language to "es" in `region.json`.
- Verify that all of the areas enumerated in the issue have been translated.