### PR TITLE
Defer assigning plugin events

### DIFF
--- a/src/js/Plugin.js
+++ b/src/js/Plugin.js
@@ -429,8 +429,6 @@ require(['use!Geosite',
             view.$el.addClass(model.getId() + '-' + view.paneNumber);
 
             if (view.$uiContainer) {
-                assignEvents(view.$uiContainer, model, view.paneNumber);
-
                 if (view.model.selected === true) {
                     view.$uiContainer.show();
                 } else {
@@ -443,6 +441,10 @@ require(['use!Geosite',
                 if (pluginObject.map) {
                     pluginObject.map.resize(true);
                 }
+
+                window.setTimeout(function() {
+                    assignEvents(view.$uiContainer, model, view.paneNumber);
+                }, 100);
             }
 
             if (view.$legendContainer) {


### PR DESCRIPTION
## Overview

Allow time to pass before assigning events so that we can be more confident that the plugin UI has been added to the DOM.

Connects #1173

### Demo

![feb-08-2019 15-26-58](https://user-images.githubusercontent.com/1042475/52504290-046ff880-2bb6-11e9-88d5-6ffb2fe323ca.gif)

## Testing Instructions

- Run `./scripts/server`, visit the site, and verify the existing plugins load correctly and that their UI buttons correctly trigger events.
- Build the hawaii region on this branch: `python build.py hawaii-region --framework-branch cpc/fix-plugin-event-assignment-2`
- Extract the resulting zip.
- Comment out lines 177-178 in `/geosite-framework-build/output/hawaii/plugins/ecological-effects-slc/main.js`. This was a temporary fix to this issue.
- Run a static server in the region directory.
- Visit the site, close the help screen, make a selection in the plugin menu, then click the "Print" button.
- Verify the print dialog appears on the first click. 