### PR TITLE
Convert C# dropdown creation to jinja and cleanup

### DIFF
--- a/src/GeositeFramework/template_index.html
+++ b/src/GeositeFramework/template_index.html
@@ -1,70 +1,3 @@
-@{
-    Layout = null;
-}
-
-@using GeositeFramework.Models
-@model Geosite
-
-@helper OptionalLinkText(Geosite.Link link)
-{
-    if (link.Url != null)
-    {
-        <a target="_blank" href="@link.Url">@link.Text</a>
-    }
-    else
-    {
-        @link.Text
-    }
-
-}
-
-
-@helper RenderLinks(IList<Geosite.Link> links, bool showDividers = true)
-{
-    foreach (var link in links)
-    {
-        if (link != headerLinks.First() && showDividers)
-        {
-            <li class="divider"></li>
-        }
-        <li id="@link.ElementId">
-            @if (link.Popup)
-            {
-                <a class="framework-popup" href="javascript:;" data-url="@link.Url">@link.Text</a>
-            }
-            else if (link.Items != null && link.Items.Any())
-            {
-                <li class="dropdown-submenu">
-                    <a id="region-header-menu" href="#">
-                        Other Regions
-                        <i class="dropdown-icon icon-angle-right"></i>
-                    </a>
-
-                    <ul class="dropdown-menu" id="region-links">
-                        @RenderRegionLinks(link.Items)
-                    </ul>
-                </li>
-            }
-            else
-            {
-                <a target="_blank" href="@link.Url">@link.Text <i class="icon-link-ext"></i></a>
-            }
-
-        </li>
-    }
-
-}
-
-@helper RenderRegionLinks(IList<Geosite.Link> links) {
-    if (links != null) {
-        foreach (var link in links) {
-            <li id="@link.ElementId">
-                <a target="_blank" href="@link.Url">@link.Text <i class="icon-link-ext"></i></a>
-            </li>
-        }
-    }
-}
-
 <!DOCTYPE html>
 <!--[if IE 8]>          <html class="no-js lt-ie9" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!-->  <html class="no-js" lang="en"> <!--<![endif]-->
@@ -173,7 +106,7 @@
             background-color: {{ colors.secondary }};
         }
 
-        @if ({{ singlePluginMode }}) {
+        {% if singlePluginMode %}
         <text>
         .sidebar-content {
             height: 100%;
@@ -199,23 +132,22 @@
             z-index: 10000;
         }
         </text>
-        }
+        {% endif %}
     </style>
 
-    @if ({{ googleUrlShortenerApiKey }}!= null)
-    {
-        <!-- Google Analytics -->
-        <script>
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    {% if googleUrlShortenerApiKey != null %}
+    <!-- Google Analytics -->
+    <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-            ga('create', 'UA-{{ googleUrlShortenerApiKey }}', 'auto');
-            ga('send', 'pageview');
-        </script>
-        <!-- End Google Analytics -->
-    }
+        ga('create', 'UA-{{ googleUrlShortenerApiKey }}', 'auto');
+        ga('send', 'pageview');
+    </script>
+    <!-- End Google Analytics -->
+    {% endif %}
 </head>
 
 
@@ -232,14 +164,14 @@
     </form>
 
     <script type="text/template" id="template-pane">
-        @if ({{ singlePluginMode }}) {
+        {% if singlePluginMode %}
         <text>
         <div id="single-plugin-mode-help-container">
             Help
         </div>
         </text>
-        }
-        <nav class="nav-apps plugins nav-apps-narrow @({{ singlePluginMode }} ? "single-plugin-mode" : "")">
+        {% endif %}
+        <nav class="nav-apps plugins nav-apps-narrow {% if singlePluginMode %} "single-plugin-mode" {% endif %}">
             <div id="sidebar-help-area">
                 <a id="help-overlay-start" href="#" data-i18n="Tour">Tour</a>
                 <div id="sidebar-toggle">
@@ -249,11 +181,11 @@
         </nav>
         <div class="flex-expand">
             <div class="flex-container map-container">
-                @if ({{ singlePluginMode }}) {
+                {% if singlePluginMode %}
                 <div id="toggle-plugin-container" class="single-plugin-mode">
                     <span><i class="fa fa-chevron-left" aria-hidden="true"></i></span>
                 </div>
-                }
+                {% endif %}
                 <div id="map-0" class="map">
                     <div class="control-container">
                         <div class="top-tools"></div>
