### PR TITLE
Single plugin mode mobile style fixes

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -1485,6 +1485,16 @@ header .nav-main {
 .esriSimpleSlider.subregion-active {
     top: 110px;
 }
+@media (max-width: 600px) {
+    .content .map .esriScalebar {
+        bottom: 60px;
+    }
+}
+@media (max-width: 360px) {
+    .content .map .esriScalebar {
+        bottom: 80px;
+    }
+}
 .content .map .basemap-selector {
     color: #444;
     position: absolute;

--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -997,7 +997,6 @@ header .nav-main {
 .header-dropdown.single-plugin-mode {
     position: absolute;
     right: 0;
-    top: 0;
     z-index: 10000;
 }
 .header-dropdown.dropdown>button {
@@ -2203,6 +2202,16 @@ body.x-body {
         width: 100vw !important;
     }
 
+    .arcgisSearch.searchExpanded .searchBtn {
+        margin-right: 2px;
+    }
+
+    .arcgisSearch .searchBtn {
+        padding: 8px 4px 6px 4px;
+        height: 25px;
+        width: 38px;
+    }
+
     @media (orientation: portrait) {
         #single-plugin-toggle-footer {
             height: 8vh;
@@ -2239,7 +2248,7 @@ body.x-body {
 
     #search {
         position: fixed !important;
-        right: 10vw !important;
+        right: 11.5vw !important;
     }
 
     .searchBtn {
@@ -2259,11 +2268,13 @@ body.x-body {
 
     .nav-main-dropdown {
         position: fixed !important;
-        right: 2vw !important;
+        right: 0vw !important;
     }
 
     .nav-region-subtitle {
-        right: 22vw;
+        position: fixed;
+        right: 24vw;
+        padding: 15px 7px 14px 7px;
     }
 
     .nav-main {
@@ -2276,5 +2287,9 @@ body.x-body {
         width: 60vw;
         text-overflow: ellipsis;
         overflow: hidden;
+    }
+
+    .single-plugin-mode .dropdown-icon-container {
+        padding: 5px 11px 0 0;
     }
 }


### PR DESCRIPTION
## Overview

Improves the single plugin mode header button clickability as well as scale bar and attribution overlapping.

Connects #1136 

### Demo

**Single plugin mobile button**

Yellow borders are for comparison purposes and represent the tap target size.

*Before*

![image](https://user-images.githubusercontent.com/1042475/47173505-3c3bf300-d2dc-11e8-95a7-966b876e3d5f.png)

*After*

![image](https://user-images.githubusercontent.com/1042475/47173595-74dbcc80-d2dc-11e8-8590-392004d2919b.png)

**Scalebar and attribution collision**

*Before*

![image](https://user-images.githubusercontent.com/1042475/47173496-37773f00-d2dc-11e8-9a72-b770b844bef8.png)

*After*

![image](https://user-images.githubusercontent.com/1042475/47173628-9046d780-d2dc-11e8-9944-08846fba42cd.png)

## Testing Instructions

- Edit the region.json file and turn on single plugin mode.
- Visit the site on your mobile device.
- Ensure the header buttons are easily clickable.
- Ensure that the scalebar and attribution don't overlap.