### PR TITLE
Set minZoom on map

### DIFF
--- a/src/js/Map.js
+++ b/src/js/Map.js
@@ -114,7 +114,8 @@ require(['use!Geosite',
 
     function createMap(view) {
         var esriMap = Map(view.$el.attr('id'), {
-                sliderPosition: 'top-right'
+                sliderPosition: 'top-right',
+                minZoom: 2
             }),
             resizeMap = _.debounce(function () {
                 // When the element containing the map resizes, the


### PR DESCRIPTION
## Overview

TNC reported a bug (see #1142 for gif) whereby switching from a regional to a global view in the map made the map very tiny, offset, and cut off. Very odd.

From the best of my investigation, it seems like a mixture of problems some our code, some behind the scenes ESRI map CSS. A quick fix that seemed to work was setting a minimum zoom on the map such that we can't zoom out enough to encounter the issue. This seems like an overall positive move because there's no use to see the map so zoomed out and we avoid black space views like:

<img width="1274" alt="screen shot 2018-10-29 at 11 58 17 am" src="https://user-images.githubusercontent.com/10568752/47662770-f69be780-db71-11e8-9315-b018a83c38d9.png">


Connects #1142

### Demo

![bug1142](https://user-images.githubusercontent.com/10568752/47662945-4f6b8000-db72-11e8-91b9-7b1559af2b97.gif)

### Notes

Even though this is a Task 4 contract bug fix, I based and pointed this branch at the static site feature branch for easier testing. If we would rather cherry-pick the commit onto master, I can do that.

## Testing Instructions

There's a lot of ways you could test this. Here's two easier ones:

From the `GeositeFramework` repo:
- Pull down this branch
- Clone [the natural-coastal-protection plugin](https://github.com/CoastalResilienceNetwork/natural-coastal-protection) into the plugin repo
- Switch to the `development` branch of the natural-coastal-protection plugin (defaults to master, which won't build)
- Update the `region.json` to include the natural-coastal-protection plugin in single plugin mode
- Serve the project `python ./scripts/server.py` or & `-d`
- Visit http://localhost:54634/
- Adjust your browser to mobile mode
- Toggle between regions and global

Static site build from the `geosite-framework-build` repo, `static-site` branch:
- clear out your `output folder` (`rm -rf output/`)
- `python build.py coastal-protection-region --framework-branch jf/bugfix#1142 --region-branch development`
- unzip the built project and hit the files with a python server (`cd output`, `unzip coastal-protection.zip`, `python -m SimpleHTTPServer 7979`)
- Visit http://localhost:7979/ or wherever
- Adjust your browser to mobile mode
- Toggle between regions and global

You shouldn't see the issue anymore, and the minzoom should be enforced with no detriment to the map.


