### PR TITLE
Fix typo in layer legend check

### DIFF
--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -286,7 +286,7 @@ require(['use!Geosite',
                 var serviceInfo = view.model.serviceInfos[service.id];
                 if (serviceInfo && service.visible &&
                     serviceInfo.pluginObject.showServiceLayersInLegend &&
-                    serviceInfo.visibleLayers) {
+                    service.visibleLayers) {
                     service.visibleLayers.sort(function(a, b) { return a - b; });
                     _.each(service.visibleLayers, function(layerId) {
                         var layer,


### PR DESCRIPTION
## Overview

The property exists on the `service` object, not the `serviceInfo` object.

Introduced in 37d315

Refs # https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/1110#issuecomment-422565942

### Notes

This change was originally introduced to prevent occasional errors that occurred in the plugin print identify point demo. This will be addressed and improved in #1113 

## Testing Instructions

- Open the regional planning plugin, add some layers, and ensure the legend appears with those layers listed.
