### PR TITLE
Migrate plugin assembly and validation

### DIFF
--- a/scripts/create_static.py
+++ b/scripts/create_static.py
@@ -10,7 +10,6 @@ Usage: python ./scripts/create_static.py [OPTIONS]
 import argparse
 import sys
 import subprocess
-import main
 import logging
 
 logging.basicConfig(level=logging.INFO)
@@ -25,16 +24,20 @@ logging.info('Attempting to compile static assets...')
 
 if args.d:
     command = ('docker-compose run --rm server ./scripts/main.py')
-    return_code = subprocess.call(command, stderr=subprocess.STDOUT, shell=True)
+    return_code = subprocess.call(command, stderr=subprocess.STDOUT,
+                                  shell=True)
 else:
     command = ('./scripts/main.py')
-    return_code = subprocess.call(command, stderr=subprocess.STDOUT, shell=True)
+    return_code = subprocess.call(command, stderr=subprocess.STDOUT,
+                                  shell=True)
 
 if return_code == 1:
-    logging.warn('Failed! Check that your JSON config files are properly formatted.')
+    msg = 'Failed! Check that your JSON config files are properly formatted.'
+    logging.warn(msg)
     sys.exit()
 if return_code == 2:
-    logging.warn('Failed! Check that your JSON config files match their schemas.')
+    msg = 'Failed! Check that your JSON config files match their schemas.'
+    logging.warn(msg)
     sys.exit()
 
 logging.info('Finished compiling static assets.')

--- a/scripts/create_static.py
+++ b/scripts/create_static.py
@@ -24,20 +24,15 @@ logging.info('Attempting to compile static assets...')
 
 if args.d:
     command = ('docker-compose run --rm server ./scripts/main.py')
-    return_code = subprocess.call(command, stderr=subprocess.STDOUT,
-                                  shell=True)
+    return_value = subprocess.call(command, stderr=subprocess.STDOUT,
+                                   shell=True)
 else:
     command = ('./scripts/main.py')
-    return_code = subprocess.call(command, stderr=subprocess.STDOUT,
-                                  shell=True)
+    return_value = subprocess.call(command, stderr=subprocess.STDOUT,
+                                   shell=True)
 
-if return_code == 1:
-    msg = 'Failed! Check that your JSON config files are properly formatted.'
-    logging.warn(msg)
-    sys.exit()
-if return_code == 2:
-    msg = 'Failed! Check that your JSON config files match their schemas.'
-    logging.warn(msg)
+if return_value != 0:
+    logging.error('Exiting before compiling static assets.')
     sys.exit()
 
 logging.info('Finished compiling static assets.')

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -2,20 +2,14 @@
 
 import os
 import sys
-import json
 from jinja2 import Environment, FileSystemLoader
 from jsonschema import validate, exceptions
+from script_helpers import to_json, BASE_DIR
 
-BASE_DIR = os.path.join('src', 'GeositeFramework')
 REGION_FILE = os.path.join(BASE_DIR, 'region.json')
 REGION_SCHEMA_FILE = os.path.join(BASE_DIR, 'App_Data/regionSchema.json')
 TMPL_FILE = os.path.join(BASE_DIR, 'template_index.html')
 IDX_FILE = os.path.join(BASE_DIR, 'index.html')
-
-
-def convert_json(file):
-    with open(file) as f:
-        return json.load(f)
 
 
 def template_index():
@@ -25,8 +19,8 @@ def template_index():
 
     # extract json from their files
     try:
-        region_json = convert_json(REGION_FILE)
-        region_schema_json = convert_json(REGION_SCHEMA_FILE)
+        region_json = to_json(REGION_FILE)
+        region_schema_json = to_json(REGION_SCHEMA_FILE)
     except ValueError as e:
         msg = 'Failed! Check that your region.json ' \
               'config file is properly formatted. {}'.format(e)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -27,16 +27,18 @@ def template_index():
     try:
         region_json = convert_json(REGION_FILE)
         region_schema_json = convert_json(REGION_SCHEMA_FILE)
-    except ValueError:
-        raise
-        sys.exit(1)
+    except ValueError as e:
+        msg = 'Failed! Check that your region.json ' \
+              'config file is properly formatted. {}'.format(e)
+        sys.exit(msg)
 
     # validate the json against their JSON schema spec
     try:
         validate(region_json, region_schema_json)
-    except exceptions.ValidationError:
-        raise
-        sys.exit(2)
+    except exceptions.ValidationError as e:
+        msg = 'Failed! Check that your region.json ' \
+              'config file matches the schema. {}'.format(e.message)
+        sys.exit(msg)
 
     # template HTML with validated custom JSON configs
     templated_idx = j2_env.get_template(TMPL_FILE).render(region_json)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -12,9 +12,11 @@ REGION_SCHEMA_FILE = os.path.join(BASE_DIR, 'App_Data/regionSchema.json')
 TMPL_FILE = os.path.join(BASE_DIR, 'template_index.html')
 IDX_FILE = os.path.join(BASE_DIR, 'index.html')
 
