### PR TITLE
Make single plugin mode reponsiveness more dynamic

### DIFF
--- a/src/GeositeFramework/css/main.css
+++ b/src/GeositeFramework/css/main.css
@@ -2133,13 +2133,13 @@ body.x-body {
   color: #fff;
 }
 
-@media not screen and (max-device-width: 737px) {
+@media not screen and (max-width: 737px) {
     #single-plugin-toggle-footer {
         display: none !important;
     }
 }
 
-@media screen and (max-device-width: 736px) {
+@media screen and (max-width: 736px) {
     .tbox {
         max-width: 96vw !important;
         max-height: 90vh !important;

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -187,8 +187,8 @@ require(['use!Geosite',
 
         function initSearch(view) {
             var isMobileSingleAppMode = N.app.singlePluginMode &&
-                window.matchMedia("screen and (max-device-width: 736px)").matches;
-            // Add search control; have it be expandable & collapsible in mobile single plugin mode
+                window.matchMedia("screen and (max-width: 736px)").matches;
+
             var search = new Search({
                 map: view.esriMap,
                 showInfoWindowOnSelect: false,

--- a/src/GeositeFramework/js/Map.js
+++ b/src/GeositeFramework/js/Map.js
@@ -186,15 +186,12 @@ require(['use!Geosite',
         }
 
         function initSearch(view) {
-            var isMobileSingleAppMode = N.app.singlePluginMode &&
-                window.matchMedia("screen and (max-width: 736px)").matches;
-
             var search = new Search({
                 map: view.esriMap,
                 showInfoWindowOnSelect: false,
                 enableHighlight: false,
-                enableButtonMode: isMobileSingleAppMode,
-                expanded: false, // this property only takes effect if `enableButtonMode` is `true`
+                enableButtonMode: true,
+                expanded: true,
             }, "search");
 
             // The translation lookup isn't ready when this is initialized.
@@ -207,21 +204,54 @@ require(['use!Geosite',
                 search.startup();
             }, 200);
 
-            if (isMobileSingleAppMode) {
-                // If the app's in mobile single app mode: hide title & subtitle on opening geocoder
-                // search input, showing them again on close. 200ms delay to smooth animation
-                search.on('focus', function() {
+            // If the app's in mobile single app mode: hide title & subtitle on opening geocoder
+            // search input, showing them again on close. 200ms delay to smooth animation
+            search.on('focus', function() {
+                if (isMobileSingleAppMode()) {
                     window.setTimeout(function() {
                         $('.nav-main-title').hide();
                         $('.nav-region-subtitle').hide();
                     }, 200)
-                });
-                search.on('blur', function() {
+                }
+            });
+
+            search.on('blur', function() {
+                if (isMobileSingleAppMode()) {
                     window.setTimeout(function() {
                         $('.nav-main-title').show();
                         $('.nav-region-subtitle').show();
                     }, 200)
-                });
+                }
+            });
+
+            // Listen for resize events, and make adjustments to the
+            // app header accordingly
+            window.addEventListener("resize", resizeThrottler, false);
+            var resizeTimeout;
+            function resizeThrottler() {
+                if (!resizeTimeout) {
+                    resizeTimeout = setTimeout(function() {
+                        resizeTimeout = null;
+                        adjustSearchControl(search);
+                    }, 66);
+                }
+            }
+
+            // To make sure the header is adjusted properly at app start,
+            // call the adjust function on init.
+            adjustSearchControl(search);
+        }
+
+        function isMobileSingleAppMode() {
+            return N.app.singlePluginMode &&
+                window.matchMedia("screen and (max-width: 736px)").matches;
+        }
+
+        function adjustSearchControl(search) {
+            if (isMobileSingleAppMode()) {
+                search.collapse();
+            } else {
+                search.expand();
             }
         }
 

--- a/src/GeositeFramework/js/Plugin.js
+++ b/src/GeositeFramework/js/Plugin.js
@@ -616,7 +616,7 @@ require(['use!Geosite',
                 modalHeight = pluginObject.printModalSize[1],
                 modalWidth = pluginObject.printModalSize[0],
                 isMobileSingleAppMode = N.app.singlePluginMode &&
-                    window.matchMedia("screen and (max-device-width: 736px)").matches;
+                    window.matchMedia("screen and (max-width: 736px)").matches;
 
             // If the plugin is not set up for a print modal,
             // resolve any pending pre-print map operations

--- a/src/GeositeFramework/js/SinglePluginModeHelp.js
+++ b/src/GeositeFramework/js/SinglePluginModeHelp.js
@@ -36,7 +36,7 @@
         $pluginToggle.show();
         $mobileToggle.show();
         if (singlePlugin.selected) {
-            if (!window.matchMedia("screen and (max-device-width: 736px)").matches ||
+            if (!window.matchMedia("screen and (max-width: 736px)").matches ||
                 viewModel.get('pluginContentVisible')) {
                 singlePlugin.get('$uiContainer').show();
             }


### PR DESCRIPTION
## Overview

Makes two changes to how single plugin mode mobile/responsive adjustments are handled:

- **Replace max-device-width with max-width**. Using max-width instead of max-device-width allows the site to adapt to smaller viewports on laptops and desktops instead of just mobile devices.
- **Rework adjustment of single plugin mode for mobile**. Instead of adjusting the header once at app initialization, adjust the header as the app is resized. This allows for the app to feel more responsive when resizing the browser on desktop.

Connects #1135 

### Demo

![oct-26-2018 13-06-05](https://user-images.githubusercontent.com/1042475/47581645-fa383000-d91f-11e8-80b4-19dd4206f1a4.gif)

## Testing Instructions

- Turn on single plugin mode.
- Visit the site in the browser, and resize the window.
- Verify the header adjusts to the browser size by 1) switching between an expanded and collapsed search control, and 2) hiding the title and subtitle when the search is focused in mobile mode.
- Visit the site on a mobile device, and verify that it still adjusts correctly.