### PR TITLE
Update region schema to support story mode

### DIFF
--- a/src/App_Data/regionSchema.json
+++ b/src/App_Data/regionSchema.json
@@ -440,6 +440,11 @@
                 }
             },
             "additionalProperties": false
+        },
+        "appIntro": {
+            "type": "boolean",
+            "required": false,
+            "additionalProperties": false
         }
     },
     "additionalProperties": false

--- a/src/region.json
+++ b/src/region.json
@@ -5,6 +5,7 @@
         "active": false,
         "pluginFolderName": "identify_point"
     },
+    "appIntro": true,
     "titleMain": {
         "text": "Geosite Framework Sample",
         "url": "http://www.azavea.com/"


### PR DESCRIPTION
## Overview

Add a boolean flag that can be set to true to turn on story mode. The build tool reads this value and determines whether or not the built site should be reconfigured for story mode.

Connects #1170

## Testing Instructions

- Tested through https://github.com/CoastalResilienceNetwork/geosite-framework-build/pull/48