+
 def convert_json(file):
     with open(file) as f:
         return json.load(f)
+
 
 def template_index():
     # create a jinja environment
@@ -28,7 +30,7 @@ def template_index():
     except ValueError:
         raise
         sys.exit(1)
-    
+
     # validate the json against their JSON schema spec
     try:
         validate(region_json, region_schema_json)
@@ -43,6 +45,7 @@ def template_index():
     # as well as served from this project's development server
     with open(IDX_FILE, 'wb') as f:
         f.write(templated_idx)
+
 
 if __name__ == '__main__':
     template_index()

--- a/scripts/plugin_loader.py
+++ b/scripts/plugin_loader.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+
+import os
+import sys
+from jsonschema import validate, exceptions
+from script_helpers import to_json, BASE_DIR
+
+
+PLUGIN_SCHEMA_FILE = os.path.join(BASE_DIR, 'App_Data/pluginSchema.json')
+
+
+def get_plugin_folder_path(basePath, pluginPath):
+    """Return pluginPath relative to basePath.
+    For example, if basePath is "~/www" and pluginPath is "~/www/plugins/xyz"
+    then return "plugins/xyz".
+    """
+    return pluginPath.replace(basePath, "").replace("\\", "/")
+
+
+def get_plugin_module_name(basePath, pluginPath):
+    """Convert pluginPath to relative module path.
+    For example, if basePath is "~/www" and pluginPath is "~/www/plugins/xyz"
+    then return "tnc/plugins/xyz/main". Assuming "tnc" prefix is a package
+    configured to point to your basePath.
+    """
+    return "tnc/{}/main".format(get_plugin_folder_path(basePath, pluginPath))
+
+
+def strip_plugin_module(pluginModule):
+    """Given a module name like "tnc/plugins/layer_selector/main"
+    return "layer_selector".
+    """
+    result = pluginModule.replace("tnc/", "") \
+                         .replace("/main", "") \
+                         .split("/")[-1]
+
+    return result
+
+
+def sort_plugin_names(pluginNames, keyFunc):
+    """Sort pluginNames by specified keyFunc.
+    Items for which keyFunc returns -1 (not found) will be sorted
+    towards the end of the list in no particular order.
+    """
+    return sorted(pluginNames, key=keyFunc)
+
+
+def get_plugin_directories(regionData, basePath):
+    """Return pluginFolders array from region.json.
+    Default value is ["plugins"]
+    """
+    pluginFolders = ["plugins"]
+
+    if ("pluginFolders" in regionData):
+        pluginFolders = regionData["pluginFolders"]
+
+    return map(lambda p: os.path.join(basePath, p), pluginFolders)
+
+
+def verify_directories_exist(dirs):
+    """Throw exception if folder does not exist."""
+    for path in dirs:
+        if not os.path.exists(path):
+            raise ValueError("{} does not exist".format(path))
+
+
+def get_plugin_configuration_data(plugin_folder_paths):
+    plugin_json_filename = "plugin.json"
+    plugin_config_data = []
+
+    for path in plugin_folder_paths:
+        if not os.path.exists(os.path.join(path, "main.js")):
+            msg = "Missing 'main.js' file in plugin folder: {}".format(path)
+            sys.exit(msg)
+
+        # Get plugin.json data if present
+        plugin_json_path = os.path.join(path, plugin_json_filename)
+        if os.path.exists(plugin_json_path):
+
+            # extract json from their files
+            try:
+                plugin_json = to_json(plugin_json_path)
+                plugin_schema_json = to_json(PLUGIN_SCHEMA_FILE)
+            except ValueError as e:
+                msg = 'Failed! Check that the plugin JSON ' \
+                      'config file located at {} is properly ' \
+                      'formatted. {}'.format(plugin_json_path, e)
+                sys.exit(msg)
+
+            # validate the json against their JSON schema spec
+            try:
+                validate(plugin_json, plugin_schema_json)
+            except exceptions.ValidationError as e:
+                msg = 'Failed! Check that the plugin JSON ' \
+                      'config file located at {} matches the ' \
+                      'required schema. {}'.format(plugin_json_path, e.message)
+                sys.exit(msg)
+
+            plugin_config_data.append(plugin_json)
+
+        # Generate plugin module names for use in JS code
+    return plugin_config_data

--- a/scripts/py_server.py
+++ b/scripts/py_server.py
@@ -11,10 +11,12 @@ PATH_TO_PROJECT = 'src/GeositeFramework/'
 
 logging.basicConfig(level=logging.INFO)
 
+
 class CustomRootHTTPServer(HTTPServer):
     def __init__(self, base_path, *args, **kwargs):
         HTTPServer.__init__(self, *args, **kwargs)
         self.RequestHandlerClass.base_path = base_path
