### PR TITLE
 Fix plugin print if no modal is used

### DIFF
--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -600,7 +600,11 @@ require(['use!Geosite',
                     window.print();
 
                     // Close out the modal, which calls the closejs method
-                    TINY.box.hide();
+                    if ($('.tbox').is(':visible')) {
+                        TINY.box.hide();
+                    } else {
+                        printReset(map, pluginObject);
+                    }
                 });
             });
         }
@@ -617,10 +621,13 @@ require(['use!Geosite',
             // If the plugin is not set up for a print modal,
             // resolve any pending pre-print map operations
             if (!pluginObject.usePrintModal) {
-                modalConfirmDeferred.resolve();
-                postModalDeferred.resolve();
-                mapReadyDeferred.resolve();
-                return mapReadyDeferred;
+                // Wrap in a setTimeout to give the map time to update
+                // before initiating print.
+                window.setTimeout(function() {
+                    printSetup(map, pluginObject, $printSandbox, modalConfirmDeferred, postModalDeferred);
+                }, 750);
+
+                return mapReadyDeferred.resolve(map);
             }
 
             // Setup a print modal window for the user.
@@ -638,56 +645,12 @@ require(['use!Geosite',
                     mapReadyDeferred.resolve(map);
 
                     $('#print-modal-confirm').on('click', function() {
-                        // Before moving the map, get the current center and extent
-                        var center = map.extent.getCenter();
-                        var extent = map.extent;
-
-                        // Move the map from the main app area to to the sandbox where
-                        // the plugin can mess with it's positioning among its other elements
-                        var mapNode = $("#map-0").detach();
-                        $(mapNode).appendTo($printSandbox);
-                        map.resize(true);
-                        map.reposition();
-
-                        // Ensure the map view matches the view before it was moved.
-                        map.centerAt(center);
-                        map.setExtent(extent);
-
-                        // Move the legend out of the map container for easier styling
-                        var legendNode = $("#legend-container-0").detach();
-                        $(legendNode).appendTo($printSandbox);
-
-                        modalConfirmDeferred.resolve();
-
-                        // Pass the modal contents to the plugin,
-                        // so it can extract form values, etc.
-                        var $modalContent = $(this).parent().siblings('#plugin-print-modal-content');
-                        pluginObject.postPrintModal(postModalDeferred, $printSandbox, $modalContent, map);
-
-                        // Move the scalebar inside the map container so
-                        // that it stays with the map.
-                        var scalebar = $('.esriScalebar').detach();
-                        $(scalebar).appendTo('#map-0_root');
+                        printSetup(map, pluginObject, $printSandbox, modalConfirmDeferred, postModalDeferred);
                     });
                 },
 
                 closejs: function () {
-                    // Move the map and legend back to the original container
-                    var mapNode = $('#map-0').detach();
-                    var legendNode = $("#legend-container-0").detach();
-                    $('.map-container').append(mapNode);
-                    $('#map-0').append(legendNode);
-                    map.resize(true);
-
-                    // Move the scalebar back to it's original location
-                    var scalebar = $('.esriScalebar').detach();
-                    $(scalebar).appendTo('#map-0');
-
-                    // Remove print related CSS
-                    $('.base-plugin-print-css').remove();
-                    $('.plugin-print-css').remove();
-
-                    pluginObject.postPrintCleanup(map);
+                    printReset(map, pluginObject)
                 }
             });
 
@@ -717,6 +680,62 @@ require(['use!Geosite',
         function hasHelp(view) {
             var pluginObj = view.model.get('pluginObject');
             return pluginObj.hasHelp;
+        }
+
+        function printSetup(map, pluginObject, $printSandbox, modalConfirmDeferred, postModalDeferred) {
+            // Before moving the map, get the current center and extent
+            var center = map.extent.getCenter();
+            var extent = map.extent;
+
+            // Move the map from the main app area to to the sandbox where
+            // the plugin can mess with it's positioning among its other elements
+            var mapNode = $("#map-0").detach();
+            $(mapNode).appendTo($printSandbox);
+            map.resize(true);
+            map.reposition();
+
+            // Ensure the map view matches the view before it was moved.
+            map.centerAt(center);
+            map.setExtent(extent);
+
+            // Move the legend out of the map container for easier styling
+            var legendNode = $("#legend-container-0").detach();
+            $(legendNode).appendTo($printSandbox);
+
+            modalConfirmDeferred.resolve();
+
+            // Pass the modal contents to the plugin,
+            // so it can extract form values, etc.
+            var $modalContent = $(this).parent().siblings('#plugin-print-modal-content');
+            if ($modalContent.length === 0) {
+                pluginObject.postPrintModal(postModalDeferred, $printSandbox, $modalContent, map);
+            } else {
+                postModalDeferred.resolve();
+            }
+
+            // Move the scalebar inside the map container so
+            // that it stays with the map.
+            var scalebar = $('.esriScalebar').detach();
+            $(scalebar).appendTo('#map-0_root');
+        }
+
+        function printReset(map, pluginObject) {
+            // Move the map and legend back to the original container
+            var mapNode = $('#map-0').detach();
+            var legendNode = $("#legend-container-0").detach();
+            $('.map-container').append(mapNode);
+            $('#map-0').append(legendNode);
+            map.resize(true);
+
+            // Move the scalebar back to it's original location
+            var scalebar = $('.esriScalebar').detach();
+            $(scalebar).appendTo('#map-0');
+
+            // Remove print related CSS
+            $('.base-plugin-print-css').remove();
+            $('.plugin-print-css').remove();
+
+            pluginObject.postPrintCleanup(map);
         }
 
         N.views = N.views || {};

--- a/src/GeositeFramework/sample_plugins/identify_point/main.css
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.css
@@ -9,10 +9,4 @@ hr {
 
 .sample {
     float: right;
-    color: hotpink;
-    font-size: 24px;
-}
-
-.sample img {
-    display: none;
 }

--- a/src/GeositeFramework/sample_plugins/identify_point/main.js
+++ b/src/GeositeFramework/sample_plugins/identify_point/main.js
@@ -102,29 +102,6 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
             prePrintModal: function(preModalDeferred, $printSandbox, $modalSandbox, mapObject) {
                 var self = this;
 
-                $.get('sample_plugins/identify_point/html/print-form.html', function(html) {
-                    $modalSandbox.append(html);
-
-                    var mapNode = $("#map-0").detach();
-                    $(mapNode).appendTo('.print-preview-map-container');
-                    mapObject.resize(true);
-                    mapObject.reposition();
-
-                    $modalSandbox.find('#add-layer').click(function() {
-                        if (self.layer) {
-                            self.layer.setVisibility(true);
-                        } else {
-                            var layerUrl = "http://services.coastalresilience.org/arcgis/rest/services/US/Population/MapServer"
-                            self.layer = new esri.layers.ArcGISDynamicMapServiceLayer(layerUrl, {
-                                "opacity": 0.8,
-                                "visibleLayers": [1]
-                            });
-
-                            mapObject.addLayer(self.layer);
-                        }
-                    });
-                }).then(preModalDeferred.resolve());
-
                 // Append optional images to print sandbox, which are hidden by default
                 $printSandbox.append('<div class="sample"><img id="north-arrow-img" src="sample_plugins/identify_point/north-arrow.png"/></div>');
                 $printSandbox.append('<div class="sample"><img id="logo-img" src="sample_plugins/identify_point/tnc-logo.png"/></div>');
@@ -132,8 +109,34 @@ define(["dojo/_base/declare", "framework/PluginBase", "dojo/text!./template.html
                 // Zoom and center to Philadelphia, as a demonstration
                 this.initialZoom = mapObject.getZoom();
                 this.initialCenter = mapObject.extent.getCenter();
-
                 mapObject.centerAndZoom([-75.1641, 39.9562], 8)
+
+                if (self.usePrintModal) {
+                    $.get('sample_plugins/identify_point/html/print-form.html', function(html) {
+                        $modalSandbox.append(html);
+
+                        var mapNode = $("#map-0").detach();
+                        $(mapNode).appendTo('.print-preview-map-container');
+                        mapObject.resize(true);
+                        mapObject.reposition();
+
+                        $modalSandbox.find('#add-layer').click(function() {
+                            if (self.layer) {
+                                self.layer.setVisibility(true);
+                            } else {
+                                var layerUrl = "http://services.coastalresilience.org/arcgis/rest/services/US/Population/MapServer"
+                                self.layer = new esri.layers.ArcGISDynamicMapServiceLayer(layerUrl, {
+                                    "opacity": 0.8,
+                                    "visibleLayers": [1]
+                                });
+
+                                mapObject.addLayer(self.layer);
+                            }
+                        });
+                    }).then(preModalDeferred.resolve());
+                } else {
+                    preModalDeferred.resolve();
+                }
             },
 
             postPrintModal: function(postModalDeferred, $printSandbox, $modalSandbox, mapObject) {


### PR DESCRIPTION
## Overview

Previously, opting to not use the plugin print modal broke the print process. The base plugin print code was not written in a way that could accommodate no modal being used. It is reworked here to support both using a modal and not using a modal.

Connects #1114 

### Demo

![sep-26-2018 12-10-11](https://user-images.githubusercontent.com/1042475/46093596-c08bd200-c185-11e8-9f07-69ad8aac6b38.gif)

## Testing Instructions

- Activate the identify point plugin, and click the print button. 
- In the modal that appears, select some of the options, drag the map, etc, and click print.
- Verify the printed page is constructed correctly in the preview.
- Cancel the print.
- Modify [this line](https://github.com/CoastalResilienceNetwork/GeositeFramework/blob/9d540d6ea9f6effe589cd900b55e9dd94eca4f46/src/GeositeFramework/sample_plugins/identify_point/main.js#L19) so that `usePrintModal` is set to `False`.
- Refresh the page, activate the identify point plugin again, and click the print button.
- Verify that no modal appears, and that the browser print preview is shown with correctly constructed printed page.