### PR TITLE
update url shortener code and service

### DIFF
--- a/src/App_Data/regionSchema.json
+++ b/src/App_Data/regionSchema.json
@@ -15,10 +15,6 @@
             "type": "string",
             "required": false
         },
-        "urlShortenerApiKey": {
-            "type": "string",
-            "required": false
-        },
         "titleMain": {
             "type": "object",
             "properties": {

--- a/src/App_Data/regionSchema.json
+++ b/src/App_Data/regionSchema.json
@@ -15,6 +15,10 @@
             "type": "string",
             "required": false
         },
+        "urlShortenerApiKey": {
+            "type": "string",
+            "required": false
+        },
         "titleMain": {
             "type": "object",
             "properties": {

--- a/src/js/App.js
+++ b/src/js/App.js
@@ -33,12 +33,6 @@
                 N.app.singlePluginMode = regionData.singlePluginMode.active;
             }
 
-            // Set up the google url shortener service
-            gapi.client.load('urlshortener', 'v1');
-            if (regionData.googleUrlShortenerApiKey) {
-                gapi.client.setApiKey(regionData.googleUrlShortenerApiKey);
-            }
-
             N.app.controllers.help = new N.controllers.HelpOverlay();
             N.app.models.screen = new N.models.Screen();
 

--- a/src/js/Permalink.js
+++ b/src/js/Permalink.js
@@ -20,20 +20,37 @@
         },
 
         shorten: function() {
-            var model = this,
-                request = gapi.client.urlshortener.url.insert({
-                    'resource': {
-                        'longUrl': model.get('url')
-                    }
-                });
-
-            request.execute(function (result) {
-                if (result.error) {
-                    model.set('shortUrl', model.get('url'));
-                } else {
-                    model.set('shortUrl', result.id);
-                }
-            });
+            
+            var model = this;
+			if (_.has(N.app.data.region, 'urlShortenerApiKey')) {
+				
+				var apiKey = N.app.data.region.urlShortenerApiKey;
+				var requestHeaders = {
+					"Content-Type": "application/json",
+					"apikey": apiKey
+				};
+				
+				var linkRequest = {
+					destination: model.get('url')
+				};
+				
+				$.ajax({
+					url: 'https://api.rebrandly.com/v1/links',
+					type: "post",
+					data: JSON.stringify(linkRequest),
+					headers: requestHeaders,
+					dataType: "json",
+					success: function(result){
+						var shortUrl = (result.shortUrl.indexOf('http') == -1) ? 'https://' + result.shortUrl : result.shortUrl;
+						model.set('shortUrl', shortUrl);
+					},
+					error: function(error) {
+						model.set('shortUrl', model.get('url')); 
+					}
+				});
+			} else {
+				model.set('shortUrl', model.get('url')); 
+			}
         }
     });
 

--- a/src/js/Permalink.js
+++ b/src/js/Permalink.js
@@ -22,9 +22,9 @@
         shorten: function() {
             
             var model = this;
-			if (_.has(N.app.data.region, 'urlShortenerApiKey')) {
+			if (isProd) {
 				
-				var apiKey = N.app.data.region.urlShortenerApiKey;
+				var apiKey = "48598fa6dd3e4237b18dd6344b77a049";
 				var requestHeaders = {
 					"Content-Type": "application/json",
 					"apikey": apiKey


### PR DESCRIPTION
remove all references to Google Url Shortener service as it is now
deprecated and update code to use rebrand.ly.  Modify regionSchema.json
to include new optional property urlShortenerApiKey.  If included in
region.json, long urls from save and share will be shortened and
returned to UI, otherwise the long url will be returned.

## Overview

Brief description of what this PR does, and why it is needed.

Connects #XXX

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

 * How to test this PR
 * Prefer bulleted description
 * Start after checking out this branch
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output

