### PR TITLE
Polish plugin print workflow demo

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -638,12 +638,20 @@ require(['use!Geosite',
                     mapReadyDeferred.resolve(map);
 
                     $('#print-modal-confirm').on('click', function() {
+                        // Before moving the map, get the current center and extent
+                        var center = map.extent.getCenter();
+                        var extent = map.extent;
+
                         // Move the map from the main app area to to the sandbox where
                         // the plugin can mess with it's positioning among its other elements
                         var mapNode = $("#map-0").detach();
                         $(mapNode).appendTo($printSandbox);
-                        map.resize();
+                        map.resize(true);
                         map.reposition();
+
+                        // Ensure the map view matches the view before it was moved.
+                        map.centerAt(center);
+                        map.setExtent(extent);
 
                         // Move the legend out of the map container for easier styling
                         var legendNode = $("#legend-container-0").detach();

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -100,6 +100,8 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
             },
 
             prePrintModal: function(preModalDeferred, $printSandbox, $modalSandbox, mapObject) {
+                var self = this;
+
                 $.get('sample_plugins/identify_point/html/print-form.html', function(html) {
                     $modalSandbox.append(html);
 
@@ -107,6 +109,20 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
                     $(mapNode).appendTo('.print-preview-map-container');
                     mapObject.resize(true);
                     mapObject.reposition();
+
+                    $modalSandbox.find('#add-layer').click(function() {
+                        if (self.layer) {
+                            self.layer.setVisibility(true);
+                        } else {
+                            var layerUrl = "http://services.coastalresilience.org/arcgis/rest/services/US/Population/MapServer"
+                            self.layer = new esri.layers.ArcGISDynamicMapServiceLayer(layerUrl, {
+                                "opacity": 0.8,
+                                "visibleLayers": [1]
+                            });
+
+                            mapObject.addLayer(self.layer);
+                        }
+                    });
                 }).then(preModalDeferred.resolve());
 
                 // Append optional images to print sandbox, which are hidden by default
@@ -123,7 +139,6 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
             postPrintModal: function(postModalDeferred, $printSandbox, $modalSandbox, mapObject) {
                 var includeNorthArrow = $modalSandbox.find('#north-arrow').is(':checked');
                 var includeTncLogo = $modalSandbox.find('#tnc-logo').is(':checked');
-                var addLayer = $modalSandbox.find('#add-layer').is(':checked');
 
                 if (includeNorthArrow) {
                     $printSandbox.find('#north-arrow-img').show();
@@ -131,18 +146,6 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
 
                 if (includeTncLogo) {
                     $printSandbox.find('#logo-img').show();
-                }
-
-                if (addLayer) {
-                    if (this.layer) {
-                        this.layer.setVisibility(true);
-                    } else {
-                        this.layer = new esri.layers.ArcGISDynamicMapServiceLayer("http://sampleserver1.arcgisonline.com/ArcGIS/rest/services/Demographics/ESRI_Population_World/MapServer", {
-                            "opacity": 0.8
-                        });
-
-                        mapObject.addLayer(this.layer);
-                    }
                 }
 
                 window.setTimeout(function() {

--- a/src/GeositeFramework/sample_plugins/identify_point/print.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/print.css
@@ -53,7 +53,9 @@
 
 .print-preview-map-container #map-0.map {
     position: relative;
-    height: 325px;
+    height: 300px;
+    width: 300px;
+    margin: 10px auto;
 }
 
 .popover-section {


### PR DESCRIPTION
## Overview

Makes a few changes to ensure that the plugin print demo developed in the identify point plugin is more useful to plugin developers. These changes came out of discussions with @cschneebeck.

See commit messages for details.

Connects #1113 

### Demo

![sep-20-2018 11-52-41](https://user-images.githubusercontent.com/1042475/45830735-bc663d00-bccb-11e8-95e3-aa398f7d9237.gif)

## Testing Instructions

- Open the identify point plugin and click the print button.
- Move the print preview map to somewhere notable that you can remember.
- Add the sample layer, and ensure it shows up on the map (it's mainly along the eastern and southern coast).
- Click the print button.
- Ensure the printed map center and extent roughly matches the extent of the print preview map.