### PR TITLE
Upgrade the esri bundle to include JSAPI 3.26

### DIFF
--- a/src/GeositeFramework/Views/Home/Index.cshtml
+++ b/src/GeositeFramework/Views/Home/Index.cshtml
@@ -81,10 +81,10 @@
     }
     <link rel='shortcut icon' href='img/favicon.ico' type='image/x-icon'/ >
 
-    <link rel="stylesheet" href="//js.arcgis.com/3.25/dijit/themes/claro/claro.css">
-    <link rel="stylesheet" href="//js.arcgis.com/3.25/esri/css/esri.css">
+    <link rel="stylesheet" href="//js.arcgis.com/3.26/dijit/themes/claro/claro.css">
+    <link rel="stylesheet" href="//js.arcgis.com/3.26/esri/css/esri.css">
     <link rel="stylesheet" href="//js.arcgis.com/3.10/js/dojo/dojox/layout/resources/ResizeHandle.css">
-    <link rel="stylesheet" href="//js.arcgis.com/o/232546/geosite-v1.0.10/esri/css/esri.css">
+    <link rel="stylesheet" href="//js.arcgis.com/o/232546/geosite-v1.0.11/esri/css/esri.css">
 
     <link rel="stylesheet" href="css/TinyBox2.css">
     <link rel="stylesheet" href="css/pageguide.min.css"/>
@@ -795,7 +795,7 @@
     <script src="js/lib/i18next-jquery-0.0.14.min.js"></script>
     <script src="js/lib/i18next-SprintfPostProcessor-0.2.2.min.js"></script>
 
-    <script src="//js.arcgis.com/o/232546/geosite-v1.0.10/dojo/dojo.js"></script>
+    <script src="//js.arcgis.com/o/232546/geosite-v1.0.11/dojo/dojo.js"></script>
     <script src="Scripts/json2.min.js"></script> <!-- Can be removed when IE8 support is dropped -->
     <script src="js/lib/backbone.picky.js"></script>
     <script src="js/lib/jquery.history.min.js"></script>


### PR DESCRIPTION
## Overview

This upgrades the jsapi version from 3.25 in order to get bugfixes for:
* Pan/Zoom on Android OS 9 Chrome
* Localhost not automatically requests from https

See https://developers.arcgis.com/javascript/3/jshelp/whats_new.html

Connects #1137 

### Notes

This commit targets develop so can be deployed to existing sites

## Testing Instructions
* Make sure the esri jsapi version is 3.26
  `console: esri.version`
* Full smoke-test of app to make sure no modules were dropped
* Try browserstack or consult with @mmcfarland about testing on an Android OS 9 Chrome device to fix #1137 