### PR TITLE
Validate region.json before static site generation

### DIFF
--- a/scripts/create_static.py
+++ b/scripts/create_static.py
@@ -20,12 +20,12 @@ parser.add_argument('-d',
                     action='store_true')
 args = parser.parse_args()
 
-logging.info('Compiling static assets...')
+logging.info('Attempting to compile static assets...')
 
 if args.d:
     command = ('docker-compose run --rm server -c'
                 '''"import subprocess;subprocess.call('./scripts/main.py')"''')
-    subprocess.call(command, shell=True)
+    subprocess.call(command, stderr=subprocess.STDOUT, shell=True)
 else:
     main.template_index()
 

--- a/scripts/create_static.py
+++ b/scripts/create_static.py
@@ -8,6 +8,7 @@ Usage: python ./scripts/create_static.py [OPTIONS]
 """
 
 import argparse
+import sys
 import subprocess
 import main
 import logging
@@ -23,10 +24,17 @@ args = parser.parse_args()
 logging.info('Attempting to compile static assets...')
 
 if args.d:
-    command = ('docker-compose run --rm server -c'
-                '''"import subprocess;subprocess.call('./scripts/main.py')"''')
-    subprocess.call(command, stderr=subprocess.STDOUT, shell=True)
+    command = ('docker-compose run --rm server ./scripts/main.py')
+    return_code = subprocess.call(command, stderr=subprocess.STDOUT, shell=True)
 else:
-    main.template_index()
+    command = ('./scripts/main.py')
+    return_code = subprocess.call(command, stderr=subprocess.STDOUT, shell=True)
+
+if return_code == 1:
+    logging.warn('Failed! Check that your JSON config files are properly formatted.')
+    sys.exit()
+if return_code == 2:
+    logging.warn('Failed! Check that your JSON config files match their schemas.')
+    sys.exit()
 
 logging.info('Finished compiling static assets.')

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
 import os
+import sys
 import json
 from jinja2 import Environment, FileSystemLoader
-from jsonschema import validate
+from jsonschema import validate, exceptions
 
 BASE_DIR = os.path.join('src', 'GeositeFramework')
 REGION_FILE = os.path.join(BASE_DIR, 'region.json')
@@ -16,14 +17,26 @@ def convert_json(file):
         return json.load(f)
 
 def template_index():
+    # create a jinja environment
     j2_env = Environment(loader=FileSystemLoader(''),
                          trim_blocks=True)
 
-    region_json = convert_json(REGION_FILE)
-    region_schema_json = convert_json(REGION_SCHEMA_FILE)
+    # extract json from their files
+    try:
+        region_json = convert_json(REGION_FILE)
+        region_schema_json = convert_json(REGION_SCHEMA_FILE)
+    except ValueError:
+        raise
+        sys.exit(1)
     
-    validate(region_json, region_schema_json)
+    # validate the json against their JSON schema spec
+    try:
+        validate(region_json, region_schema_json)
+    except exceptions.ValidationError:
+        raise
+        sys.exit(2)
 
+    # template HTML with validated custom JSON configs
     templated_idx = j2_env.get_template(TMPL_FILE).render(region_json)
 
     # write jinja template to disk, to be used in geosite static assets build

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -3,27 +3,33 @@
 import os
 import json
 from jinja2 import Environment, FileSystemLoader
+from jsonschema import validate
 
 BASE_DIR = os.path.join('src', 'GeositeFramework')
 REGION_FILE = os.path.join(BASE_DIR, 'region.json')
+REGION_SCHEMA_FILE = os.path.join(BASE_DIR, 'App_Data/regionSchema.json')
 TMPL_FILE = os.path.join(BASE_DIR, 'template_index.html')
 IDX_FILE = os.path.join(BASE_DIR, 'index.html')
 
-def convert_region_json():
-    with open(REGION_FILE) as f:
-        data = json.load(f)
-        return data
+def convert_json(file):
+    with open(file) as f:
+        return json.load(f)
 
 def template_index():
     j2_env = Environment(loader=FileSystemLoader(''),
                          trim_blocks=True)
-    region_json = convert_region_json()
-    templated = j2_env.get_template(TMPL_FILE).render(region_json)
+
+    region_json = convert_json(REGION_FILE)
+    region_schema_json = convert_json(REGION_SCHEMA_FILE)
+    
+    validate(region_json, region_schema_json)
+
+    templated_idx = j2_env.get_template(TMPL_FILE).render(region_json)
 
     # write jinja template to disk, to be used in geosite static assets build
     # as well as served from this project's development server
     with open(IDX_FILE, 'wb') as f:
-        f.write(templated)
+        f.write(templated_idx)
 
 if __name__ == '__main__':
     template_index()

--- a/src/GeositeFramework/requirements.txt
+++ b/src/GeositeFramework/requirements.txt
@@ -1,1 +1,2 @@
 Jinja2==2.10
+jsonschema==2.6.0


### PR DESCRIPTION
## Overview

The Geosite build process pulls in various config files including`region.json`, a plug-in JSON config, etc. to slot into the framework. JSON validation is run on said configs to verify that they are compatible before wasting time on templating, bundling, etc. All of this logic exists in C#. This PR adds JSON validation and builds on the new and growing python setup.

Connects #1089 

### Notes

Looking for inspiration in how logging is done.
Because of the use of the `subprocess` call in `create_static.py`, any errors that should occur in `main.py` aren't easily propagated up to stop the parent script. Thus, the completion logging occurs error or not when running `create_static.py` in docker. 
<img width="586" alt="screen shot 2018-09-26 at 2 07 42 pm" src="https://user-images.githubusercontent.com/10568752/46103121-0fddfc80-c19e-11e8-9abe-0804eb4dae25.png">
<img width="596" alt="screen shot 2018-09-26 at 2 08 23 pm" src="https://user-images.githubusercontent.com/10568752/46103122-0fddfc80-c19e-11e8-9c1d-1de8023d815c.png">


## Testing Instructions

Edit `region.json` to be valid and invalid. Run the create static script at each go. Also run the server and make the same changes, see console errors and the page not loading as appropriate.
- change a value to be the wrong type
>     "language": "en",
becomes
>     "language": 1,

- erroneous json formatting, i.e. drop a comma

Test locally:
`python ./scripts/create_static.py`
`python ./scripts/server.py`

Test in docker:
`python ./scripts/create_static.py -d`
`python ./scripts/server.py -d`
