### PR TITLE
Migrate internationalization to static site

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,18 +1,59 @@
 #!/usr/bin/env python
 
 import os
+import re
 import codecs
 import sys
 import plugin_loader
 from jinja2 import Environment, FileSystemLoader
 from jsonschema import validate, exceptions
-from script_helpers import to_json, BASE_DIR
+from script_helpers import (to_json,
+                            BASE_DIR,
+                            REGION_FILE,
+                            extract_filepaths_from_dirs)
 
-REGION_FILE = os.path.join(BASE_DIR, 'region.json')
 REGION_SCHEMA_FILE = os.path.join(BASE_DIR, 'App_Data/regionSchema.json')
 TMPL_FILE = os.path.join(BASE_DIR, 'template_index.html')
 IDX_FILE = os.path.join(BASE_DIR, 'index.html')
 PARTIALS_DIR = os.path.join(BASE_DIR, 'Views/Shared')
+
+
+def prepare_languages():
+    # get app-wide translation files
+    try:
+        language_dir = os.path.join(BASE_DIR, 'locales')
+        plugin_loader.verify_directories_exist([language_dir])
+        app_json_files = [os.path.join(language_dir, file) for file in
+                          os.listdir(language_dir) if file.endswith('.json')]
+    except ValueError as e:
+        msg = 'Failed! Check the app has JSON translation files. {}'.format(e)
+        sys.exit(msg)
+
+    # get plug-ins' translation files
+    plugin_folder_paths = plugin_loader.get_plugin_folder_paths()
+    plugin_locales = [str(path+'/locales') for path in plugin_folder_paths
+                      if os.path.exists(path+'/locales')]
+    plugin_json_files = extract_filepaths_from_dirs(plugin_locales)
+
+    # merge app and plugin translation dicts keyed to language code
+    # prefer app dict translations, if conflict
+    # final format:
+    # {
+    #   "es": {
+    #       "Start": "Comience",
+    #   }
+    # }
+    all_json_files = plugin_json_files + app_json_files
+    translations = {}
+
+    for file in all_json_files:
+        language = re.search(r'locales\/(.*?)\.json', file).group(1)
+        if language in translations:
+            translations[language].update(to_json(file))
+        else:
+            translations.update({language: to_json(file)})
+
+    return translations
 
 
 def template_index():
@@ -41,11 +82,7 @@ def template_index():
     try:
         base_path = os.path.join(os.path.dirname(
                         os.path.dirname(os.path.realpath(__file__))), BASE_DIR)
-        plugin_directories = plugin_loader.get_plugin_directories(region_json,
-                                                                  base_path)
-        plugin_loader.verify_directories_exist(plugin_directories)
-        plugin_folder_paths = [d + '/' + r for d in plugin_directories
-                               for r in os.listdir(d)]
+        plugin_folder_paths = plugin_loader.get_plugin_folder_paths(custom_base_path=base_path)
 
         # Generate plugin config data, folder names, and module names for use
         # in JS code
@@ -70,6 +107,11 @@ def template_index():
                 plugin_loader.merge_plugin_config_data(plugin_config_data))
     except ValueError as e:
         sys.exit(e)
+
+    translations = prepare_languages()
+
+    # TODO: Remove print statement. For testing only.
+    print(translations)
 
     # rewrite partials in charset utf-8 for Jinja2 compatibility
     for file in os.listdir(PARTIALS_DIR):

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -24,16 +24,22 @@ def prepare_languages():
     try:
         language_dir = os.path.join(BASE_DIR, 'locales')
         plugin_loader.verify_directories_exist([language_dir])
-        app_json_files = [os.path.join(language_dir, file) for file in
-                          os.listdir(language_dir) if file.endswith('.json')]
+        app_json_files = [os.path.join(language_dir, f) for f in
+                          os.listdir(language_dir) if f.endswith('.json')]
     except ValueError as e:
         msg = 'Failed! Check the app has JSON translation files. {}'.format(e)
         sys.exit(msg)
 
     # get plug-ins' translation files
     plugin_folder_paths = plugin_loader.get_plugin_folder_paths()