+
 
 class CustomRootHTTPRequestHandler(SimpleHTTPRequestHandler):
     def translate_path(self, path):
@@ -25,15 +27,18 @@ class CustomRootHTTPRequestHandler(SimpleHTTPRequestHandler):
             modified_path = os.path.join(modified_path, word)
         return modified_path
 
-    def do_GET(self):     
-        main.template_index() ## create template files    
+    def do_GET(self):
+        main.template_index()  # create template files
 
         return SimpleHTTPRequestHandler.do_GET(self)
 
+
 def serve():
-    server = CustomRootHTTPServer(PATH_TO_PROJECT, ('', PORT), CustomRootHTTPRequestHandler)
+    server = CustomRootHTTPServer(PATH_TO_PROJECT, ('', PORT),
+                                  CustomRootHTTPRequestHandler)
     logging.info('Now serving on http://localhost:%s' % PORT)
     server.serve_forever()
+
 
 if __name__ == '__main__':
     serve()

--- a/scripts/script_helpers.py
+++ b/scripts/script_helpers.py
@@ -1,0 +1,10 @@
+import os
+import json
+
+BASE_DIR = os.path.join('src', 'GeositeFramework')
+
+
+def to_json(file):
+    """Opens a JSON file and converts it to JSON"""
+    with open(file) as f:
+        return json.load(f)

--- a/scripts/server.py
+++ b/scripts/server.py
@@ -11,8 +11,10 @@ import subprocess
 import py_server
 import signal
 
+
 def handler(signum, frame):
     subprocess.call('docker-compose stop server', shell=True)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -24,6 +26,7 @@ if __name__ == '__main__':
     if args.d:
         subprocess.call('docker-compose -f docker-compose.yml up',
                         shell=True)
-        signal.signal(signal.SIGINT, handler) # kill docker container when script is stopped
+        # kill docker container when script is stopped
+        signal.signal(signal.SIGINT, handler)
     else:
         py_server.serve()

--- a/scripts/update.py
+++ b/scripts/update.py
@@ -13,7 +13,8 @@ logging.basicConfig(level=logging.INFO)
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-d',
-                    help='Update dependencies within the python docker container.',
+                    help='Update dependencies within ' +
+                         'the python docker container.',
                     action='store_true')
 args = parser.parse_args()
 

--- a/src/GeositeFramework/plugins/launchpad/plugin.json
+++ b/src/GeositeFramework/plugins/launchpad/plugin.json
@@ -1,6 +1,6 @@
 {
     "css": [
-        "plugins/launchpad/style.css",
+        "plugins/launchpad/style.css"
     ],
     "use": {}
 }

--- a/src/GeositeFramework/sample_plugins/identify_point/plugin.json
+++ b/src/GeositeFramework/sample_plugins/identify_point/plugin.json
@@ -1,6 +1,6 @@
 {
     "css": [
-        "sample_plugins/identify_point/main.css",
+        "sample_plugins/identify_point/main.css"
     ],
     "use": { }
 }


### PR DESCRIPTION
## Overview

Migrates the C# code responsible for assembling the instance plugins, validating their contents, and setting them up for use in the instance. A lot of the code is a direct port of the C# code. Some refactoring is also done along the way.

See commit messages for details.

Connects #1090 

### Demo

*Currently plugin data is printed to the log*
```
INFO:root:Attempting to compile static assets...
([{u'css': [u'plugins/subregion_toggle/subregion-toggle.css']}, {u'use': {}, u'css': [u'plugins/launchpad/style.css']}, {u'use': {}, u'css': [u'sample_plugins/identify_point/main.css']}], [u'/plugins/subregion_toggle', u'/plugins/launchpad', u'/sample_plugins/identify_point'], ['tnc//plugins/subregion_toggle/main', 'tnc//plugins/launchpad/main', 'tnc//sample_plugins/identify_point/main'])
INFO:root:Finished compiling static assets.
```

*When a plugin has malformed configuration data*
```
INFO:root:Attempting to compile static assets...
Failed! Check that the plugin JSON config file located at /Users/ccesari/projects/GeositeFramework/src/GeositeFramework/sample_plugins/identify_point/plugin.json is properly formatted.
WARNING:root:1
```

*When a plugin has configuration data that doesn't match the schema*
```
INFO:root:Attempting to compile static assets...
Failed! Check that the plugin JSON config file located at /Users/ccesari/projects/GeositeFramework/src/GeositeFramework/sample_plugins/identify_point/plugin.json matches the required schema.
WARNING:root:1
```

*When a plugin folder is missing main.js*
```
INFO:root:Attempting to compile static assets...
Missing 'main.js' file in plugin folder: /Users/ccesari/projects/GeositeFramework/src/GeositeFramework/plugins/launchpad
WARNING:root:1
```

## Testing Instructions

- Try to reproduce the various scenarios outlined in the demo section above, both running `./scripts/create_static.py` locally and on Docker. Ensure the correct error messages shown.
