### PR TITLE
Hide map legend in demo print preview window

### DIFF
--- a/src/GeositeFramework/sample_plugins/identify_point/print.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/print.css
@@ -58,6 +58,10 @@
     margin: 10px auto;
 }
 
+.print-preview-map-container #legend-container-0 {
+    display: none !important;
+}
+
 .popover-section {
     height: 400px;
 }


### PR DESCRIPTION
## Overview

The legend is not necessary or helpful at this stage of the workflow. It
will still display on the printed document.

Connects #1113

### Demo

Before

![image](https://user-images.githubusercontent.com/1042475/45838902-e1b17600-bce0-11e8-8cda-d32e5780eddb.png)

After

![image](https://user-images.githubusercontent.com/1042475/45838921-ed04a180-bce0-11e8-8bad-1826b9e26406.png)

## Testing Instructions

- Open the identify point plugin and click the print button.
- Add the sample layer, and verify that the legend is not added to the print preview window.
- Click print, and verify that the legend is displayed on the printed document.