### PR TITLE
Print plugin demo stylesheet clean-up

### DIFF
--- a/src/GeositeFramework/css/print.css
+++ b/src/GeositeFramework/css/print.css
@@ -29,8 +29,8 @@
 
     #plugin-print-sandbox {
         visibility: visible;
-        height: 100%;
-        width: 100%;
+        height: 90%;
+        width: 90%;
     }
 
     #plugin-print-sandbox .control-container {

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -157,7 +157,7 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
                     } else {
                         postModalDeferred.resolve();
                     }
-                }, 500);
+                }, 750);
             },
 
             postPrintCleanup: function(mapObject) {

--- a/src/GeositeFramework/sample_plugins/identify_point/print.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/print.css
@@ -1,14 +1,7 @@
 ﻿@media print {
     @page { 
-        size: landscape;
+        size: portrait;
     }
-
-    #sample-graphic-print {
-        visibility: visible;
-        position: absolute;
-        top: 1710px;
-        -webkit-transform: rotate(45deg);
-    }    
 
     #legend-container-0 {
         position: absolute;
@@ -17,6 +10,7 @@
     }
 
     #map-0 {
+       margin-top: 1in;
        height: 8in;
        width: 8in;
     }
@@ -28,6 +22,7 @@
     position: absolute;
     bottom: 20px;
     right: 20px;
+    z-index: 1000;
 }
 
 #logo-img {


### PR DESCRIPTION
## Overview

Ensures the document is only one page when printed in major browsers by making the document take up 90% of the page, instead of 100%, which leaves room for margins.

Also removes some rules that were no longer applicable and makes sure the north arrow is not covered by the legend.

Connects #1010

### Demo

**Chrome**
![image](https://user-images.githubusercontent.com/1042475/45900086-ac725a00-bdac-11e8-810c-931737ae0d4e.png)

**Firefox**
![image](https://user-images.githubusercontent.com/1042475/45900075-a4b2b580-bdac-11e8-836b-506ff1b8cd52.png)

**IE**
![image](https://user-images.githubusercontent.com/1042475/45900062-9a90b700-bdac-11e8-9791-b40b73630337.png)

**Edge**
<img width="614" alt="screen shot 2018-09-21 at 2 40 46 pm" src="https://user-images.githubusercontent.com/1042475/45900035-8947aa80-bdac-11e8-9141-808397fb194a.png">

## Testing Instructions

- Activate the print process for the identify point plugin.
- Check all of the boxes in the dialog, and click print.
- Ensure the printed document is confined to one page.
- Repeat this process in Chrome, Firefox, IE, and Edge.