### PR TITLE
Install pip requirements into user directory

### DIFF
--- a/scripts/update.py
+++ b/scripts/update.py
@@ -22,5 +22,6 @@ logging.info('Updating python dependencies...')
 if args.d:
     subprocess.call('docker-compose build', shell=True)
 else:
-    subprocess.call('pip install -r src/GeositeFramework/requirements.txt',
+    subprocess.call('pip install --user '
+                    '-r src/GeositeFramework/requirements.txt',
                     shell=True)


### PR DESCRIPTION
## Overview

By default, pip installs libraries into a system directory, which can result in permissions issues. Installing them with the --user argument should allow most users running the framework on their host to install the framework requirements.

Connects to https://github.com/CoastalResilienceNetwork/geosite-framework-build/issues/41

## Testing instructions

Tested via https://github.com/CoastalResilienceNetwork/geosite-framework-build/pull/42