### PR TITLE
Template in HTML partials

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import codecs
 import sys
 import plugin_loader
 from jinja2 import Environment, FileSystemLoader
@@ -12,6 +13,7 @@ REGION_SCHEMA_FILE = os.path.join(BASE_DIR, 'App_Data/regionSchema.json')
 TMPL_FILE = os.path.join(BASE_DIR, 'template_index.html')
 IDX_FILE = os.path.join(BASE_DIR, 'index.html')
 
+PARTIALS_DIR= os.path.join(BASE_DIR, 'Views/Shared')
 
 def template_index():
     # create a jinja environment
@@ -58,6 +60,12 @@ def template_index():
         print(plugin_config_data, plugin_folder_names, plugin_module_names)
     except ValueError as e:
         sys.exit(e)
+
+    # rewrite partials in charset utf-8 for Jinja2 compatibility
+    for file in os.listdir(PARTIALS_DIR):
+        filename = os.path.join(PARTIALS_DIR, file)
+        s = codecs.open(filename, mode='r', encoding='utf-8-sig').read()
+        codecs.open(filename, mode='w', encoding='utf-8').write(s)
 
     # template HTML with validated custom JSON configs
     templated_idx = j2_env.get_template(TMPL_FILE).render(region_json)

--- a/src/GeositeFramework/Views/Shared/CustomLaunchPadContent.cshtml
+++ b/src/GeositeFramework/Views/Shared/CustomLaunchPadContent.cshtml
@@ -1,4 +1,4 @@
-﻿<h2>Custom Launchpad</h2>
+<h2>Custom Launchpad</h2>
 <div>
     This shows how it is possible to include custom launchpad markup.
 </div>

--- a/src/GeositeFramework/Views/Shared/TourInfo.cshtml
+++ b/src/GeositeFramework/Views/Shared/TourInfo.cshtml
@@ -1,4 +1,4 @@
-﻿<ul id="tlyPageGuide">
+<ul id="tlyPageGuide">
     <li class="tlypageguide_right" data-tourtarget=".name">
         <div>
 			These are links that will take you to the Coastal Resilience website for more project background.

--- a/src/GeositeFramework/template_index.html
+++ b/src/GeositeFramework/template_index.html
@@ -702,16 +702,16 @@
         {% endif %}
     </header>
 
-    @Html.Partial("TourInfo")
+   {% include "src/GeositeFramework/Views/Shared/TourInfo.cshtml" %}
 
     <!-- If a view is provided (overwritten via the region repo), a user can
         change the region setting `launchpad.html = true` to use this content -->
     <div id="custom-launchpad-content" style="display:none;">
-        @Html.Partial("CustomLaunchpadContent")
+        {% include "src/GeositeFramework/Views/Shared/CustomLaunchPadContent.cshtml" %}
     </div>
 
     <div id="single-plugin-mode-help-content" style="display:none;">
-        @Html.Partial("SinglePluginModeHelp")
+        {% include "src/GeositeFramework/Views/Shared/SinglePluginModeHelp.cshtml" %}
     </div>
 
     <!-- Area for plugins to arrange their markup independent

--- a/src/GeositeFramework/template_index.html
+++ b/src/GeositeFramework/template_index.html
@@ -171,7 +171,7 @@
         </div>
         </text>
         {% endif %}
-        <nav class="nav-apps plugins nav-apps-narrow {% if singlePluginMode %} "single-plugin-mode" {% endif %}">
+        <nav class="nav-apps plugins nav-apps-narrow {% if singlePluginMode %}single-plugin-mode{% endif %}">
             <div id="sidebar-help-area">
                 <a id="help-overlay-start" href="#" data-i18n="Tour">Tour</a>
                 <div id="sidebar-toggle">


### PR DESCRIPTION
## Overview

Inject the HTML partials into the HTML that comprise other parts of the app conditionally. They were previously brought into the app by C# templating and now are being injected via jinja.

Connects #1087 

### Demo

<img width="877" alt="screen shot 2018-10-01 at 2 21 07 pm" src="https://user-images.githubusercontent.com/10568752/46307577-498b7a80-c585-11e8-8cee-fbca7118b21b.png">

The last 3 elements in the console are injected partials. In CSS the all default to `display: none` hence not seeing them on the browser.

### Notes

I resaved the partials as `utf-8` because jinja requires that templates be this charset and cant parse special unicode chars that come along with other formats.

I didn't move the `.cshtml` files as specified by the issue. All of the C# refs will eventually be torn out of the app and all static site work is on a feature branch, so I'm wondering if I should rather forgo that recommendation and reorganize all the partials. Am I missing something that would prevent me from doing so?

## Testing Instructions

Serve the project.