-    plugin_locales = [str(path+'/locales') for path in plugin_folder_paths
-                      if os.path.exists(path+'/locales')]
+    plugin_locales = []
+    for path in plugin_folder_paths:
+        try:
+            locale_dir = os.path.join(str(path),'locales')
+            plugin_locales.append(locale_dir)
+        except:
+            continue
+
     plugin_json_files = extract_filepaths_from_dirs(plugin_locales)
 
     # merge app and plugin translation dicts keyed to language code
@@ -41,12 +47,12 @@ def prepare_languages():
     all_json_files = plugin_json_files + app_json_files
     translations = {}
 
-    for file in all_json_files:
-        language = re.search(r'locales\/(.*?)\.json', file).group(1)
+    for f in all_json_files:
+        language = re.search(r'locales\/(.*?)\.json', f).group(1)
         if language in translations:
-            translations[language].update(to_json(file))
+            translations[language].update(to_json(f))
         else:
-            translations.update({language: to_json(file)})
+            translations.update({language: to_json(f)})
     
     # split languages to their own files
     lang_dir = os.path.join(BASE_DIR, 'languages')
@@ -86,7 +92,7 @@ def template_index():
     try:
         base_path = os.path.join(os.path.dirname(
                         os.path.dirname(os.path.realpath(__file__))), BASE_DIR)
-        plugin_folder_paths = plugin_loader.get_plugin_folder_paths(custom_base_path=base_path)
+        plugin_folder_paths = plugin_loader.get_plugin_folder_paths(base_path)
 
         # Generate plugin config data, folder names, and module names for use
         # in JS code
@@ -115,8 +121,8 @@ def template_index():
     prepare_languages()
 
     # rewrite partials in charset utf-8 for Jinja2 compatibility
-    for file in os.listdir(PARTIALS_DIR):
-        filename = os.path.join(PARTIALS_DIR, file)
+    for f in os.listdir(PARTIALS_DIR):
+        filename = os.path.join(PARTIALS_DIR, f)
         s = codecs.open(filename, mode='r', encoding='utf-8-sig').read()
         codecs.open(filename, mode='w', encoding='utf-8').write(s)
 

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -5,6 +5,7 @@ import re
 import codecs
 import sys
 import plugin_loader
