### PR TITLE
Use correct region.json attribute for GA key

### DIFF
--- a/src/region.json
+++ b/src/region.json
@@ -1,6 +1,7 @@
 {
     "language": "en",
     "googleUrlShortenerApiKey": "AIzaSyDd5hwYX4vAMLOH425cnMSq3gte98w4VFA",
+    "googleAnalyticsPropertyId": "XXXXXXXXX-0",
     "singlePluginMode": {
         "active": false,
         "pluginFolderName": "identify_point"

--- a/src/template_index.html
+++ b/src/template_index.html
@@ -160,7 +160,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-        ga('create', 'UA-{{ region.googleUrlShortenerApiKey }}', 'auto');
+        ga('create', 'UA-{{ region.googleAnalyticsPropertyId }}', 'auto');
         ga('send', 'pageview');
     </script>
     <!-- End Google Analytics -->


### PR DESCRIPTION
## Overview

We were mistakenly using the Google URL shortener key instead of the Google Analytics key.

Connects #1176

### Demo

![image](https://user-images.githubusercontent.com/1042475/54304391-6ba91000-459b-11e9-94c6-9a6d16601bbd.png)

## Testing Instructions

- Build and serve the site with `./scripts/server.py`, and verify the correct key is used to populate the GA key.