@@ -267,9 +199,9 @@
                                     <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="map-utils-dropdown-button">
                                         <li><a href="#" class="i18n" data-command="measure" data-i18n="Measure">Measure</a></li>
                                         <li><a href="#" class="i18n" data-command="zoom" data-i18n="Zoom to Extent">Zoom to Extent</a></li>
-                                        @if (!{{ singlePluginMode }}) {
+                                        {% if singlePluginMode %}
                                             <li><a href="#" class="i18n" data-command="export" data-i18n="Create Map">Create Map</a></li>
-                                        }
+                                        {% endif %}
                                         <li><a href="#" class="i18n" data-command="share" data-i18n="Save &amp; Share">Save &amp; Share</a></li>
                                     </ul>
                                 </div>
@@ -699,7 +631,7 @@
 
     <!-- TOP BAR, FIXED TO THE TOP OF THE SCREEN -->
     <header>
-        @if (!{{ singlePluginMode }}) {
+        {% if singlePluginMode %}
         <div class="dropdown header-dropdown nav-main-dropdown">
             <button class="button dropdown-toggle nav-main-button" type="button" id="header-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <div class="nav-main">
@@ -712,25 +644,44 @@
                 </div>
             </button>
             <ul class="dropdown-menu" aria-labelledby="header-menu">
-                @RenderLinks(headerLinks)
+                {% for headerLink in headerLinks %}
+                    <li>
+                        <a target="_blank" href="{{ headerLink.url }}">{{ headerLink.text }}<i class="icon-link-ext"></i></a>
+                    </li>
+                    <li class="divider"></li>
+                {% endfor %}
+                <li class="dropdown-submenu">
+                    <a id="region-header-menu" href="#">
+                        Other Regions
+                        <i class="dropdown-icon icon-angle-right"></i>
+                    </a>
+
+                    <ul class="dropdown-menu" id="region-links">
+                        {% for region in regionLinks %}
+                        <li id="@link.ElementId">
+                            <a target="_blank" href="{{ region.url }}">{{ region.text }} <i class="icon-link-ext"></i></a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </li>
             </ul>
         </div>
-        } else {
+        {% else %}
         <div class="nav-main">
             <div class="nav-main-title">
                 {{ titleMain.text }}
             </div>
         </div>
-        }
+        {% endif %}
         <div class="nav-region-subtitle">
-            @if (!{{ singlePluginMode }}) {
+            {% if singlePluginMode %}
                 {{ titleDetail.text }}
-            } else {
+            {% else %}
                 <text><span id="show-single-plugin-mode-help">About</span></text>
-            }
+            {% endif %}
         </div>
         <div id="search"></div>
-        @if ({{ singlePluginMode }}) {
+        {% if singlePluginMode %}
         <div class="dropdown header-dropdown nav-main-dropdown single-plugin-mode">
             <button class="button dropdown-toggle nav-main-button" type="button" id="header-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 <div class="nav-main">
@@ -740,10 +691,15 @@
                 </div>
             </button>
             <ul class="dropdown-menu" aria-labelledby="header-menu">
-                @RenderLinks(headerLinks)
+                {% for headerLink in headerLinks %}
+                    <li>
+                        <a target="_blank" href="{{ headerLink.url }}">{{ headerLink.text }}<i class="icon-link-ext"></i></a>
+                    </li>
+                    <li class="divider"></li>
+                {% endfor %}
             </ul>
         </div>
-        }
+        {% endif %}
     </header>
 
     @Html.Partial("TourInfo")
@@ -855,11 +811,11 @@
     <script src="js/HelpOverlay.js"></script>
     <script src="js/BasemapSelector.js"></script>
     <script src="js/SidebarToggle.js"></script>
-    @if ({{ singlePluginMode }}) {
+    {% if singlePluginMode %}
     <text>
         <script src="js/SinglePluginModeHelp.js"></script>
     </text>
-    }
+    {% endif %}
     <script src="js/TimeoutWrapper.js"></script>
     <script src="js/Identify.js"></script>
     <script src="js/Map.js"></script>


### PR DESCRIPTION
## Overview

Continue converting templating of what was `index.html` (now `template_index.html`). This PR converts dropdown creation and also cleans up the file's jinja2 formatting generally. Getting closer! The icons (known issue bringing in font files #1100 #1108)

Connects #1084 

### Demo

<img width="548" alt="screen shot 2018-09-28 at 1 14 09 pm" src="https://user-images.githubusercontent.com/10568752/46223188-a89c8580-c320-11e8-909a-0957acebe8ca.png">

All the links work too 🎉 

## Testing Instructions

`python ./scripts/server.py` or & `-d`
Add/remove the singlePluginMode section from `region.json` and refresh the page. See that the site changes.