+import json
 from jinja2 import Environment, FileSystemLoader
 from jsonschema import validate, exceptions
 from script_helpers import (to_json,
@@ -37,12 +38,6 @@ def prepare_languages():
 
     # merge app and plugin translation dicts keyed to language code
     # prefer app dict translations, if conflict
-    # final format:
-    # {
-    #   "es": {
-    #       "Start": "Comience",
-    #   }
-    # }
     all_json_files = plugin_json_files + app_json_files
     translations = {}
 
@@ -52,9 +47,18 @@ def prepare_languages():
             translations[language].update(to_json(file))
         else:
             translations.update({language: to_json(file)})
+    
+    # split languages to their own files
+    lang_dir = os.path.join(BASE_DIR, 'languages')
+    languages = translations.keys()
 
-    return translations
-
+    # write files to languages directory for i18next to consume
+    if not os.path.exists(lang_dir):
+        os.makedirs(lang_dir)
+    for lang in languages:
+        filename = os.path.join(lang_dir, lang)
+        data = json.dumps(translations[lang], ensure_ascii=False)
+        codecs.open(filename, mode='w', encoding='utf-8').write(data)
 
 def template_index():
     # create a jinja environment
@@ -108,10 +112,7 @@ def template_index():
     except ValueError as e:
         sys.exit(e)
 
-    translations = prepare_languages()
-
-    # TODO: Remove print statement. For testing only.
-    print(translations)
+    prepare_languages()
 
     # rewrite partials in charset utf-8 for Jinja2 compatibility
     for file in os.listdir(PARTIALS_DIR):

--- a/scripts/plugin_loader.py
+++ b/scripts/plugin_loader.py
@@ -3,8 +3,7 @@
 import os
 import sys
 from jsonschema import validate, exceptions
-from script_helpers import to_json, BASE_DIR
-
+from script_helpers import to_json, BASE_DIR, REGION_FILE
 
 PLUGIN_SCHEMA_FILE = os.path.join(BASE_DIR, 'App_Data/pluginSchema.json')
 
@@ -62,6 +61,19 @@ def verify_directories_exist(dirs):
     for path in dirs:
         if not os.path.exists(path):
             raise ValueError("{} does not exist".format(path))
+
+
+def get_plugin_folder_paths(**kwargs):
+    """Returns paths to all plugin directories.
+
+    Options: `custom_base_path`
+    """
+    base_path = kwargs.get('custom_base_path', BASE_DIR)
+    region_json = to_json(REGION_FILE)
+    plugin_directories = get_plugin_directories(region_json,
+                                                base_path)
+    verify_directories_exist(plugin_directories)
+    return [d + '/' + r for d in plugin_directories for r in os.listdir(d)]
 
 
 def get_plugin_configuration_data(plugin_folder_paths):

--- a/scripts/plugin_loader.py
+++ b/scripts/plugin_loader.py
@@ -63,12 +63,11 @@ def verify_directories_exist(dirs):
             raise ValueError("{} does not exist".format(path))
 
 
-def get_plugin_folder_paths(**kwargs):
+def get_plugin_folder_paths(base_path=BASE_DIR):
     """Returns paths to all plugin directories.
 
-    Options: `custom_base_path`
+    Accepts a custom base path.
     """
-    base_path = kwargs.get('custom_base_path', BASE_DIR)
     region_json = to_json(REGION_FILE)
     plugin_directories = get_plugin_directories(region_json,
                                                 base_path)

--- a/scripts/script_helpers.py
+++ b/scripts/script_helpers.py
@@ -2,9 +2,20 @@ import os
 import json
 
 BASE_DIR = os.path.join('src', 'GeositeFramework')
+REGION_FILE = os.path.join(BASE_DIR, 'region.json')
 
 
 def to_json(file):
     """Opens a JSON file and converts it to JSON"""
     with open(file) as f:
         return json.load(f)
+
+
+def extract_filepaths_from_dirs(directory_list):
+    """Returns the full paths of all files in a list of directories"""
+    f = []
+    for dir in directory_list:
+        f.append([os.path.join(dir, file)
+                  for (path, dirs, files) in os.walk(dir)
+                  for file in files])
+    return f[0]


### PR DESCRIPTION
## Overview

The Framework can be internationalized by providing translation dictionaries for plugins, core and then specifying what language in `region.json`. This PR ports that ability from the C# site to the static site -- this amounts really to compiling the translation dicts across the various folders using python. We are able to use the already implemented `i18next ` library to template in the values-- it automagically just works behind the scenes. TNC developers won't have to make any updates for translations to work.

Connects #1088 

### Demo

<img width="834" alt="screen shot 2018-10-08 at 2 00 13 pm" src="https://user-images.githubusercontent.com/10568752/46626230-aa2a3280-cb04-11e8-8495-5c481ca79af9.png">

Using spanish.

### Notes

There are some known translation fails that were fixed in https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/1109 and https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/1112 . These fixes are on develop.

Some instances of English ("Zoom to Extent") are also because there is no provided translation.

## Testing Instructions

- Serve the static site. 
- ** Ensure there are no (javascript) errors in the console for the map and text to load. If you have any custom plugins downloaded for testing that are erroring, you may want to just delete them.
- The site should be in english

- Change the language in `region.json` to Spanish `es` instead of English (`en`).
- Refresh the web page
- See that translations (as far as they exist).